### PR TITLE
Visibility keywords in Ladle

### DIFF
--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -409,12 +409,8 @@ contract Ladle is AccessControl(), Multicall {
         // Manage debt tokens
         if (art != 0) {
             DataTypes.Series memory series = getSeries(vault.seriesId);
-            if (art > 0) {
-                require(uint32(block.timestamp) <= series.maturity, "Mature");
-                series.fyToken.mint(to, uint128(art));
-            } else {
-                series.fyToken.burn(msg.sender, uint128(-art));
-            }
+            if (art > 0) series.fyToken.mint(to, uint128(art));
+            else series.fyToken.burn(msg.sender, uint128(-art));
         }
     }
 

--- a/test/031_fyToken.ts
+++ b/test/031_fyToken.ts
@@ -64,11 +64,11 @@ describe('FYToken', function () {
   })
 
   it('does not allow to mature before maturity', async () => {
-    await expect(fyToken.mature()).to.be.revertedWith('Record after maturity')
+    await expect(fyToken.mature()).to.be.revertedWith('Only after maturity')
   })
 
   it('does not allow to redeem before maturity', async () => {
-    await expect(fyToken.redeem(owner, WAD)).to.be.revertedWith('Not mature')
+    await expect(fyToken.redeem(owner, WAD)).to.be.revertedWith('Only after maturity')
   })
 
   describe('after maturity', async () => {
@@ -76,11 +76,8 @@ describe('FYToken', function () {
       await ethers.provider.send('evm_mine', [(await fyToken.maturity()).toNumber()])
     })
 
-    it('matures by recording the chi value', async () => {
-      const maturity = await fyToken.maturity()
-      expect(await fyToken.mature())
-        .to.emit(chiOracle, 'Recorded')
-        .withArgs(maturity, DEC6)
+    it('does not allow to mint after maturity', async () => {
+      await expect(fyToken.mint(owner, WAD)).to.be.revertedWith('Only before maturity')
     })
 
     it('does not allow to mature more than once', async () => {
@@ -90,6 +87,13 @@ describe('FYToken', function () {
 
     it('does not allow to redeem before chi is recorded', async () => {
       await expect(fyToken.redeem(owner, WAD)).to.be.revertedWith('No recorded spot')
+    })
+
+    it('matures by recording the chi value', async () => {
+      const maturity = await fyToken.maturity()
+      expect(await fyToken.mature())
+        .to.emit(chiOracle, 'Recorded')
+        .withArgs(maturity, DEC6)
     })
 
     describe('once matured', async () => {

--- a/test/032_fyToken_flash.ts
+++ b/test/032_fyToken_flash.ts
@@ -86,4 +86,16 @@ describe('FYToken - flash', function () {
     await borrower.flashBorrow(fyToken.address, WAD, actions.reenter) // It will borrow WAD, and then reenter and borrow WAD * 2
     expect(await borrower.flashBalance()).to.equal(WAD.mul(3))
   })
+
+  describe('after maturity', async () => {
+    beforeEach(async () => {
+      await ethers.provider.send('evm_mine', [(await fyToken.maturity()).toNumber()])
+    })
+
+    it('does not allow to flash mint after maturity', async () => {
+      await expect(borrower.flashBorrow(fyToken.address, WAD, actions.normal)).to.be.revertedWith(
+        'Only before maturity'
+      )
+    })
+  })
 })


### PR DESCRIPTION
Use `external` everywhere instead of `public`.

Also, I was calling the `public` version of `pour` several times without need. Gas savings!