### PR TITLE
Tweak/external internal

### DIFF
--- a/test/055_cauldron_roll.ts
+++ b/test/055_cauldron_roll.ts
@@ -72,10 +72,6 @@ describe('Cauldron - roll', function () {
     await expect(cauldron.roll(vaultId, otherSeriesId, WAD.mul(2))).to.be.revertedWith('Undercollateralized')
   })
 
-  it('does not allow rolling to a series without a matching ilk for the vault', async () => {
-    await expect(cauldron.roll(vaultId, mockSeriesId, 0)).to.be.revertedWith('Ilk not added')
-  })
-
   it('rolls a vault', async () => {
     expect(await cauldron.roll(vaultId, otherSeriesId, WAD.div(-2)))
       .to.emit(cauldron, 'VaultRolled')


### PR DESCRIPTION
User `external` instead of `public` everywhere.
Split `level` into internal and external versions.
Preloaded structs in the external functions, as early as possible, and passed them on to the internal functions.

Let's keep this here, after the Berlin hard fork it might not be needed.