### PR TITLE
Use uint256 for intermediate math

### DIFF
--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -26,17 +26,6 @@ library CauldronDMath { // Fixed point arithmetic in 6 decimal units
     }
 }
 
-library CauldronRMath { // Fixed point arithmetic in Ray units
-    /// @dev Multiply an integer amount by a fixed point factor in ray units, returning an integer amount
-    function rmul(int128 x, uint128 y) internal pure returns (int128 z) {
-        unchecked {
-            int256 z_ = int256(x) * int256(uint256(y)) / 1e27;
-            require (z_ >= type(int128).min && z_ <= type(int128).max, "RMUL Overflow");
-            z = int128(z_);
-        }
-    }
-}
-
 library CauldronSafe128 {
     /// @dev Safely cast an int128 to an uint128
     function u128(int128 x) internal pure returns (uint128 y) {
@@ -70,7 +59,6 @@ library CauldronSafe256 {
 contract Cauldron is AccessControl() {
     using CauldronMath for uint128;
     using CauldronDMath for uint256;
-    using CauldronRMath for int128;
     using CauldronSafe256 for uint256;
     using CauldronSafe128 for uint128;
     using CauldronSafe128 for int128;
@@ -426,7 +414,7 @@ contract Cauldron is AccessControl() {
 
         // Modify global debt records
         DataTypes.Debt memory debt_ = debt[oldSeries_.baseId][vault_.ilkId];
-        debt_.sum = debt_.sum + art - balances_.art;
+        debt_.sum = debt_.sum - balances_.art + art;
         require (debt_.sum <= debt_.max, "Max debt exceeded");
         debt[oldSeries_.baseId][vault_.ilkId] = debt_;
 

--- a/contracts/Witch.sol
+++ b/contracts/Witch.sol
@@ -7,49 +7,44 @@ import "@yield-protocol/vault-interfaces/DataTypes.sol";
 
 library WitchMath {
     /// @dev Minimum of two unsigned integers
-    function min(uint128 x, uint128 y) internal pure returns (uint128) {
+    function min(uint256 x, uint256 y) internal pure returns (uint256) {
         return x < y ? x : y;
     }
 }
 
 library WitchRMath {
     /// @dev Multiply an amount by a fixed point factor in ray units, returning an amount
-    function rmul(uint128 x, uint128 y) internal pure returns (uint128 z) {
-        unchecked {
-            uint256 _z = uint256(x) * uint256(y) / 1e27;
-            require (_z <= type(uint128).max, "RMUL Overflow");
-            z = uint128(_z);
-        }
+    function rmul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = x * y / 1e27;
     }
 
     /// @dev Divide x and y, with y being fixed point. If both are integers, the result is a fixed point factor. Rounds down.
-    function rdiv(uint128 x, uint128 y) internal pure returns (uint128 z) {
-        unchecked {
-            require (y > 0, "RDIV by zero");
-            uint256 _z = uint256(x) * 1e27 / y;
-            require (_z <= type(uint128).max, "RDIV Overflow");
-            z = uint128(_z);
-        }
+    function rdiv(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = x * 1e27 / y;
     }
 
     /// @dev Divide x and y, with y being fixed point. If both are integers, the result is a fixed point factor. Rounds up.
-    function rdivup(uint128 x, uint128 y) internal pure returns (uint128 z) {
-        unchecked {
-            require (y > 0, "RDIVUP by zero");
-            uint256 _z = uint256(x) * 1e27 % y == 0 ? uint256(x) * 1e27 / y : uint256(x) * 1e27 / y + 1;
-            require (_z <= type(uint128).max, "RDIV Overflow");
-            z = uint128(_z);
-        }
+    function rdivup(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        z = x * 1e27 % y == 0 ? x * 1e27 / y : x * 1e27 / y + 1;
+    }
+}
+
+library WitchSafe256 {
+    /// @dev Safely cast an uint256 to an uint128
+    function u128(uint256 x) internal pure returns (uint128 y) {
+        require (x <= type(uint128).max, "Cast overflow");
+        y = uint128(x);
     }
 }
 
 // TODO: Add a setter for AUCTION_TIME
 contract Witch {
-    using WitchRMath for uint128;
+    using WitchRMath for uint256;
+    using WitchSafe256 for uint256;
 
-    event Bought(address indexed buyer, bytes12 indexed vaultId, uint128 ink, uint128 art);
+    event Bought(address indexed buyer, bytes12 indexed vaultId, uint256 ink, uint256 art);
   
-    uint128 constant public AUCTION_TIME = 4 * 60 * 60; // Time that auctions take to go to minimal price and stay there.
+    uint256 constant public AUCTION_TIME = 4 * 60 * 60; // Time that auctions take to go to minimal price and stay there.
     ICauldron immutable public cauldron;
     ILadle immutable public ladle;
 
@@ -68,8 +63,8 @@ contract Witch {
         DataTypes.Balances memory balances_ = cauldron.balances(vaultId);
 
         require (balances_.art > 0, "Nothing to buy");                                      // Cheapest way of failing gracefully if given a non existing vault
-        uint128 elapsed = uint32(block.timestamp) - cauldron.timestamps(vaultId);           // Auctions will malfunction on the 7th of February 2106, at 06:28:16 GMT, we should replace this contract before then.
-        uint128 price;
+        uint256 elapsed = uint32(block.timestamp) - cauldron.timestamps(vaultId);           // Auctions will malfunction on the 7th of February 2106, at 06:28:16 GMT, we should replace this contract before then.
+        uint256 price;
         {
             // Price of a collateral unit, in underlying, at the present moment, for a given vault
             //
@@ -77,18 +72,18 @@ contract Witch {
             // price = 1 / (------- * (--- + -----------------------))
             //                art       2       2 * auction
             // solhint-disable-next-line var-name-mixedcase
-            uint128 RAY = 1e27;
-            uint128 term1 = balances_.ink.rdiv(balances_.art);
-            uint128 term2 = RAY / 2;
-            uint128 dividend3 = WitchMath.min(AUCTION_TIME, elapsed);
-            uint128 divisor3 = AUCTION_TIME * 2;
-            uint128 term3 = dividend3.rdiv(divisor3);
+            uint256 RAY = 1e27;
+            uint256 term1 = uint256(balances_.ink).rdiv(balances_.art);
+            uint256 term2 = RAY / 2;
+            uint256 dividend3 = WitchMath.min(AUCTION_TIME, elapsed);
+            uint256 divisor3 = AUCTION_TIME * 2;
+            uint256 term3 = dividend3.rdiv(divisor3);
             price = RAY.rdiv(term1.rmul(term2 + term3));
         }
-        uint128 ink = art.rdivup(price);                                                    // Calculate collateral to sell. Using divdrup stops rounding from leaving 1 stray wei in vaults.
-        require (ink >= min, "Not enough bought");                                          // TODO: We could also check that min <= balances_.ink
+        uint256 ink = uint256(art).rdivup(price);                                                    // Calculate collateral to sell. Using divdrup stops rounding from leaving 1 stray wei in vaults.
+        require (ink >= min, "Not enough bought");
 
-        ladle.settle(vaultId, msg.sender, ink, art);                                        // Move the assets
+        ladle.settle(vaultId, msg.sender, ink.u128(), art);                                        // Move the assets
         if (balances_.art - art == 0 && balances_.ink - ink == 0) cauldron.destroy(vaultId);
 
         emit Bought(msg.sender, vaultId, ink, art);


### PR DESCRIPTION
A few small fixes where in some rare cases we could have an overflow in intermediate calculations. This is no more or less safe, but in very rare cases it would avoid an unnecessary revert.