### PR TITLE
feat: use AccessControl for MultiOracles

### DIFF
--- a/contracts/oracles/chainlink/ChainlinkMultiOracle.sol
+++ b/contracts/oracles/chainlink/ChainlinkMultiOracle.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import "@yield-protocol/utils-v2/contracts/access/Ownable.sol";
+import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/vault-interfaces/IOracle.sol";
 import "../../math/CastBytes32Bytes6.sol";
 import "./AggregatorV3Interface.sol";
@@ -10,7 +10,7 @@ import "./AggregatorV3Interface.sol";
 /**
  * @title ChainlinkMultiOracle
  */
-contract ChainlinkMultiOracle is IOracle, Ownable {
+contract ChainlinkMultiOracle is IOracle, AccessControl {
     using CastBytes32Bytes6 for bytes32;
 
     event SourceSet(bytes6 indexed baseId, bytes6 indexed quoteId, address indexed source);
@@ -26,7 +26,7 @@ contract ChainlinkMultiOracle is IOracle, Ownable {
     /**
      * @notice Set or reset an oracle source and its inverse
      */
-    function setSource(bytes6 base, bytes6 quote, address source) public onlyOwner {
+    function setSource(bytes6 base, bytes6 quote, address source) public auth {
         uint8 decimals = AggregatorV3Interface(source).decimals();
         require (decimals <= 18, "Unsupported decimals");
         sources[base][quote] = Source({
@@ -46,7 +46,7 @@ contract ChainlinkMultiOracle is IOracle, Ownable {
     /**
      * @notice Set or reset a number of oracle sources and their inverses
      */
-    function setSources(bytes6[] memory bases, bytes6[] memory quotes, address[] memory sources_) public onlyOwner {
+    function setSources(bytes6[] memory bases, bytes6[] memory quotes, address[] memory sources_) public auth {
         require(
             bases.length == quotes.length && 
             bases.length == sources_.length,

--- a/contracts/oracles/compound/CompoundMultiOracle.sol
+++ b/contracts/oracles/compound/CompoundMultiOracle.sol
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import "@yield-protocol/utils-v2/contracts/access/Ownable.sol";
+import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/vault-interfaces/IOracle.sol";
 import "../../math/CastBytes32Bytes6.sol";
 import "./CTokenInterface.sol";
 
 
-contract CompoundMultiOracle is IOracle, Ownable {
+contract CompoundMultiOracle is IOracle, AccessControl {
     using CastBytes32Bytes6 for bytes32;
 
-    event SourceSet(bytes6 indexed baseId, bytes32 indexed kind, address indexed source);
+    event SourceSet(bytes6 indexed baseId, bytes6 indexed kind, address indexed source);
 
     uint public constant SCALE_FACTOR = 1; // I think we don't need scaling for rate and chi oracles
 
-    mapping(bytes6 => mapping(bytes32 => address)) public sources;
+    mapping(bytes6 => mapping(bytes6 => address)) public sources;
 
     /**
      * @notice Set or reset one source
      */
-    function setSource(bytes6 base, bytes32 kind, address source) public onlyOwner {
+    function setSource(bytes6 base, bytes6 kind, address source) public auth {
         sources[base][kind] = source;
         emit SourceSet(base, kind, source);
     }
@@ -27,7 +27,7 @@ contract CompoundMultiOracle is IOracle, Ownable {
     /**
      * @notice Set or reset an oracle source
      */
-    function setSources(bytes6[] memory bases, bytes32[] memory kinds, address[] memory sources_) public onlyOwner {
+    function setSources(bytes6[] memory bases, bytes6[] memory kinds, address[] memory sources_) public auth {
         require(bases.length == kinds.length && kinds.length == sources_.length, "Mismatched inputs");
         for (uint256 i = 0; i < bases.length; i++)
             setSource(bases[i], kinds[i], sources_[i]);
@@ -37,7 +37,7 @@ contract CompoundMultiOracle is IOracle, Ownable {
      * @notice Retrieve the latest price of a given source.
      * @return price
      */
-    function _peek(bytes6 base, bytes32 kind) private view returns (uint price, uint updateTime) {
+    function _peek(bytes6 base, bytes6 kind) private view returns (uint price, uint updateTime) {
         uint256 rawPrice;
         address source = sources[base][kind];
         require (source != address(0), "Source not found");
@@ -58,7 +58,7 @@ contract CompoundMultiOracle is IOracle, Ownable {
      */
     function peek(bytes32 base, bytes32 kind, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
         uint256 price;
-        (price, updateTime) = _peek(base.b6(), kind);
+        (price, updateTime) = _peek(base.b6(), kind.b6());
         value = price * amount / 1e18;
     }
 
@@ -68,7 +68,7 @@ contract CompoundMultiOracle is IOracle, Ownable {
      */
     function get(bytes32 base, bytes32 kind, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
         uint256 price;
-        (price, updateTime) = _peek(base.b6(), kind);
+        (price, updateTime) = _peek(base.b6(), kind.b6());
         value = price * amount / 1e18;
     }
 }

--- a/contracts/oracles/uniswap/UniswapV3Oracle.sol
+++ b/contracts/oracles/uniswap/UniswapV3Oracle.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-import "@yield-protocol/utils-v2/contracts/access/Ownable.sol";
+import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/vault-interfaces/IOracle.sol";
 import "../../math/CastBytes32Bytes6.sol";
 import "./IUniswapV3PoolImmutables.sol";
@@ -12,7 +12,7 @@ import "../../mocks/oracles/uniswap/UniswapV3OracleLibraryMock.sol";
 /**
  * @title UniswapV3Oracle
  */
-contract UniswapV3Oracle is IOracle, Ownable {
+contract UniswapV3Oracle is IOracle, AccessControl {
     using CastBytes32Bytes6 for bytes32;
 
     event SecondsAgoSet(uint32 indexed secondsAgo);
@@ -37,7 +37,7 @@ contract UniswapV3Oracle is IOracle, Ownable {
     /**
      * @notice Set or reset the number of seconds Uniswap will use for its Time Weighted Average Price computation
      */
-    function setSecondsAgo(uint32 secondsAgo_) public onlyOwner {
+    function setSecondsAgo(uint32 secondsAgo_) public auth {
         require(secondsAgo_ != 0, "Uniswap must look into the past.");
         secondsAgo = secondsAgo_;
         emit SecondsAgoSet(secondsAgo_);
@@ -46,7 +46,7 @@ contract UniswapV3Oracle is IOracle, Ownable {
     /**
      * @notice Set or reset an oracle source and its inverse
      */
-    function setSource(bytes6 base, bytes6 quote, address source) public onlyOwner {
+    function setSource(bytes6 base, bytes6 quote, address source) public auth {
         sources[base][quote] = Source(source, false);
         sources[quote][base] = Source(source, true);
         sourcesData[source] = SourceData(
@@ -62,7 +62,7 @@ contract UniswapV3Oracle is IOracle, Ownable {
     /**
      * @notice Set or reset a number of oracle sources
      */
-    function setSources(bytes6[] memory bases, bytes6[] memory quotes, address[] memory sources_) public onlyOwner {
+    function setSources(bytes6[] memory bases, bytes6[] memory quotes, address[] memory sources_) public auth {
         require(bases.length == quotes.length && quotes.length == sources_.length, "Mismatched inputs");
         for (uint256 i = 0; i < bases.length; i++) {
             setSource(bases[i], quotes[i], sources_[i]);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,5 +24,5 @@ export const OPS = {
     MODULE:               20,
   }
 
-export const CHI = ethers.utils.formatBytes32String('chi')
-export const RATE = ethers.utils.formatBytes32String('rate')
+export const CHI = ethers.utils.formatBytes32String('chi').slice(0, 14)
+export const RATE = ethers.utils.formatBytes32String('rate').slice(0, 14)

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -1,7 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
-import { id } from '@yield-protocol/utils-v2'
-import { constants } from '@yield-protocol/utils-v2'
+import { id, constants } from '@yield-protocol/utils-v2'
 const { WAD, THREE_MONTHS, ETH, DAI, USDC } = constants
 import { CHI, RATE } from '../../src/constants'
 
@@ -285,8 +284,8 @@ export class YieldEnvironment {
     await this.cauldronGovAuth(cauldron, wand.address)
     await this.ladleGovAuth(ladle, wand.address)
     await this.witchGovAuth(witch, wand.address)
-    await chiRateOracle.transferOwnership(wand.address)
-    await spotOracle.transferOwnership(wand.address)
+    await chiRateOracle.grantRole(id('setSource(bytes6,bytes6,address)'), wand.address)
+    await spotOracle.grantRole(id('setSource(bytes6,bytes6,address)'), wand.address)
 
     // ==== Owner access (only test environment) ====
     await this.wandAuth(wand, ownerAdd)


### PR DESCRIPTION
MultiOracles now inherit from AccessControl instead of Ownable. Otherwise, control would be locked in forever in the Wand.

Also, unified the `setSource` interface between spot oracles and rate/chi oracles.