### PR TITLE
Tweak/unique libraries

### DIFF
--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -6,7 +6,7 @@ import "@yield-protocol/vault-interfaces/DataTypes.sol";
 import "@yield-protocol/utils-v2/contracts/AccessControl.sol";
 
 
-library Math {
+library CauldronMath {
     /// @dev Add a number (which might be negative) to a positive, and revert if the result is negative.
     function add(uint128 x, int128 y) internal pure returns (uint128 z) {
         require (y > 0 || x >= uint128(-y), "Result below zero");
@@ -14,7 +14,7 @@ library Math {
     }
 }
 
-library DMath { // Fixed point arithmetic in 6 decimal units
+library CauldronDMath { // Fixed point arithmetic in 6 decimal units
     /// @dev Multiply an amount by a fixed point factor with 6 decimals, returning an amount
     function dmul(uint128 x, uint128 y) internal pure returns (uint128 z) {
         unchecked {
@@ -25,7 +25,7 @@ library DMath { // Fixed point arithmetic in 6 decimal units
     }
 }
 
-library RMath { // Fixed point arithmetic in Ray units
+library CauldronRMath { // Fixed point arithmetic in Ray units
     /// @dev Multiply an integer amount by a fixed point factor in ray units, returning an integer amount
     function rmul(int128 x, uint128 y) internal pure returns (int128 z) {
         unchecked {
@@ -36,7 +36,7 @@ library RMath { // Fixed point arithmetic in Ray units
     }
 }
 
-library Safe128 {
+library CauldronSafe128 {
     /// @dev Safely cast an int128 to an uint128
     function u128(int128 x) internal pure returns (uint128 y) {
         require (x >= 0, "Cast overflow");
@@ -50,7 +50,7 @@ library Safe128 {
     }
 }
 
-library Safe256 {
+library CauldronSafe256 {
     /// @dev Safely cast an uint256 to an int128
     function u32(uint256 x) internal pure returns (uint32 y) {
         require (x <= type(uint32).max, "Cast overflow");
@@ -61,12 +61,12 @@ library Safe256 {
 // TODO: Add a setter for auction protection (same as Witch.AUCTION_TIME?)
 
 contract Cauldron is AccessControl() {
-    using Math for uint128;
-    using DMath for uint128;
-    using RMath for int128;
-    using Safe256 for uint256;
-    using Safe128 for uint128;
-    using Safe128 for int128;
+    using CauldronMath for uint128;
+    using CauldronDMath for uint128;
+    using CauldronRMath for int128;
+    using CauldronSafe256 for uint256;
+    using CauldronSafe128 for uint128;
+    using CauldronSafe128 for int128;
 
     event AssetAdded(bytes6 indexed assetId, address indexed asset);
     event SeriesAdded(bytes6 indexed seriesId, bytes6 indexed baseId, address indexed fyToken);

--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -10,14 +10,14 @@ import "@yield-protocol/vault-interfaces/IOracle.sol";
 import "@yield-protocol/utils-v2/contracts/AccessControl.sol";
 
 
-library DMath { // Fixed point arithmetic in 6 decimal units
+library FYTokenDMath { // Fixed point arithmetic in 6 decimal units
     /// @dev Multiply an amount by a fixed point factor with 6 decimals, returning an amount
     function dmul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         z = x * y / 1e6;
     }
 }
 
-library Safe256 {
+library FYTokenSafe256 {
     /// @dev Safely cast an uint256 to an uint128
     function u128(uint256 x) internal pure returns (uint128 y) {
         require (x <= type(uint128).max, "Cast overflow");
@@ -33,8 +33,8 @@ library Safe256 {
 
 // TODO: Setter for MAX_TIME_TO_MATURITY
 contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit {
-    using DMath for uint256;
-    using Safe256 for uint256;
+    using FYTokenDMath for uint256;
+    using FYTokenSafe256 for uint256;
 
     event Redeemed(address indexed from, address indexed to, uint256 amount, uint256 redeemed);
 

--- a/contracts/Join.sol
+++ b/contracts/Join.sol
@@ -9,7 +9,7 @@ import "@yield-protocol/utils-v2/contracts/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/TransferHelper.sol";
 
 
-library RMath { // Fixed point arithmetic in Ray units
+library JoinRMath { // Fixed point arithmetic in Ray units
     /// @dev Multiply an amount by a fixed point factor in ray units, returning an amount
     function rmul(uint256 x, uint256 y) internal pure returns (uint256 z) {
         unchecked {
@@ -19,7 +19,7 @@ library RMath { // Fixed point arithmetic in Ray units
     }
 }
 
-library Safe256 {
+library JoinSafe256 {
     /// @dev Safely cast an uint256 to an uint128
     function u128(uint256 x) internal pure returns (uint128 y) {
         require (x <= type(uint128).max, "Cast overflow");
@@ -29,8 +29,8 @@ library Safe256 {
 
 contract Join is IJoin, IERC3156FlashLender, AccessControl() {
     using TransferHelper for IERC20;
-    using RMath for uint256;
-    using Safe256 for uint256;
+    using JoinRMath for uint256;
+    using JoinSafe256 for uint256;
 
     event FlashFeeFactorSet(uint256 indexed fee);
 

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -15,7 +15,7 @@ import "@yield-protocol/utils-v2/contracts/TransferHelper.sol";
 import "@yield-protocol/utils-v2/contracts/IWETH9.sol";
 
 
-library DMath { // Fixed point arithmetic in 6 decimal units
+library LadleDMath { // Fixed point arithmetic in 6 decimal units
     /// @dev Multiply an amount by a fixed point factor with 6 decimals, returning an amount
     function dmul(uint128 x, uint128 y) internal pure returns (uint128 z) {
         unchecked {
@@ -26,7 +26,7 @@ library DMath { // Fixed point arithmetic in 6 decimal units
     }
 }
 
-library Safe128 {
+library LadleSafe128 {
     /// @dev Safely cast an uint128 to an int128
     function i128(uint128 x) internal pure returns (int128 y) {
         require (x <= uint128(type(int128).max), "Cast overflow");
@@ -36,8 +36,8 @@ library Safe128 {
 
 /// @dev Ladle orchestrates contract calls throughout the Yield Protocol v2 into useful and efficient user oriented features.
 contract Ladle is AccessControl(), Multicall {
-    using DMath for uint128;
-    using Safe128 for uint128;
+    using LadleDMath for uint128;
+    using LadleSafe128 for uint128;
     using TransferHelper for IERC20;
     using TransferHelper for address payable;
 

--- a/contracts/Witch.sol
+++ b/contracts/Witch.sol
@@ -5,14 +5,14 @@ import "@yield-protocol/vault-interfaces/ICauldron.sol";
 import "@yield-protocol/vault-interfaces/DataTypes.sol";
 
 
-library Math {
+library WitchMath {
     /// @dev Minimum of two unsigned integers
     function min(uint128 x, uint128 y) internal pure returns (uint128) {
         return x < y ? x : y;
     }
 }
 
-library RMath {
+library WitchRMath {
     /// @dev Multiply an amount by a fixed point factor in ray units, returning an amount
     function rmul(uint128 x, uint128 y) internal pure returns (uint128 z) {
         unchecked {
@@ -45,7 +45,7 @@ library RMath {
 
 // TODO: Add a setter for AUCTION_TIME
 contract Witch {
-    using RMath for uint128;
+    using WitchRMath for uint128;
 
     event Bought(address indexed buyer, bytes12 indexed vaultId, uint128 ink, uint128 art);
   
@@ -80,7 +80,7 @@ contract Witch {
             uint128 RAY = 1e27;
             uint128 term1 = balances_.ink.rdiv(balances_.art);
             uint128 term2 = RAY / 2;
-            uint128 dividend3 = Math.min(AUCTION_TIME, elapsed);
+            uint128 dividend3 = WitchMath.min(AUCTION_TIME, elapsed);
             uint128 divisor3 = AUCTION_TIME * 2;
             uint128 term3 = dividend3.rdiv(divisor3);
             price = RAY.rdiv(term1.rmul(term2 + term3));


### PR DESCRIPTION
Giving unique names to locally defined libraries, to avoid namespace clashes in testing environment.