### PR TITLE
Tweak: Ilks and Bases are now both Assets

### DIFF
--- a/contract-drafts/Cat.sol
+++ b/contract-drafts/Cat.sol
@@ -40,7 +40,7 @@ contract Cat {
     uint256 constant public AUCTION_TIME; // Time that auctions take to go to minimal price and stay there.
     IVat immutable public vat;
 
-    mapping (bytes6 => IOracle) oracles;                                                // [ilk] Spot oracles
+    mapping (bytes6 => IOracle) oracles;                                                // [asset] Spot oracles
 
     constructor (IVat vat_) {
         vat = vat_;
@@ -72,7 +72,7 @@ contract Cat {
         returns (int128)
     {
         // Let fail if the vault doesn't exist?
-        // Let fail if the vault doesn't have the right ilk?
+        // Let fail if the vault doesn't have the right asset?
         // Let fail if the vault doesn't have enough ink?
         uint32 timestamp = vat.timestamps(vaultId);                                     // 1 SLOAD + 700 + 12*16
         require (timestamp > 0, "Not for sale");

--- a/contract-drafts/interfaces/IJoin.sol
+++ b/contract-drafts/interfaces/IJoin.sol
@@ -10,7 +10,7 @@ interface IJoin {
     function deny(address usr) external;
 
     function token() external view returns (IERC20);
-    function ilk() external view returns (bytes6);
+    function asset() external view returns (bytes6);
     function dec() external view returns (uint);
     function live() external view returns (uint);
 

--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -12,19 +12,19 @@ contract FYToken is /* Orchestrated(),*/ ERC20Permit  {
 
     uint256 constant internal MAX_TIME_TO_MATURITY = 126144000; // seconds in four years
 
-    IERC20 public underlying;
+    IERC20 public base;
     IOracle public oracle;
     uint256 public maturity;
 
     constructor(
-        IERC20 underlying_,
+        IERC20 base_,
         IOracle oracle_, // Underlying vs its interest-bearing version
         uint256 maturity_,
         string memory name,
         string memory symbol
     ) ERC20Permit(name, symbol) {
         // require(maturity_ > block.timestamp && maturity_ < block.timestamp + MAX_TIME_TO_MATURITY, "FYToken: Invalid maturity");
-        underlying = underlying_;
+        base = base_;
         oracle = oracle_;
         maturity = maturity_;
     }
@@ -48,7 +48,7 @@ contract FYToken is /* Orchestrated(),*/ ERC20Permit  {
 
         // consider moving these two lines to Vat. Credit the user's account with the redemption value, then they can remove via the join.
         uint256 redeemed = amount * oracle.accrual(maturity);
-        treasury.pull(underlying, to, amount);
+        treasury.pull(base, to, amount);
         
         emit Redeemed(from, to, amount);
         return amount;

--- a/contracts/Join.sol
+++ b/contracts/Join.sol
@@ -14,14 +14,14 @@ contract Join {
     } */
 
     IERC20 public token;
-    // bytes6  public ilk;   // Collateral Type
+    // bytes6  public asset;   // Collateral Type
     // uint    public dec;
     // uint    public live;  // Active Flag
 
     constructor(/* address vat_, */IERC20 token_) {
         // wards[msg.sender] = 1;
         token = token_;
-        // ilk = ilk_;
+        // asset = asset_;
         // dec = token.decimals();
         // live = 1;
     }

--- a/contracts/interfaces/IFYToken.sol
+++ b/contracts/interfaces/IFYToken.sol
@@ -6,7 +6,7 @@ import "./IOracle.sol";
 
 interface IFYToken is IERC20 {
     /// @dev Token that is returned on redemption. Also called underlying.
-    function base() external view returns (IERC20);
+    function asset() external view returns (IERC20);
 
     /// @dev Oracle that returns the accrual of the borrowing rate, which is accrued after maturity.
     function oracle() external view returns (IOracle);

--- a/contracts/interfaces/IVat.sol
+++ b/contracts/interfaces/IVat.sol
@@ -8,31 +8,31 @@ import "../libraries/DataTypes.sol";
 
 interface IVat {
     /// @dev Add a collateral to Vat
-    // function addIlk(bytes6 id, address ilk) external;
+    // function addAsset(bytes6 id, address asset) external;
 
     /// @dev Add an underlying to Vat
-    // function addBase(address base) external;
+    // function addAsset(address asset) external;
 
     /// @dev Add a series to Vat
-    // function addSeries(bytes32 series, IERC20 base, IFYToken fyToken) external;
+    // function addSeries(bytes32 series, IERC20 asset, IFYToken fyToken) external;
 
     /// @dev Add a spot oracle to Vat
-    // function addSpotOracle(IERC20 base, IERC20 ilk, IOracle oracle) external;
+    // function addSpotOracle(IERC20 asset, IERC20 asset, IOracle oracle) external;
 
     /// @dev Add a chi oracle to Vat
-    // function addChiOracle(IERC20 base, IOracle oracle) external;
+    // function addChiOracle(IERC20 asset, IOracle oracle) external;
 
     /// @dev Add a rate oracle to Vat
-    // function addRateOracle(IERC20 base, IOracle oracle) external;
+    // function addRateOracle(IERC20 asset, IOracle oracle) external;
 
     /// @dev Spot price oracle for an underlying and collateral
-    // function chiOracles(bytes6 base, bytes6 ilk) external returns (address);
+    // function chiOracles(bytes6 asset, bytes6 asset) external returns (address);
 
     /// @dev Chi (savings rate) accruals oracle for an underlying
-    // function chiOracles(bytes6 base) external returns (address);
+    // function chiOracles(bytes6 asset) external returns (address);
 
     /// @dev Rate (borrowing rate) accruals oracle for an underlying
-    // function rateOracles(bytes6 base) external returns (address);
+    // function rateOracles(bytes6 asset) external returns (address);
 
     /// @dev An user can own one or more Vaults, with each vault being able to borrow from a single series.
     function vaults(bytes12 vault) external view returns (DataTypes.Vault memory);
@@ -41,10 +41,10 @@ interface IVat {
     function series(bytes6 seriesId) external returns (DataTypes.Series memory);
 
     /// @dev Collaterals available in Vat.
-    function ilks(bytes6 ilksDd) external returns (IERC20);
+    function assets(bytes6 assetsDd) external returns (IERC20);
 
     /// @dev Underlyings available in Vat.
-    // function bases(bytes6 id) external returns (IERC20);
+    // function assets(bytes6 id) external returns (IERC20);
 
     /// @dev Each vault records debt and collateral balances.
     // function vaultBalances(bytes12 vault) external view returns (Balances);
@@ -53,7 +53,7 @@ interface IVat {
     // function timestamps(bytes12 vault) external view returns (uint32);
 
     /// @dev Create a new vault, linked to a series (and therefore underlying) and up to 5 collateral types
-    // function build(bytes12 series, bytes32 ilks) external returns (bytes12 id);
+    // function build(bytes12 series, bytes32 assets) external returns (bytes12 id);
 
     /// @dev Destroy an empty vault. Used to recover gas costs.
     // function destroy(bytes12 vault) external;
@@ -79,22 +79,22 @@ interface IVat {
     // function give(bytes12 vault, address user) external;
 
     /// @dev Move collateral between vaults.
-    // function flux(bytes12 from, bytes12 to, bytes1 ilks, uint128[] memory inks) external returns (Balances, Balances);
+    // function flux(bytes12 from, bytes12 to, bytes1 assets, uint128[] memory inks) external returns (Balances, Balances);
 
-    /// @dev Add collateral and borrow from vault, pull ilks from and push borrowed asset to user
-    /// Or, repay to vault and remove collateral, pull borrowed asset from and push ilks to user
+    /// @dev Add collateral and borrow from vault, pull assets from and push borrowed asset to user
+    /// Or, repay to vault and remove collateral, pull borrowed asset from and push assets to user
     /// Checks the vault is valid, and collateralization levels at the end.
-    // function frob(bytes12 vault, bytes1 ilks,  int128[] memory inks, int128 art) external returns (Balances);
+    // function frob(bytes12 vault, bytes1 assets,  int128[] memory inks, int128 art) external returns (Balances);
 
     /// @dev Repay vault debt using underlying token, pulled from user. Collateral is returned to caller
-    // function close(bytes12 vault, bytes1 ilks, int128[] memory inks, uint128 repay) external returns (Balances);
+    // function close(bytes12 vault, bytes1 assets, int128[] memory inks, uint128 repay) external returns (Balances);
 
     // ==== Accounting ====
 
     /// @dev Return the vault debt in underlying terms
     // function dues(bytes12 vault) external view returns (uint128 uart);
 
-    /// @dev Return the capacity of the vault to borrow underlying based on the ilks held
+    /// @dev Return the capacity of the vault to borrow underlying assetd on the assets held
     // function value(bytes12 vault) external view returns (uint128 uart);
 
     /// @dev Return the collateralization level of a vault. It will be negative if undercollateralized.

--- a/contracts/libraries/DataTypes.sol
+++ b/contracts/libraries/DataTypes.sol
@@ -5,8 +5,8 @@ import "../interfaces/IFYToken.sol";
 library DataTypes {
     struct Series {
         IFYToken fyToken;                                               // Redeemable token for the series.
-        bytes6  baseId;                                                  // Token received on redemption.
-        uint32  maturity;                                              // Unix time at which redemption becomes possible.
+        bytes6  baseId;                                                 // Asset received on redemption.
+        uint32  maturity;                                               // Unix time at which redemption becomes possible.
         // bytes2 free
     }
 
@@ -14,11 +14,11 @@ library DataTypes {
     struct Vault {
         address owner;
         bytes6 seriesId;                                                 // Each vault is related to only one series, which also determines the underlying.
-        bytes6 ilkId;
+        bytes6 ilkId;                                                    // Asset accepted as collateral
     }
 
     struct Balances {
-        uint128 art;                                                     // Debt
-        uint128 ink;                                                     // Assets
+        uint128 art;                                                     // Debt amount
+        uint128 ink;                                                     // Collateral amount
     }
 }

--- a/test/051_vat_build.ts
+++ b/test/051_vat_build.ts
@@ -52,32 +52,23 @@ describe('Vat', () => {
     vatFromOther = vat.connect(otherAcc)
   })
 
-  it('adds a base', async () => {
-    expect(await vat.addBase(baseId, base.address)).to.emit(vat, 'BaseAdded').withArgs(baseId, base.address)
-    expect(await vat.bases(baseId)).to.equal(base.address)
-  })
-
-  it('adds an ilk', async () => {
-    expect(await vat.addIlk(ilkId, ilk.address)).to.emit(vat, 'IlkAdded').withArgs(ilkId, ilk.address)
-    expect(await vat.ilks(ilkId)).to.equal(ilk.address)
+  it('adds an asset', async () => {
+    expect(await vat.addAsset(ilkId, ilk.address)).to.emit(vat, 'AssetAdded').withArgs(ilkId, ilk.address)
+    expect(await vat.assets(ilkId)).to.equal(ilk.address)
   })
 
   it('does not allow adding a series before adding its base', async () => {
-    await expect(vat.addSeries(seriesId, baseId, fyToken.address)).to.be.revertedWith('Vat: Base not found')
+    await expect(vat.addSeries(seriesId, baseId, fyToken.address)).to.be.revertedWith('Vat: Asset not found')
   })
 
   describe('with a base and an ilk added', async () => {
     beforeEach(async () => {
-      await vat.addBase(baseId, base.address)
-      await vat.addIlk(ilkId, ilk.address)
+      await vat.addAsset(baseId, base.address)
+      await vat.addAsset(ilkId, ilk.address)
     })
 
-    it('does not allow using the same base identifier twice', async () => {
-      await expect(vat.addBase(baseId, base.address)).to.be.revertedWith('Vat: Id already used')
-    })
-
-    it('does not allow using the same ilk identifier twice', async () => {
-      await expect(vat.addIlk(ilkId, ilk.address)).to.be.revertedWith('Vat: Id already used')
+    it('does not allow using the same asset identifier twice', async () => {
+      await expect(vat.addAsset(baseId, base.address)).to.be.revertedWith('Vat: Id already used')
     })
 
     it('does not allow not linking a series to a fyToken', async () => {
@@ -107,7 +98,7 @@ describe('Vat', () => {
       })
   
       it('does not build a vault not linked to an ilk', async () => {
-        await expect(vat.build(seriesId, mockAssetId)).to.be.revertedWith('Vat: Ilk not found')
+        await expect(vat.build(seriesId, mockAssetId)).to.be.revertedWith('Vat: Asset not found')
       })
 
       it('builds a vault', async () => {
@@ -118,6 +109,7 @@ describe('Vat', () => {
         const vault = await vat.vaults(vaultId)
         expect(vault.owner).to.equal(owner)
         expect(vault.seriesId).to.equal(seriesId)
+        expect(vault.ilkId).to.equal(ilkId)
 
         // Remove these two when `expect...to.emit` works
         expect(event.args.owner).to.equal(owner)


### PR DESCRIPTION
 - Assets can be chosen as underlying for any series, and when that happens they are also known as the `base`-
 - Assets can be chosen as collateral for any series, and when that happens they are also known as the `ilk`.