### PR TITLE
Simplify batch in Ladle

### DIFF
--- a/src/ladleWrapper.ts
+++ b/src/ladleWrapper.ts
@@ -54,186 +54,181 @@ export class LadleWrapper {
     return this.ladle.pools(seriesId)
   }
 
-  public async batch(vaultId: string, actions: Array<BatchAction>, overrides?: PayableOverrides): Promise<ContractTransaction> {
+  public async batch(actions: Array<BatchAction>, overrides?: PayableOverrides): Promise<ContractTransaction> {
     const ops = new Array<BigNumberish>()
     const data = new Array<BytesLike>()
     actions.forEach(action => {
       ops.push(action.op)
       data.push(action.data)
     });
-    if (overrides === undefined) return this.ladle.batch(vaultId, ops, data)
-    else return this.ladle.batch(vaultId, ops, data, overrides)
+    if (overrides === undefined) return this.ladle.batch(ops, data)
+    else return this.ladle.batch(ops, data, overrides)
   }
 
-  public buildAction(seriesId: string, ilkId: string): BatchAction {
-    return new BatchAction(OPS.BUILD, ethers.utils.defaultAbiCoder.encode(['bytes6', 'bytes6'], [seriesId, ilkId]))
+  public buildAction(vaultId: string, seriesId: string, ilkId: string): BatchAction {
+    return new BatchAction(OPS.BUILD, ethers.utils.defaultAbiCoder.encode(['bytes12', 'bytes6', 'bytes6'], [vaultId, seriesId, ilkId]))
   }
 
   public async build(vaultId: string, seriesId: string, ilkId: string): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.buildAction(seriesId, ilkId)])
+    return this.batch([this.buildAction(vaultId, seriesId, ilkId)])
   }
 
-  public tweakAction(seriesId: string, ilkId: string): BatchAction {
-    return new BatchAction(OPS.TWEAK, ethers.utils.defaultAbiCoder.encode(['bytes6', 'bytes6'], [seriesId, ilkId]))
+  public tweakAction(vaultId: string, seriesId: string, ilkId: string): BatchAction {
+    return new BatchAction(OPS.TWEAK, ethers.utils.defaultAbiCoder.encode(['bytes12', 'bytes6', 'bytes6'], [vaultId, seriesId, ilkId]))
   }
 
   public async tweak(vaultId: string, seriesId: string, ilkId: string): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.tweakAction(seriesId, ilkId)])
+    return this.batch([this.tweakAction(vaultId, seriesId, ilkId)])
   }
 
-  public giveAction(to: string): BatchAction {
-    return new BatchAction(OPS.GIVE, ethers.utils.defaultAbiCoder.encode(['address'], [to]))
+  public giveAction(vaultId: string, to: string): BatchAction {
+    return new BatchAction(OPS.GIVE, ethers.utils.defaultAbiCoder.encode(['bytes12', 'address'], [vaultId, to]))
   }
 
   public async give(vaultId: string, to: string): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.giveAction(to)])
+    return this.batch([this.giveAction(vaultId, to)])
   }
 
-  public destroyAction(): BatchAction {
-    return new BatchAction(OPS.DESTROY, ethers.utils.defaultAbiCoder.encode(['uint256'], [0]))  // The data will be ignored
+  public destroyAction(vaultId: string): BatchAction {
+    return new BatchAction(OPS.DESTROY, ethers.utils.defaultAbiCoder.encode(['bytes12'], [vaultId]))
   }
 
   public async destroy(vaultId: string): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.destroyAction()])
+    return this.batch([this.destroyAction(vaultId)])
   }
 
-  public stirToAction(from: string, ink: BigNumberish, art: BigNumberish): BatchAction {
-    return new BatchAction(OPS.STIR_TO, ethers.utils.defaultAbiCoder.encode(['bytes12', 'uint128', 'uint128'], [from, ink, art]))
+  public stirToAction(from: string, to: string, ink: BigNumberish, art: BigNumberish): BatchAction {
+    return new BatchAction(OPS.STIR_TO, ethers.utils.defaultAbiCoder.encode(['bytes12', 'bytes12', 'uint128', 'uint128'], [from, to, ink, art]))
   }
 
-  public stirFromAction(to: string, ink: BigNumberish, art: BigNumberish): BatchAction {
-    return new BatchAction(OPS.STIR_FROM, ethers.utils.defaultAbiCoder.encode(['bytes12', 'uint128', 'uint128'], [to, ink, art]))
+  public stirFromAction(from: string, to: string, ink: BigNumberish, art: BigNumberish): BatchAction {
+    return new BatchAction(OPS.STIR_FROM, ethers.utils.defaultAbiCoder.encode(['bytes12', 'bytes12', 'uint128', 'uint128'], [from, to, ink, art]))
   }
 
-  public async stir(from: string, to: string, ink: BigNumberish, art: BigNumberish): Promise<ContractTransaction> {
-    return this.batch(from, [this.stirFromAction(to, ink, art)])
+  public async stir(from: string, to: string, ink: BigNumberish, art: BigNumberish): Promise<ContractTransaction> { // Default stir. Use when `from` has been used before in the same batch.
+    return this.batch([this.stirFromAction(from, to, ink, art)])
   }
 
-  public async stirTo(from: string, to: string, ink: BigNumberish, art: BigNumberish): Promise<ContractTransaction> {
-    return this.batch(to, [this.stirToAction(from, ink, art)])
+  public async stirTo(from: string, to: string, ink: BigNumberish, art: BigNumberish): Promise<ContractTransaction> { // Alternate stir. Use when `to` has been used before in the same batch.
+    return this.batch([this.stirToAction(from, to, ink, art)])
   }
 
-  public pourAction(to: string, ink: BigNumberish, art: BigNumberish): BatchAction {
-    return new BatchAction(OPS.POUR, ethers.utils.defaultAbiCoder.encode(['address', 'int128', 'int128'], [to, ink, art]))
+  public pourAction(vaultId: string, to: string, ink: BigNumberish, art: BigNumberish): BatchAction {
+    return new BatchAction(OPS.POUR, ethers.utils.defaultAbiCoder.encode(['bytes12', 'address', 'int128', 'int128'], [vaultId, to, ink, art]))
   }
 
   public async pour(vaultId: string, to: string, ink: BigNumberish, art: BigNumberish): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.pourAction(to, ink, art)])
+    return this.batch([this.pourAction(vaultId, to, ink, art)])
   }
 
-  public closeAction(to: string, ink: BigNumberish, art: BigNumberish): BatchAction {
-    return new BatchAction(OPS.CLOSE, ethers.utils.defaultAbiCoder.encode(['address', 'int128', 'int128'], [to, ink, art]))
+  public closeAction(vaultId: string, to: string, ink: BigNumberish, art: BigNumberish): BatchAction {
+    return new BatchAction(OPS.CLOSE, ethers.utils.defaultAbiCoder.encode(['bytes12', 'address', 'int128', 'int128'], [vaultId, to, ink, art]))
   }
 
   public async close(vaultId: string, to: string, ink: BigNumberish, art: BigNumberish): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.closeAction(to, ink, art)])
+    return this.batch([this.closeAction(vaultId, to, ink, art)])
   }
 
-  public serveAction(to: string, ink: BigNumberish, base: BigNumberish, max: BigNumberish): BatchAction {
-    return new BatchAction(OPS.SERVE, ethers.utils.defaultAbiCoder.encode(['address', 'uint128', 'uint128', 'uint128'], [to, ink, base, max]))
+  public serveAction(vaultId: string, to: string, ink: BigNumberish, base: BigNumberish, max: BigNumberish): BatchAction {
+    return new BatchAction(OPS.SERVE, ethers.utils.defaultAbiCoder.encode(['bytes12', 'address', 'uint128', 'uint128', 'uint128'], [vaultId, to, ink, base, max]))
   }
 
   public async serve(vaultId: string, to: string, ink: BigNumberish, base: BigNumberish, max: BigNumberish): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.serveAction(to, ink, base, max)])
+    return this.batch([this.serveAction(vaultId, to, ink, base, max)])
   }
 
-  public repayAction(to: string, ink: BigNumberish, min: BigNumberish): BatchAction {
-    return new BatchAction(OPS.REPAY, ethers.utils.defaultAbiCoder.encode(['address', 'int128', 'uint128'], [to, ink, min]))
+  public repayAction(vaultId: string, to: string, ink: BigNumberish, min: BigNumberish): BatchAction {
+    return new BatchAction(OPS.REPAY, ethers.utils.defaultAbiCoder.encode(['bytes12', 'address', 'int128', 'uint128'], [vaultId, to, ink, min]))
   }
 
   public async repay(vaultId: string, to: string, ink: BigNumberish, min: BigNumberish): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.repayAction(to, ink, min)])
+    return this.batch([this.repayAction(vaultId, to, ink, min)])
   }
 
-  public repayVaultAction(to: string, ink: BigNumberish, max: BigNumberish): BatchAction {
-    return new BatchAction(OPS.REPAY_VAULT, ethers.utils.defaultAbiCoder.encode(['address', 'int128', 'uint128'], [to, ink, max]))
+  public repayVaultAction(vaultId: string, to: string, ink: BigNumberish, max: BigNumberish): BatchAction {
+    return new BatchAction(OPS.REPAY_VAULT, ethers.utils.defaultAbiCoder.encode(['bytes12', 'address', 'int128', 'uint128'], [vaultId, to, ink, max]))
   }
 
   public async repayVault(vaultId: string, to: string, ink: BigNumberish, max: BigNumberish): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.repayVaultAction(to, ink, max)])
+    return this.batch([this.repayVaultAction(vaultId, to, ink, max)])
   }
 
-  public rollAction(newSeriesId: string, max: BigNumberish): BatchAction {
-    return new BatchAction(OPS.ROLL, ethers.utils.defaultAbiCoder.encode(['bytes6', 'uint128'], [newSeriesId, max]))
+  public rollAction(vaultId: string, newSeriesId: string, max: BigNumberish): BatchAction {
+    return new BatchAction(OPS.ROLL, ethers.utils.defaultAbiCoder.encode(['bytes12', 'bytes6', 'uint128'], [vaultId, newSeriesId, max]))
   }
 
   public async roll(vaultId: string, newSeriesId: string, max: BigNumberish): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.rollAction(newSeriesId, max)])
+    return this.batch([this.rollAction(vaultId, newSeriesId, max)])
   }
 
-  public forwardPermitAction(seriesId: string, asset: boolean, spender: string, amount: BigNumberish, deadline: BigNumberish, v: BigNumberish, r: Buffer, s: Buffer): BatchAction {
+  public forwardPermitAction(id: string, asset: boolean, spender: string, amount: BigNumberish, deadline: BigNumberish, v: BigNumberish, r: Buffer, s: Buffer): BatchAction {
     return new BatchAction(OPS.FORWARD_PERMIT, ethers.utils.defaultAbiCoder.encode(
       ['bytes6', 'bool', 'address', 'uint256', 'uint256', 'uint8', 'bytes32', 'bytes32'],
-      [seriesId, asset, spender, amount, deadline, v, r, s]
+      [id, asset, spender, amount, deadline, v, r, s]
     ))
   }
 
-  public async forwardPermit(vaultId: string, seriesId: string, asset: boolean, spender: string, amount: BigNumberish, deadline: BigNumberish, v: BigNumberish, r: Buffer, s: Buffer): Promise<ContractTransaction> {
-    // The vaultId parameter is irrelevant to forwardPermit, but necessary when included in a batch
-    return this.batch(vaultId, [this.forwardPermitAction(seriesId, asset, spender, amount, deadline, v, r, s)])
+  public async forwardPermit(id: string, asset: boolean, spender: string, amount: BigNumberish, deadline: BigNumberish, v: BigNumberish, r: Buffer, s: Buffer): Promise<ContractTransaction> {
+    return this.batch([this.forwardPermitAction(id, asset, spender, amount, deadline, v, r, s)])
   }
 
-  public forwardDaiPermitAction(seriesId: string, asset: boolean, spender: string, nonce: BigNumberish, deadline: BigNumberish, approved: boolean, v: BigNumberish, r: Buffer, s: Buffer): BatchAction {
+  public forwardDaiPermitAction(id: string, asset: boolean, spender: string, nonce: BigNumberish, deadline: BigNumberish, approved: boolean, v: BigNumberish, r: Buffer, s: Buffer): BatchAction {
     return new BatchAction(OPS.FORWARD_DAI_PERMIT, ethers.utils.defaultAbiCoder.encode(
       ['bytes6', 'bool', 'address', 'uint256', 'uint256', 'bool', 'uint8', 'bytes32', 'bytes32'],
-      [seriesId, asset, spender, nonce, deadline, approved, v, r, s]
+      [id, asset, spender, nonce, deadline, approved, v, r, s]
     ))
   }
 
-  public async forwardDaiPermit(vaultId: string, seriesId: string, asset: boolean, spender: string, nonce: BigNumberish, deadline: BigNumberish, approved: boolean, v: BigNumberish, r: Buffer, s: Buffer): Promise<ContractTransaction> {
-    // The vaultId parameter is irrelevant to forwardDaiPermit, but necessary when included in a batch
-    return this.batch(vaultId, [this.forwardDaiPermitAction(seriesId, asset, spender, nonce, deadline, approved, v, r, s)])
+  public async forwardDaiPermit(id: string, asset: boolean, spender: string, nonce: BigNumberish, deadline: BigNumberish, approved: boolean, v: BigNumberish, r: Buffer, s: Buffer): Promise<ContractTransaction> {
+    return this.batch([this.forwardDaiPermitAction(id, asset, spender, nonce, deadline, approved, v, r, s)])
   }
 
   public joinEtherAction(etherId: string): BatchAction {
     return new BatchAction(OPS.JOIN_ETHER, ethers.utils.defaultAbiCoder.encode(['bytes6'], [etherId]))
   }
 
-  public async joinEther(vaultId: string, etherId: string, overrides?: any): Promise<ContractTransaction> {
-    // The vaultId parameter is irrelevant to joinEther, but necessary when included in a batch
-    const action = this.joinEtherAction(etherId)
-    return this.ladle.batch(vaultId, [action.op], [action.data], overrides)
+  public async joinEther(etherId: string, overrides?: any): Promise<ContractTransaction> {
+    return this.batch([this.joinEtherAction(etherId)], overrides)
   }
 
   public exitEtherAction(etherId: string, to: string): BatchAction {
     return new BatchAction(OPS.EXIT_ETHER, ethers.utils.defaultAbiCoder.encode(['bytes6', 'address'], [etherId, to]))
   }
 
-  public async exitEther(vaultId: string, etherId: string, to: string): Promise<ContractTransaction> {
-    // The vaultId parameter is irrelevant to exitEther, but necessary when included in a batch
-    return this.batch(vaultId, [this.exitEtherAction(etherId, to)])
+  public async exitEther(etherId: string, to: string): Promise<ContractTransaction> {
+    return this.batch([this.exitEtherAction(etherId, to)])
   }
 
-  public transferToPoolAction(base: boolean, wad: BigNumberish): BatchAction {
-    return new BatchAction(OPS.TRANSFER_TO_POOL, ethers.utils.defaultAbiCoder.encode(['bool', 'uint128'], [base, wad]))
+  public transferToPoolAction(seriesId: string, base: boolean, wad: BigNumberish): BatchAction {
+    return new BatchAction(OPS.TRANSFER_TO_POOL, ethers.utils.defaultAbiCoder.encode(['bytes6', 'bool', 'uint128'], [seriesId, base, wad]))
   }
 
-  public async transferToPool(vaultId: string, base: boolean, wad: BigNumberish): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.transferToPoolAction(base, wad)])
+  public async transferToPool(seriesId: string, base: boolean, wad: BigNumberish): Promise<ContractTransaction> {
+    return this.batch([this.transferToPoolAction(seriesId, base, wad)])
   }
 
-  public routeAction(call: string): BatchAction {
-    return new BatchAction(OPS.ROUTE, call)  // `call` is already an encoded function call, no need to abi-encode it again
+  public routeAction(seriesId: string, poolCall: string): BatchAction {
+    return new BatchAction(OPS.ROUTE, ethers.utils.defaultAbiCoder.encode(['bytes6', 'bytes'], [seriesId, poolCall]))
   }
 
-  public async route(vaultId: string, innerCall: string): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.routeAction(innerCall)])
+  public async route(seriesId: string, poolCall: string): Promise<ContractTransaction> {
+    return this.batch([this.routeAction(seriesId, poolCall)])
   }
 
-  public transferToFYTokenAction(wad: BigNumberish): BatchAction {
-    return new BatchAction(OPS.TRANSFER_TO_FYTOKEN, ethers.utils.defaultAbiCoder.encode(['uint256'], [wad]))
+  public transferToFYTokenAction(seriesId: string, wad: BigNumberish): BatchAction {
+    return new BatchAction(OPS.TRANSFER_TO_FYTOKEN, ethers.utils.defaultAbiCoder.encode(['bytes6', 'uint256'], [seriesId, wad]))
   }
 
-  public async transferToFYToken(vaultId: string, seriesId: string, wad: BigNumberish): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.transferToFYTokenAction(wad)])
+  public async transferToFYToken(seriesId: string, wad: BigNumberish): Promise<ContractTransaction> {
+    return this.batch([this.transferToFYTokenAction(seriesId, wad)])
   }
 
-  public redeemAction(to: string, wad: BigNumberish): BatchAction {
-    return new BatchAction(OPS.REDEEM, ethers.utils.defaultAbiCoder.encode(['address', 'uint256'], [to, wad]))
+  public redeemAction(seriesId: string, to: string, wad: BigNumberish): BatchAction {
+    return new BatchAction(OPS.REDEEM, ethers.utils.defaultAbiCoder.encode(['bytes6', 'address', 'uint256'], [seriesId, to, wad]))
   }
 
-  public async redeem(vaultId: string, seriesId: string, to: string, wad: BigNumberish): Promise<ContractTransaction> {
-    return this.batch(vaultId, [this.redeemAction(to, wad)])
+  public async redeem(seriesId: string, to: string, wad: BigNumberish): Promise<ContractTransaction> {
+    return this.batch([this.redeemAction(seriesId, to, wad)])
   }
 }
   

--- a/test/031_fyToken.ts
+++ b/test/031_fyToken.ts
@@ -164,13 +164,7 @@ describe('FYToken', function () {
         await fyToken.approve(ladle.address, WAD)
 
         await expect(
-          await ladle.batch(
-            vaultId,
-            [
-              ladle.transferToFYTokenAction(WAD),
-              ladle.redeemAction(owner, WAD)
-            ]
-          )
+          await ladle.batch([ladle.transferToFYTokenAction(seriesId, WAD), ladle.redeemAction(seriesId, owner, WAD)])
         )
           .to.emit(fyToken, 'Transfer')
           .withArgs(owner, fyToken.address, WAD)

--- a/test/060_ladle_admin.ts
+++ b/test/060_ladle_admin.ts
@@ -118,7 +118,7 @@ describe('Ladle - admin', function () {
 
     it('adds a join', async () => {
       expect(await ladle.addJoin(ilkId, ilkJoin.address))
-        .to.emit(ladle, 'JoinAdded')
+        .to.emit(ladle.ladle, 'JoinAdded') // The event is emitted by the ladle, not the wrapper
         .withArgs(ilkId, ilkJoin.address)
       expect(await ladle.joins(ilkId)).to.equal(ilkJoin.address)
     })
@@ -126,7 +126,7 @@ describe('Ladle - admin', function () {
     it('adds the same join for a second ilk of the same asset', async () => {
       await cauldron.addAsset(otherIlkId, ilk.address)
       expect(await ladle.addJoin(otherIlkId, ilkJoin.address))
-        .to.emit(ladle, 'JoinAdded')
+        .to.emit(ladle.ladle, 'JoinAdded')
         .withArgs(otherIlkId, ilkJoin.address)
       expect(await ladle.joins(otherIlkId)).to.equal(ilkJoin.address)
     })
@@ -160,7 +160,7 @@ describe('Ladle - admin', function () {
 
     it('adds a pool', async () => {
       expect(await ladle.addPool(seriesId, pool.address))
-        .to.emit(ladle, 'PoolAdded')
+        .to.emit(ladle.ladle, 'PoolAdded')
         .withArgs(seriesId, pool.address)
       expect(await ladle.pools(seriesId)).to.equal(pool.address)
     })

--- a/test/062_ladle_close.ts
+++ b/test/062_ladle_close.ts
@@ -127,7 +127,7 @@ describe('Ladle - close', function () {
   it('users can repay their debt with underlying and remove collateral at the same time in a batch', async () => {
     const baseBefore = await base.balanceOf(owner)
 
-    await expect(ladle.batch(vaultId, [ladle.closeAction(owner, WAD.mul(-1), WAD.mul(-1))]))
+    await expect(ladle.batch([ladle.closeAction(vaultId, owner, WAD.mul(-1), WAD.mul(-1))]))
       .to.emit(cauldron, 'VaultPoured')
       .withArgs(vaultId, seriesId, ilkId, WAD.mul(-1), WAD.mul(-1))
 

--- a/test/064_ladle_stir.ts
+++ b/test/064_ladle_stir.ts
@@ -105,7 +105,7 @@ describe('Ladle - stir', function () {
     await ladle.pour(vaultFromId, owner, WAD, 0)
     await ladle.give(vaultToId, other)
 
-    expect(await ladle.batch(vaultFromId, [ladle.stirFromAction(vaultToId, WAD, 0)]))
+    expect(await ladle.batch([ladle.stirFromAction(vaultFromId, vaultToId, WAD, 0)]))
       .to.emit(cauldron, 'VaultStirred')
       .withArgs(vaultFromId, vaultToId, WAD, 0)
     expect((await cauldron.balances(vaultFromId)).ink).to.equal(0)
@@ -116,7 +116,7 @@ describe('Ladle - stir', function () {
     await ladle.pour(vaultFromId, owner, WAD, 0)
     await ladle.give(vaultFromId, other)
 
-    await expect(ladle.batch(vaultFromId, [ladle.stirFromAction(vaultToId, WAD, 0)])).to.be.revertedWith(
+    await expect(ladle.batch([ladle.stirFromAction(vaultFromId, vaultToId, WAD, 0)])).to.be.revertedWith(
       'Only vault owner'
     )
   })
@@ -126,7 +126,7 @@ describe('Ladle - stir', function () {
     await ladle.pour(vaultToId, owner, WAD, 0)
     await ladle.give(vaultFromId, other)
 
-    expect(await ladle.batch(vaultToId, [ladle.stirToAction(vaultFromId, 0, WAD)]))
+    expect(await ladle.batch([ladle.stirToAction(vaultFromId, vaultToId, 0, WAD)]))
       .to.emit(cauldron, 'VaultStirred')
       .withArgs(vaultFromId, vaultToId, 0, WAD)
     expect((await cauldron.balances(vaultFromId)).art).to.equal(0)
@@ -137,6 +137,8 @@ describe('Ladle - stir', function () {
     await ladle.pour(vaultFromId, owner, WAD, WAD)
     await ladle.give(vaultToId, other)
 
-    await expect(ladle.batch(vaultToId, [ladle.stirToAction(vaultFromId, 0, WAD)])).to.be.revertedWith('Only vault owner')
+    await expect(ladle.batch([ladle.stirToAction(vaultFromId, vaultToId, 0, WAD)])).to.be.revertedWith(
+      'Only vault owner'
+    )
   })
 })

--- a/test/067_ladle_serve_and_repay.ts
+++ b/test/067_ladle_serve_and_repay.ts
@@ -107,10 +107,12 @@ describe('Ladle - serve and repay', function () {
     const inkRetrieved = WAD.div(4)
 
     await base.approve(ladle.address, debtRepaidInBase) // This would normally be part of a multicall, using ladle.forwardPermit
-    await expect(ladle.batch(vaultId, [
-      ladle.transferToPoolAction(true, debtRepaidInBase),
-      ladle.repayAction(owner, inkRetrieved, 0)
-    ]))
+    await expect(
+      ladle.batch([
+        ladle.transferToPoolAction(seriesId, true, debtRepaidInBase),
+        ladle.repayAction(vaultId, owner, inkRetrieved, 0),
+      ])
+    )
       .to.emit(cauldron, 'VaultPoured')
       .withArgs(vaultId, seriesId, ilkId, inkRetrieved, debtRepaidInFY.mul(-1))
       .to.emit(pool, 'Trade')
@@ -152,9 +154,9 @@ describe('Ladle - serve and repay', function () {
 
     await base.approve(ladle.address, baseOffered) // This would normally be part of a multicall, using ladle.forwardPermit
     await expect(
-      ladle.batch(vaultId, [
-        ladle.transferToPoolAction(true, baseOffered),
-        ladle.repayVaultAction(owner, inkRetrieved, MAX)
+      ladle.batch([
+        ladle.transferToPoolAction(seriesId, true, baseOffered),
+        ladle.repayVaultAction(vaultId, owner, inkRetrieved, MAX),
       ])
     )
       .to.emit(cauldron, 'VaultPoured')

--- a/test/068_ladle_eth.ts
+++ b/test/068_ladle_eth.ts
@@ -64,7 +64,7 @@ describe('Ladle - eth', function () {
   })
 
   it('users can transfer ETH then pour', async () => {
-    expect(await ladle.joinEther(ethVaultId, ethId, { value: WAD }))
+    expect(await ladle.joinEther(ethId, { value: WAD }))
     expect(await ladle.pour(ethVaultId, owner, WAD, 0))
       .to.emit(cauldron, 'VaultPoured')
       .withArgs(ethVaultId, seriesId, ethId, WAD, 0)
@@ -73,15 +73,12 @@ describe('Ladle - eth', function () {
   })
 
   it('users can transfer ETH then pour in a single transaction with batch', async () => {
-    await ladle.batch(ethVaultId, [
-      ladle.joinEtherAction(ethId),
-      ladle.pourAction(owner, WAD, 0)
-    ], { value: WAD })
+    await ladle.batch([ladle.joinEtherAction(ethId), ladle.pourAction(ethVaultId, owner, WAD, 0)], { value: WAD })
   })
 
   describe('with ETH posted', async () => {
     beforeEach(async () => {
-      expect(await ladle.joinEther(ethVaultId, ethId, { value: WAD }))
+      expect(await ladle.joinEther(ethId, { value: WAD }))
       await ladle.pour(ethVaultId, owner, WAD, 0)
     })
 
@@ -93,28 +90,28 @@ describe('Ladle - eth', function () {
       expect((await cauldron.balances(ethVaultId)).ink).to.equal(0)
       expect(await weth.balanceOf(ladle.address)).to.equal(WAD)
 
-      expect(await ladle.exitEther(ethVaultId, ethId, owner))
+      expect(await ladle.exitEther(ethId, owner))
         .to.emit(weth, 'Withdrawal')
         .withArgs(ladle.address, WAD)
       expect(await weth.balanceOf(ladle.address)).to.equal(0)
     })
 
     it('users can pour then unwrap to ETH in a single transaction with batch', async () => {
-      await ladle.batch(ethVaultId, [
-        ladle.pourAction(ladle.address, WAD.mul(-1), 0),
-        ladle.exitEtherAction(ethId, owner)
+      await ladle.batch([
+        ladle.pourAction(ethVaultId, ladle.address, WAD.mul(-1), 0),
+        ladle.exitEtherAction(ethId, owner),
       ])
     })
   })
 
   describe('with ETH posted and positive debt', async () => {
     beforeEach(async () => {
-      expect(await ladle.joinEther(ethVaultId, ethId, { value: WAD }))
+      expect(await ladle.joinEther(ethId, { value: WAD }))
       await ladle.pour(ethVaultId, owner, WAD, WAD)
     })
 
     it('users can close to post ETH', async () => {
-      expect(await ladle.joinEther(ethVaultId, ethId, { value: WAD }))
+      expect(await ladle.joinEther(ethId, { value: WAD }))
       expect(await ladle.close(ethVaultId, owner, WAD, WAD.mul(-1)))
         .to.emit(cauldron, 'VaultPoured')
         .withArgs(ethVaultId, seriesId, ethId, WAD, WAD.mul(-1))

--- a/test/069_ladle_permit.ts
+++ b/test/069_ladle_permit.ts
@@ -72,7 +72,7 @@ describe('Ladle - permit', function () {
 
     const { v, r, s } = signatures.sign(permitDigest, signatures.privateKey0)
 
-    expect(await ladle.forwardPermit(ilkVaultId, ilkId, true, ilkJoin.address, amount, deadline, v, r, s))
+    expect(await ladle.forwardPermit(ilkId, true, ilkJoin.address, amount, deadline, v, r, s))
       .to.emit(ilk, 'Approval')
       .withArgs(owner, ilkJoin.address, WAD)
 
@@ -93,7 +93,7 @@ describe('Ladle - permit', function () {
 
     const { v, r, s } = signatures.sign(permitDigest, signatures.privateKey0)
 
-    expect(await ladle.forwardPermit(ilkVaultId, seriesId, false, ladle.address, amount, deadline, v, r, s))
+    expect(await ladle.forwardPermit(seriesId, false, ladle.address, amount, deadline, v, r, s))
       .to.emit(fyToken, 'Approval')
       .withArgs(owner, ladle.address, WAD)
 
@@ -116,10 +116,12 @@ describe('Ladle - permit', function () {
 
     const vaultId = ethers.utils.hexlify(ethers.utils.randomBytes(12)) // You can't use `batch` without owning or building a vault.
 
-    expect(await ladle.batch(vaultId, [
-      ladle.buildAction(seriesId, ilkId),
-      ladle.forwardPermitAction(seriesId, false, ladle.address, amount, deadline, v, r, s)
-    ]))
+    expect(
+      await ladle.batch([
+        ladle.buildAction(vaultId, seriesId, ilkId),
+        ladle.forwardPermitAction(seriesId, false, ladle.address, amount, deadline, v, r, s),
+      ])
+    )
       .to.emit(fyToken, 'Approval')
       .withArgs(owner, ladle.address, WAD)
 
@@ -139,7 +141,7 @@ describe('Ladle - permit', function () {
 
     const { v, r, s } = signatures.sign(daiPermitDigest, signatures.privateKey0)
 
-    expect(await ladle.forwardDaiPermit(ilkVaultId, DAI, true, ladle.address, nonce, deadline, true, v, r, s))
+    expect(await ladle.forwardDaiPermit(DAI, true, ladle.address, nonce, deadline, true, v, r, s))
       .to.emit(dai, 'Approval')
       .withArgs(owner, ladle.address, MAX)
 
@@ -161,10 +163,12 @@ describe('Ladle - permit', function () {
 
     const vaultId = ethers.utils.hexlify(ethers.utils.randomBytes(12)) // You can't use `batch` without owning or building a vault.
 
-    expect(await ladle.batch(vaultId, [
-      ladle.buildAction(seriesId, ilkId),
-      ladle.forwardDaiPermitAction(DAI, true, ladle.address, nonce, deadline, true, v, r, s)
-    ]))
+    expect(
+      await ladle.batch([
+        ladle.buildAction(vaultId, seriesId, ilkId),
+        ladle.forwardDaiPermitAction(DAI, true, ladle.address, nonce, deadline, true, v, r, s),
+      ])
+    )
       .to.emit(dai, 'Approval')
       .withArgs(owner, ladle.address, MAX)
 
@@ -185,8 +189,8 @@ describe('Ladle - permit', function () {
 
     const { v, r, s } = signatures.sign(permitDigest, signatures.privateKey0)
 
-    await expect(
-      ladle.forwardPermit(ilkVaultId, mockIlkId, true, ilkJoin.address, amount, deadline, v, r, s)
-    ).to.be.revertedWith('Token not found')
+    await expect(ladle.forwardPermit(mockIlkId, true, ilkJoin.address, amount, deadline, v, r, s)).to.be.revertedWith(
+      'Token not found'
+    )
   })
 })

--- a/test/070_ladle_batch.ts
+++ b/test/070_ladle_batch.ts
@@ -87,10 +87,10 @@ describe('Ladle - batch', function () {
 
     const borrowed = WAD
 
-    await ladle.batch(vaultId, [
-      ladle.buildAction(seriesId, ilkId),
+    await ladle.batch([
+      ladle.buildAction(vaultId, seriesId, ilkId),
       ladle.forwardPermitAction(ilkId, true, ilkJoin.address, posted, deadline, v, r, s),
-      ladle.serveAction(owner, posted, borrowed, MAX)
+      ladle.serveAction(vaultId, owner, posted, borrowed, MAX),
     ])
 
     const vault = await cauldron.vaults(vaultId)
@@ -105,11 +105,10 @@ describe('Ladle - batch', function () {
     const borrowed = WAD
 
     await ladle.batch(
-      newVaultId,
       [
-        ladle.buildAction(seriesId, ethId),
+        ladle.buildAction(newVaultId, seriesId, ethId),
         ladle.joinEtherAction(ethId),
-        ladle.serveAction(owner, posted, borrowed, MAX)
+        ladle.serveAction(newVaultId, owner, posted, borrowed, MAX),
       ],
       { value: posted }
     )
@@ -125,22 +124,21 @@ describe('Ladle - batch', function () {
     const borrowed = WAD
 
     await ladle.batch(
-      ethVaultId,
       [
         ladle.joinEtherAction(ethId),
-        ladle.pourAction(owner, posted, 0),
-        ladle.serveAction(other, 0, borrowed, MAX)        
+        ladle.pourAction(ethVaultId, owner, posted, 0),
+        ladle.serveAction(ethVaultId, other, 0, borrowed, MAX),
       ],
       { value: posted }
     )
   })
 
   it('calls can be routed to pools', async () => {
-    await ladle.build(vaultId, seriesId, ilkId) // ladle.batch can only be executed by vault owners
+    await ladle.build(vaultId, seriesId, ilkId)
     await base.mint(pool.address, WAD)
 
     const retrieveBaseTokenCall = pool.interface.encodeFunctionData('retrieveBaseToken', [owner])
-    await expect(await ladle.route(vaultId, retrieveBaseTokenCall)) // The pool is found through the vault seriesId
+    await expect(await ladle.route(seriesId, retrieveBaseTokenCall))
       .to.emit(base, 'Transfer')
       .withArgs(pool.address, owner, WAD)
   })


### PR DESCRIPTION
There is no need to specify which vault is the `batch` going to operate on. Each action takes a `vaultId` parameter if needed and the caching happens transparently.