### PR TITLE
feat: grab to

### DIFF
--- a/contracts/Witch.sol
+++ b/contracts/Witch.sol
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
+
+import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/vault-interfaces/ILadle.sol";
 import "@yield-protocol/vault-interfaces/ICauldron.sol";
 import "@yield-protocol/vault-interfaces/DataTypes.sol";
@@ -9,21 +11,38 @@ import "./math/WDivUp.sol";
 import "./math/CastU256U128.sol";
 
 
-contract Witch {
+contract Witch is AccessControl() {
     using WMul for uint256;
     using WDiv for uint256;
     using WDivUp for uint256;
     using CastU256U128 for uint256;
 
+    event AuctionTimeSet(uint128 indexed auctionTime);
+    event InitialProportionSet(uint128 indexed initialProportion);
     event Bought(address indexed buyer, bytes12 indexed vaultId, uint256 ink, uint256 art);
   
-    uint256 constant public AUCTION_TIME = 4 * 60 * 60; // Time that auctions take to go to minimal price and stay there.
+    uint128 public auctionTime = 4 * 60 * 60; // Time that auctions take to go to minimal price and stay there.
+    uint128 public initialProportion = 5e17;  // Proportion of collateral that is sold at auction start.
+
     ICauldron immutable public cauldron;
     ILadle immutable public ladle;
 
     constructor (ICauldron cauldron_, ILadle ladle_) {
         cauldron = cauldron_;
         ladle = ladle_;
+    }
+
+    /// @dev Set the auction time to calculate liquidation prices
+    function setAuctionTime(uint128 auctionTime_) public auth {
+        auctionTime = auctionTime_;
+        emit AuctionTimeSet(auctionTime_);
+    }
+
+    /// @dev Set the proportion of the collateral that will be sold at auction start
+    function setInitialProportion(uint128 initialProportion_) public auth {
+        require (initialProportion_ <= 1e18, "Only at or under 100%");
+        initialProportion = initialProportion_;
+        emit InitialProportionSet(initialProportion_);
     }
 
     /// @dev Put an undercollateralized vault up for liquidation.
@@ -36,21 +55,20 @@ contract Witch {
         DataTypes.Balances memory balances_ = cauldron.balances(vaultId);
 
         require (balances_.art > 0, "Nothing to buy");                                      // Cheapest way of failing gracefully if given a non existing vault
-        uint256 elapsed = uint32(block.timestamp) - cauldron.timestamps(vaultId);           // Auctions will malfunction on the 7th of February 2106, at 06:28:16 GMT, we should replace this contract before then.
+        uint256 elapsed = uint32(block.timestamp) - cauldron.auctions(vaultId);           // Auctions will malfunction on the 7th of February 2106, at 06:28:16 GMT, we should replace this contract before then.
         uint256 price;
         {
             // Price of a collateral unit, in underlying, at the present moment, for a given vault
             //
-            //                ink       1      min(auction, elapsed)
-            // price = 1 / (------- * (--- + -----------------------))
-            //                art       2       2 * auction
-            // solhint-disable-next-line var-name-mixedcase
+            //                ink                     min(auction, elapsed)
+            // price = 1 / (------- * (p + (1 - p) * -----------------------))
+            //                art                          auction
+            (uint256 auctionTime_, uint256 initialProportion_) = (auctionTime, initialProportion);
             uint256 term1 = uint256(balances_.ink).wdiv(balances_.art);
-            uint256 term2 = 1e18 / 2;
-            uint256 dividend3 = AUCTION_TIME < elapsed ? AUCTION_TIME : elapsed;
-            uint256 divisor3 = AUCTION_TIME * 2;
-            uint256 term3 = dividend3.wdiv(divisor3);
-            price = uint256(1e18).wdiv(term1.wmul(term2 + term3));
+            uint256 dividend2 = auctionTime_ < elapsed ? auctionTime_ : elapsed;
+            uint256 divisor2 = auctionTime_;
+            uint256 term2 = initialProportion_ + (1e18 - initialProportion_).wmul(dividend2.wdiv(divisor2));
+            price = uint256(1e18).wdiv(term1.wmul(term2));
         }
         uint256 ink = uint256(art).wdivup(price);                                                    // Calculate collateral to sell. Using divdrup stops rounding from leaving 1 stray wei in vaults.
         require (ink >= min, "Not enough bought");

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@truffle/hdwallet-provider": "^1.0.40",
     "@types/mocha": "^8.0.0",
     "@yield-protocol/utils-v2": "^2.2.2",
-    "@yield-protocol/vault-interfaces": "^2.0.26",
+    "@yield-protocol/vault-interfaces": "^2.0.27",
     "@yield-protocol/yieldspace-interfaces": "^2.0.11",
     "chai": "4.2.0",
     "dss-interfaces": "0.1.1",

--- a/test/051_cauldron_admin.ts
+++ b/test/051_cauldron_admin.ts
@@ -67,6 +67,7 @@ describe('Cauldron - admin', function () {
 
     await cauldron.grantRoles(
       [
+        id('setAuctionInterval(uint32)'),
         id('addAsset(bytes6,address)'),
         id('setMaxDebt(bytes6,bytes6,uint128)'),
         id('setRateOracle(bytes6,address)'),
@@ -76,6 +77,13 @@ describe('Cauldron - admin', function () {
       ],
       owner
     )
+  })
+
+  it('sets the protection period', async () => {
+    expect(await cauldron.setAuctionInterval(1))
+      .to.emit(cauldron, 'AuctionIntervalSet')
+      .withArgs(1)
+    expect(await cauldron.auctionInterval()).to.equal(1)
   })
 
   it('does not allow using zero as an asset identifier', async () => {

--- a/test/081_witch.ts
+++ b/test/081_witch.ts
@@ -76,6 +76,24 @@ describe('Witch', function () {
     await ladle.pour(vaultId, owner, WAD, WAD)
   })
 
+  it('does not allow to set the initial proportion over 100%', async () => {
+    await expect(witch.setInitialProportion(WAD.mul(2))).to.be.revertedWith('Only at or under 100%')
+  })
+
+  it('allows to set the initial proportion', async () => {
+    expect(await witch.setInitialProportion(1))
+      .to.emit(witch, 'InitialProportionSet')
+      .withArgs(1)
+    expect(await witch.initialProportion()).to.equal(1)
+  })
+
+  it('allows to set the auction time', async () => {
+    expect(await witch.setAuctionTime(1))
+      .to.emit(witch, 'AuctionTimeSet')
+      .withArgs(1)
+    expect(await witch.auctionTime()).to.equal(1)
+  })
+
   it('does not allow to grab collateralized vaults', async () => {
     await expect(witch.grab(vaultId)).to.be.revertedWith('Not undercollateralized')
   })
@@ -91,9 +109,9 @@ describe('Witch', function () {
   it('grabs undercollateralized vaults', async () => {
     await spotSource.set(WAD.div(2))
     await witch.grab(vaultId)
-    const event = (await cauldron.queryFilter(cauldron.filters.VaultTimestamped(null, null)))[0]
+    const event = (await cauldron.queryFilter(cauldron.filters.VaultLocked(null, null)))[0]
     expect(event.args.timestamp.toNumber()).to.be.greaterThan(0)
-    expect(await cauldron.timestamps(vaultId)).to.equal(event.args.timestamp)
+    expect(await cauldron.auctions(vaultId)).to.equal(event.args.timestamp)
   })
 
   describe('once a vault has been grabbed', async () => {
@@ -103,7 +121,7 @@ describe('Witch', function () {
     })
 
     it("it can't be grabbed again", async () => {
-      await expect(witch.grab(vaultId)).to.be.revertedWith('Timestamped')
+      await expect(witch.grab(vaultId)).to.be.revertedWith('Vault under auction')
     })
 
     it('does not buy if minimum collateral not reached', async () => {
@@ -131,7 +149,7 @@ describe('Witch', function () {
     describe('once the auction time has passed', async () => {
       beforeEach(async () => {
         const now = (await ethers.provider.getBlock(await ethers.provider.getBlockNumber())).timestamp
-        await ethers.provider.send('evm_mine', [now + (await witch.AUCTION_TIME()).toNumber()])
+        await ethers.provider.send('evm_mine', [now + (await witch.auctionTime()).toNumber()])
       })
 
       it('allows to buy all of the collateral for the whole debt at the end', async () => {

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -86,6 +86,7 @@ export class YieldEnvironment {
   public static async cauldronGovAuth(cauldron: Cauldron, receiver: string) {
     await cauldron.grantRoles(
       [
+        id('setAuctionInterval(uint32)'),
         id('addAsset(bytes6,address)'),
         id('addSeries(bytes6,bytes6,address)'),
         id('addIlks(bytes6,bytes6[])'),
@@ -140,6 +141,16 @@ export class YieldEnvironment {
       id(
         'settle(bytes12,address,uint128,uint128)'
       )],
+      receiver
+    )
+  }
+
+  public static async witchGovAuth(witch: Witch, receiver: string) {
+    await witch.grantRoles(
+      [
+        id('setAuctionTime(uint128)'),
+        id('setInitialProportion(uint128)'),
+      ],
       receiver
     )
   }
@@ -253,6 +264,10 @@ export class YieldEnvironment {
     await this.cauldronLadleAuth(cauldron, ownerAdd)
     await this.ladleGovAuth(ladle, ownerAdd)
     await this.ladleWitchAuth(ladle, ownerAdd)
+    await this.witchGovAuth(witch, ownerAdd)
+
+    // ==== Set protection period for vaults in liquidation ====
+    await cauldron.setAuctionInterval(24 * 60 * 60)
 
     // ==== Add assets and joins ====
     // For each asset id passed as an argument, we create a Mock ERC20 which we register in cauldron, and its Join, that we register in Ladle.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,10 +2297,10 @@
     ethereumjs-util "^7.0.8"
     ethers "^5.0.7"
 
-"@yield-protocol/vault-interfaces@^2.0.26":
-  version "2.0.26"
-  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.0.26.tgz#2532b3888cb31509aa91859133cf995d2f742333"
-  integrity sha512-xwTqex1yJcYmMoCzhARdIwALIs4AWWBjGco47b1HLIq0X0L+OFyI85WpPgqDHfTD+YeFc7WbFPVffZ4oldkOWA==
+"@yield-protocol/vault-interfaces@^2.0.27":
+  version "2.0.27"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.0.27.tgz#312c8cf0e076692737c02bb4fafb6da8e194c793"
+  integrity sha512-rWIKHV1UrhDZ4ssXS67slAiJmoZpctqvGcWmgJ/mljZMIRv3VxO8M2JTEliz78YcffDXbDGuUhcK9CpHaGBsFg==
 
 "@yield-protocol/yieldspace-interfaces@^2.0.11":
   version "2.0.11"


### PR DESCRIPTION
By not using `msg.sender` anywhere in `Cauldron.sol` the attack surface is clearer.