### PR TITLE
fix: give permission to the fyToken to transfer base from the join

### DIFF
--- a/contracts/Wand.sol
+++ b/contracts/Wand.sol
@@ -131,7 +131,7 @@ contract Wand is AccessControl {
         // Allow the fyToken to pull from the base join for redemption
         bytes4[] memory sigs = new bytes4[](1);
         sigs[0] = EXIT;
-        AccessControl(address(baseJoin)).grantRoles(sigs, address(ladle));
+        AccessControl(address(baseJoin)).grantRoles(sigs, address(fyToken));
 
         // Allow the ladle to issue and cancel fyToken
         sigs = new bytes4[](2);


### PR DESCRIPTION
The Wand was giving permission to the Ladle, not to the FYToken, when adding a series.