### PR TITLE
Use Kashi oracles

### DIFF
--- a/contracts/IOracle.sol
+++ b/contracts/IOracle.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+// Taken from https://github.com/sushiswap/kashi-lending/blob/master/contracts/interfaces/IOracle.sol
+pragma solidity >=0.8.0;
+
+interface IOracle {
+    /// @notice Get the latest exchange rate.
+    /// @param data Usually abi encoded, implementation specific data that contains information and arguments to & about the oracle.
+    /// For example:
+    /// (string memory collateralSymbol, string memory assetSymbol, uint256 division) = abi.decode(data, (string, string, uint256));
+    /// @return success if no valid (recent) rate is available, return false else true.
+    /// @return rate The rate of the requested asset / pair / pool.
+    function get(bytes calldata data) external returns (bool success, uint256 rate);
+
+    /// @notice Check the last exchange rate without any state changes.
+    /// @param data Usually abi encoded, implementation specific data that contains information and arguments to & about the oracle.
+    /// For example:
+    /// (string memory collateralSymbol, string memory assetSymbol, uint256 division) = abi.decode(data, (string, string, uint256));
+    /// @return success if no valid (recent) rate is available, return false else true.
+    /// @return rate The rate of the requested asset / pair / pool.
+    function peek(bytes calldata data) external view returns (bool success, uint256 rate);
+
+    /// @notice Check the current spot exchange rate without any state changes. For oracles like TWAP this will be different from peek().
+    /// @param data Usually abi encoded, implementation specific data that contains information and arguments to & about the oracle.
+    /// For example:
+    /// (string memory collateralSymbol, string memory assetSymbol, uint256 division) = abi.decode(data, (string, string, uint256));
+    /// @return rate The rate of the requested asset / pair / pool.
+    function peekSpot(bytes calldata data) external view returns (uint256 rate);
+
+    /// @notice Returns a human readable (short) name about this oracle.
+    /// @param data Usually abi encoded, implementation specific data that contains information and arguments to & about the oracle.
+    /// For example:
+    /// (string memory collateralSymbol, string memory assetSymbol, uint256 division) = abi.decode(data, (string, string, uint256));
+    /// @return (string) A human readable symbol name about this oracle.
+    function symbol(bytes calldata data) external view returns (string memory);
+
+    /// @notice Returns a human readable name about this oracle.
+    /// @param data Usually abi encoded, implementation specific data that contains information and arguments to & about the oracle.
+    /// For example:
+    /// (string memory collateralSymbol, string memory assetSymbol, uint256 division) = abi.decode(data, (string, string, uint256));
+    /// @return (string) A human readable name about this oracle.
+    function name(bytes calldata data) external view returns (string memory);
+}

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 import "@yield-protocol/vault-interfaces/IFYToken.sol";
 import "@yield-protocol/vault-interfaces/IJoin.sol";
 import "@yield-protocol/vault-interfaces/ICauldron.sol";
-import "@yield-protocol/vault-interfaces/IOracle.sol";
 import "@yield-protocol/vault-interfaces/DataTypes.sol";
 import "@yield-protocol/yieldspace-interfaces/IPool.sol";
 import "@yield-protocol/utils/contracts/token/IERC20.sol";

--- a/contracts/mocks/OracleMock.sol
+++ b/contracts/mocks/OracleMock.sol
@@ -1,20 +1,49 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.0;
-import "@yield-protocol/vault-interfaces/IOracle.sol";
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+import "../IOracle.sol";
 
 
 /// @dev An oracle that allows to set the spot price to anyone. It also allows to record spot values and return the accrual between a recorded and current spots.
 contract OracleMock is IOracle {
-    uint128 internal _spot;
-    mapping(uint32 => uint128) public recorded;
+    uint256 public rate;
+    bool public success;
 
-    /// @dev Return the spot price
-    function spot() external view override returns (uint128) {
-        return _spot;
+    constructor() public {
+        success = true;
     }
 
-    /// @dev Set the spot price.
-    function setSpot(uint128 spot_) external {
-        _spot = spot_;
+    function set(uint256 rate_) public {
+        // The rate can be updated.
+        rate = rate_;
+    }
+
+    function setSuccess(bool val) public {
+        success = val;
+    }
+
+    function getDataParameter() public pure returns (bytes memory) {
+        return abi.encode("0x0");
+    }
+
+    // Get the latest exchange rate
+    function get(bytes calldata) public override returns (bool, uint256) {
+        return (success, rate);
+    }
+
+    // Check the last exchange rate without any state changes
+    function peek(bytes calldata) public view override returns (bool, uint256) {
+        return (success, rate);
+    }
+
+    function peekSpot(bytes calldata) public view override returns (uint256) {
+        return rate;
+    }
+
+    function name(bytes calldata) public view override returns (string memory) {
+        return "Test";
+    }
+
+    function symbol(bytes calldata) public view override returns (string memory) {
+        return "TEST";
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -54,7 +54,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 20000,
+        runs: 2000,
       }
     }
   },

--- a/test/011_oracle.ts
+++ b/test/011_oracle.ts
@@ -27,7 +27,9 @@ describe('Oracle', function () {
   })
 
   it('sets and retrieves the spot price', async () => {
-    await oracle.setSpot(1)
-    expect(await oracle.spot()).to.equal(1)
+    await oracle.set(1)
+    const result = await oracle.callStatic.get('0x00')
+    expect(result[0]).to.be.true
+    expect(result[1]).to.equal(1)
   })
 })

--- a/test/031_fyToken.ts
+++ b/test/031_fyToken.ts
@@ -105,7 +105,7 @@ describe('FYToken', function () {
 
       beforeEach(async () => {
         await fyToken.mature()
-        await chiOracle.setSpot(accrual) // Since spot was 1 when recorded at maturity, accrual is equal to the current spot
+        await chiOracle.set(accrual) // Since spot was 1 when recorded at maturity, accrual is equal to the current spot
       })
 
       it('redeems fyToken for underlying according to the chi accrual', async () => {

--- a/test/051_cauldron_admin.ts
+++ b/test/051_cauldron_admin.ts
@@ -68,8 +68,8 @@ describe('Cauldron - admin', function () {
       [
         id('addAsset(bytes6,address)'),
         id('setMaxDebt(bytes6,bytes6,uint128)'),
-        id('setRateOracle(bytes6,address)'),
-        id('setSpotOracle(bytes6,bytes6,address,uint32)'),
+        id('setRateOracle(bytes6,address,bytes)'),
+        id('setSpotOracle(bytes6,bytes6,address,uint32,bytes)'),
         id('addSeries(bytes6,bytes6,address)'),
         id('addIlks(bytes6,bytes6[])'),
       ],
@@ -124,13 +124,13 @@ describe('Cauldron - admin', function () {
     })
 
     it('does not allow adding a rate oracle for an unknown base', async () => {
-      await expect(cauldron.setRateOracle(mockAssetId, oracle.address)).to.be.revertedWith('Asset not found')
+      await expect(cauldron.setRateOracle(mockAssetId, oracle.address, '0x00')).to.be.revertedWith('Asset not found')
     })
 
     it('adds a rate oracle', async () => {
-      expect(await cauldron.setRateOracle(baseId, oracle.address))
+      expect(await cauldron.setRateOracle(baseId, oracle.address, '0x00'))
         .to.emit(cauldron, 'RateOracleAdded')
-        .withArgs(baseId, oracle.address)
+        .withArgs(baseId, oracle.address, '0x00')
 
       expect(await cauldron.rateOracles(baseId)).to.equal(oracle.address)
     })
@@ -141,7 +141,7 @@ describe('Cauldron - admin', function () {
 
     describe('with a rate oracle added', async () => {
       beforeEach(async () => {
-        await cauldron.setRateOracle(baseId, oracle.address)
+        await cauldron.setRateOracle(baseId, oracle.address, '0x00')
       })
 
       it('does not allow not linking a series to a fyToken', async () => {
@@ -175,21 +175,21 @@ describe('Cauldron - admin', function () {
         })
 
         it('does not allow adding a spot oracle for an unknown base', async () => {
-          await expect(cauldron.setSpotOracle(mockAssetId, ilkId1, oracle.address, ratio)).to.be.revertedWith(
+          await expect(cauldron.setSpotOracle(mockAssetId, ilkId1, oracle.address, ratio, '0x00')).to.be.revertedWith(
             'Asset not found'
           )
         })
 
         it('does not allow adding a spot oracle for an unknown ilk', async () => {
-          await expect(cauldron.setSpotOracle(baseId, mockAssetId, oracle.address, ratio)).to.be.revertedWith(
+          await expect(cauldron.setSpotOracle(baseId, mockAssetId, oracle.address, ratio, '0x00')).to.be.revertedWith(
             'Asset not found'
           )
         })
 
         it('adds a spot oracle and its collateralization ratio', async () => {
-          expect(await cauldron.setSpotOracle(baseId, ilkId1, oracle.address, ratio))
+          expect(await cauldron.setSpotOracle(baseId, ilkId1, oracle.address, ratio, '0x00'))
             .to.emit(cauldron, 'SpotOracleAdded')
-            .withArgs(baseId, ilkId1, oracle.address, ratio)
+            .withArgs(baseId, ilkId1, oracle.address, ratio, '0x00')
 
           const spot = await cauldron.spotOracles(baseId, ilkId1)
           expect(spot.oracle).to.equal(oracle.address)
@@ -198,8 +198,8 @@ describe('Cauldron - admin', function () {
 
         describe('with an oracle for the series base and an ilk', async () => {
           beforeEach(async () => {
-            await cauldron.setSpotOracle(baseId, ilkId1, oracle.address, ratio)
-            await cauldron.setSpotOracle(baseId, ilkId2, oracle.address, ratio)
+            await cauldron.setSpotOracle(baseId, ilkId1, oracle.address, ratio, '0x00')
+            await cauldron.setSpotOracle(baseId, ilkId2, oracle.address, ratio, '0x00')
           })
 
           it("does not allow adding an asset as an ilk to a series that doesn't exist", async () => {

--- a/test/053_cauldron_level.ts
+++ b/test/053_cauldron_level.ts
@@ -54,7 +54,7 @@ describe('Cauldron - level', function () {
     fyToken = env.series.get(seriesId) as FYToken
     vaultId = (env.vaults.get(seriesId) as Map<string, string>).get(ilkId) as string
 
-    await spotOracle.setSpot(DEC6.mul(2))
+    await spotOracle.set(DEC6.mul(2))
     await ladle.pour(vaultId, owner, WAD, WAD)
   })
 
@@ -62,9 +62,9 @@ describe('Cauldron - level', function () {
     const ink = (await cauldron.balances(vaultId)).ink
     const art = (await cauldron.balances(vaultId)).art
     for (let spot of [1, 2, 4]) {
-      await spotOracle.setSpot(DEC6.mul(spot))
+      await spotOracle.set(DEC6.mul(spot))
       for (let ratio of [50, 100, 200]) {
-        await cauldron.setSpotOracle(baseId, ilkId, spotOracle.address, ratio * 10000)
+        await cauldron.setSpotOracle(baseId, ilkId, spotOracle.address, ratio * 10000, '0x00')
         const expectedLevel = ink.mul(spot).sub(art.mul(ratio).div(100))
         expect(await cauldron.callStatic.level(vaultId)).to.equal(expectedLevel)
         // console.log(`${ink} * ${DEC6.mul(spot)} - ${art} * ${ratio} = ${await cauldron.level(vaultId)} | ${expectedLevel} `)
@@ -86,8 +86,8 @@ describe('Cauldron - level', function () {
 
   describe('after maturity', async () => {
     beforeEach(async () => {
-      await spotOracle.setSpot(DEC6.mul(1))
-      await rateOracle.setSpot(DEC6.mul(1))
+      await spotOracle.set(DEC6.mul(1))
+      await rateOracle.set(DEC6.mul(1))
       await ethers.provider.send('evm_mine', [(await fyToken.maturity()).toNumber()])
     })
 
@@ -103,12 +103,12 @@ describe('Cauldron - level', function () {
       const ink = (await cauldron.balances(vaultId)).ink
       const art = (await cauldron.balances(vaultId)).art
       for (let spot of [1, 2, 4]) {
-        await spotOracle.setSpot(DEC6.mul(spot))
+        await spotOracle.set(DEC6.mul(spot))
         for (let rate of [110, 120, 140]) {
-          await rateOracle.setSpot(DEC6.mul(rate).div(100))
+          await rateOracle.set(DEC6.mul(rate).div(100))
           // accrual = rate / 100
           for (let ratio of [50, 100, 200]) {
-            await cauldron.setSpotOracle(baseId, ilkId, spotOracle.address, ratio * 10000)
+            await cauldron.setSpotOracle(baseId, ilkId, spotOracle.address, ratio * 10000, '0x00')
             const expectedLevel = ink.mul(spot).sub(art.mul(rate).mul(ratio).div(10000))
             expect(await cauldron.callStatic.level(vaultId)).to.equal(expectedLevel)
             // console.log(`${ink} * ${RAY.mul(spot)} - ${art} * ${ratio} = ${await cauldron.level(vaultId)} | ${expectedLevel} `)

--- a/test/060_ladle_admin.ts
+++ b/test/060_ladle_admin.ts
@@ -81,11 +81,11 @@ describe('Ladle - admin', function () {
     // ==== Set testing environment ====
     ilk = (await deployContract(ownerAcc, ERC20MockArtifact, [ilkId, 'Mock Ilk'])) as ERC20Mock
     oracle = (await deployContract(ownerAcc, OracleMockArtifact, [])) as OracleMock
-    await oracle.setSpot(DEC6)
+    await oracle.set(DEC6)
 
     await cauldron.addAsset(ilkId, ilk.address)
     await cauldron.setMaxDebt(baseId, ilkId, WAD.mul(2))
-    await cauldron.setSpotOracle(baseId, ilkId, oracle.address, ratio)
+    await cauldron.setSpotOracle(baseId, ilkId, oracle.address, ratio, '0x00')
 
     // Deploy a join
     ilkJoin = (await deployContract(ownerAcc, JoinArtifact, [ilk.address])) as Join

--- a/test/062_ladle_close.ts
+++ b/test/062_ladle_close.ts
@@ -148,11 +148,11 @@ describe('Ladle - close', function () {
     const accrual = DEC6.mul(110).div(100) // accrual is 10%
 
     beforeEach(async () => {
-      await spotOracle.setSpot(DEC6.mul(1))
-      await rateOracle.setSpot(DEC6.mul(1))
+      await spotOracle.set(DEC6.mul(1))
+      await rateOracle.set(DEC6.mul(1))
       await ethers.provider.send('evm_mine', [(await fyToken.maturity()).toNumber()])
       await cauldron.mature(seriesId)
-      await rateOracle.setSpot(accrual) // Since spot was 1 when recorded at maturity, accrual is equal to the current spot
+      await rateOracle.set(accrual) // Since spot was 1 when recorded at maturity, accrual is equal to the current spot
     })
 
     it('users can repay their debt with underlying at accrual rate', async () => {

--- a/test/081_witch.ts
+++ b/test/081_witch.ts
@@ -87,7 +87,7 @@ describe('Witch', function () {
   })
 
   it('grabs undercollateralized vaults', async () => {
-    await spotOracle.setSpot(DEC6.div(2))
+    await spotOracle.set(DEC6.div(2))
     await witch.grab(vaultId)
     const event = (await cauldron.queryFilter(cauldron.filters.VaultTimestamped(null, null)))[0]
     expect(event.args.timestamp.toNumber()).to.be.greaterThan(0)
@@ -96,7 +96,7 @@ describe('Witch', function () {
 
   describe('once a vault has been grabbed', async () => {
     beforeEach(async () => {
-      await spotOracle.setSpot(DEC6.div(2))
+      await spotOracle.set(DEC6.div(2))
       await witch.grab(vaultId)
     })
 

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -69,8 +69,8 @@ export class YieldEnvironment {
         id('addSeries(bytes6,bytes6,address)'),
         id('addIlks(bytes6,bytes6[])'),
         id('setMaxDebt(bytes6,bytes6,uint128)'),
-        id('setRateOracle(bytes6,address)'),
-        id('setSpotOracle(bytes6,bytes6,address,uint32)'),
+        id('setRateOracle(bytes6,address,bytes)'),
+        id('setSpotOracle(bytes6,bytes6,address,uint32,bytes)'),
       ],
       receiver
     )
@@ -140,21 +140,21 @@ export class YieldEnvironment {
   public static async addSpotOracle(owner: SignerWithAddress, cauldron: Cauldron, baseId: string, ilkId: string) {
     const ratio = 1000000 //  1000000 == 100% collateralization ratio
     const oracle = (await deployContract(owner, OracleMockArtifact, [])) as OracleMock
-    await oracle.setSpot(DEC6.mul(2))
-    await cauldron.setSpotOracle(baseId, ilkId, oracle.address, ratio)
+    await oracle.set(DEC6.mul(2))
+    await cauldron.setSpotOracle(baseId, ilkId, oracle.address, ratio, '0x00')
     return oracle
   }
 
   public static async addRateOracle(owner: SignerWithAddress, cauldron: Cauldron, baseId: string) {
     const oracle = (await deployContract(owner, OracleMockArtifact, [])) as OracleMock
-    await oracle.setSpot(DEC6.mul(2))
-    await cauldron.setRateOracle(baseId, oracle.address)
+    await oracle.set(DEC6.mul(2))
+    await cauldron.setRateOracle(baseId, oracle.address, '0x00')
     return oracle
   }
 
   public static async addChiOracle(owner: SignerWithAddress) { // This will be referenced by the fyToken, and needs no id
     const oracle = (await deployContract(owner, OracleMockArtifact, [])) as OracleMock
-    await oracle.setSpot(DEC6)
+    await oracle.set(DEC6)
     return oracle
   }
 


### PR DESCRIPTION
SushiSwap's Kashi uses an oracle format that we can perfectly reuse. This will not only distribute the burden of creating and deploying new oracle wrappers, but also means that the Uniswap v2 TWAP oracles will be more accurate.

The downside is that the configuration parameters to read the rate and spot oracles need to be stored in the Cauldron and read each time we check for collateralization, adding several SLOAD. Would this be [3 SLOAD](https://github.com/sushiswap/kashi-lending/blob/master/contracts/oracles/ChainlinkOracle.sol) for checking a Chainlink oracle?