### PR TITLE
Rc7

### DIFF
--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/vault-interfaces/IFYToken.sol";
 import "@yield-protocol/vault-interfaces/IOracle.sol";
 import "@yield-protocol/vault-interfaces/DataTypes.sol";

--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -409,7 +409,10 @@ contract Cauldron is AccessControl() {
     // ==== Accounting ====
 
     /// @dev Return the collateralization level of a vault. It will be negative if undercollateralized.
-    function level(bytes12 vaultId) public returns (int256) {
+    function level(bytes12 vaultId)
+        external
+        returns (int256)
+    {
         (DataTypes.Vault memory vault_, DataTypes.Series memory series_, DataTypes.Balances memory balances_) = vaultData(vaultId, true);
 
         return _level(vault_, balances_, series_);
@@ -417,7 +420,7 @@ contract Cauldron is AccessControl() {
 
     /// @dev Record the borrowing rate at maturity for a series
     function mature(bytes6 seriesId)
-        public
+        external
     {
         DataTypes.Series memory series_ = series[seriesId];
         require (uint32(block.timestamp) >= series_.maturity, "Only after maturity");
@@ -438,7 +441,7 @@ contract Cauldron is AccessControl() {
 
     /// @dev Retrieve the rate accrual since maturity, maturing if necessary.
     function accrual(bytes6 seriesId)
-        public
+        external
         returns (uint256)
     {
         DataTypes.Series memory series_ = series[seriesId];

--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -270,6 +270,7 @@ contract Cauldron is AccessControl() {
         auth
         returns (DataTypes.Balances memory, DataTypes.Balances memory)
     {
+        require (from != to, "Identical vaults");
         (DataTypes.Vault memory vaultFrom, , DataTypes.Balances memory balancesFrom) = vaultData(from, false);
         (DataTypes.Vault memory vaultTo, , DataTypes.Balances memory balancesTo) = vaultData(to, false);
 

--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -177,6 +177,8 @@ contract Cauldron is AccessControl() {
         returns(DataTypes.Vault memory vault)
     {
         require (vaultId != bytes12(0), "Vault id is zero");
+        require (seriesId != bytes12(0), "Series id is zero");
+        require (ilkId != bytes12(0), "Ilk id is zero");
         require (vaults[vaultId].seriesId == bytes6(0), "Vault already exists");   // Series can't take bytes6(0) as their id
         require (ilks[seriesId][ilkId] == true, "Ilk not added to series");
         vault = DataTypes.Vault({
@@ -205,6 +207,8 @@ contract Cauldron is AccessControl() {
     function _tweak(bytes12 vaultId, DataTypes.Vault memory vault)
         internal
     {
+        require (vault.seriesId != bytes6(0), "Series id is zero");
+        require (vault.ilkId != bytes6(0), "Ilk id is zero");
         require (ilks[vault.seriesId][vault.ilkId] == true, "Ilk not added to series");
 
         vaults[vaultId] = vault;
@@ -236,6 +240,7 @@ contract Cauldron is AccessControl() {
         internal
         returns(DataTypes.Vault memory vault)
     {
+        require (vaultId != bytes12(0), "Vault id is zero");
         vault = vaults[vaultId];
         vault.owner = receiver;
         vaults[vaultId] = vault;

--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -169,7 +169,7 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit 
         // First use any tokens locked in this contract
         uint256 available = _balanceOf[address(this)];
         if (available >= amount) {
-            unchecked { return super._burn(address(this), amount); }
+            return super._burn(address(this), amount);
         } else {
             if (available > 0 ) super._burn(address(this), available);
             unchecked { _decreaseAllowance(from, amount - available); }

--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.1;
 import "erc3156/contracts/interfaces/IERC3156FlashBorrower.sol";
 import "erc3156/contracts/interfaces/IERC3156FlashLender.sol";
 import "@yield-protocol/utils-v2/contracts/token/ERC20Permit.sol";
+import "@yield-protocol/utils-v2/contracts/token/SafeERC20Namer.sol";
 import "@yield-protocol/vault-interfaces/IFYToken.sol";
 import "@yield-protocol/vault-interfaces/IJoin.sol";
 import "@yield-protocol/vault-interfaces/IOracle.sol";
@@ -44,7 +45,7 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit,
         uint256 maturity_,
         string memory name,
         string memory symbol
-    ) ERC20Permit(name, symbol, IERC20Metadata(address(IJoin(join_).asset())).decimals()) { // The join asset is this fyToken's underlying, from which we inherit the decimals
+    ) ERC20Permit(name, symbol, SafeERC20Namer.tokenDecimals(address(IJoin(join_).asset()))) { // The join asset is this fyToken's underlying, from which we inherit the decimals
         uint256 now_ = block.timestamp;
         require(
             maturity_ > now_ &&

--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "erc3156/contracts/interfaces/IERC3156FlashBorrower.sol";
 import "erc3156/contracts/interfaces/IERC3156FlashLender.sol";

--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -12,9 +12,10 @@ import "./math/WMul.sol";
 import "./math/WDiv.sol";
 import "./math/CastU256U128.sol";
 import "./math/CastU256U32.sol";
+import "./constants/Constants.sol";
 
 
-contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit {
+contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit, Constants {
     using WMul for uint256;
     using WDiv for uint256;
     using CastU256U128 for uint256;
@@ -24,7 +25,7 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit 
     event Redeemed(address indexed from, address indexed to, uint256 amount, uint256 redeemed);
     event OracleSet(address indexed oracle);
 
-    bytes32 constant CHI = "chi";
+    uint256 constant CHI_NOT_SET = type(uint256).max;
 
     uint256 constant internal MAX_TIME_TO_MATURITY = 126144000; // seconds in four years
     bytes32 constant internal FLASH_LOAN_RETURN = keccak256("ERC3156FlashBorrower.onFlashLoan");
@@ -34,7 +35,7 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit 
     address public immutable override underlying;
     bytes6 public immutable underlyingId;                             // Needed to access the oracle
     uint256 public immutable override maturity;
-    uint256 public chiAtMaturity = type(uint256).max;           // Spot price (exchange rate) between the base and an interest accruing token at maturity 
+    uint256 public chiAtMaturity = CHI_NOT_SET;           // Spot price (exchange rate) between the base and an interest accruing token at maturity 
 
     constructor(
         bytes6 underlyingId_,
@@ -91,7 +92,7 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit 
         external override
         afterMaturity
     {
-        require (chiAtMaturity == type(uint256).max, "Already matured");
+        require (chiAtMaturity == CHI_NOT_SET, "Already matured");
         _mature();
     }
 
@@ -120,7 +121,7 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit 
         private
         returns (uint256 accrual_)
     {
-        if (chiAtMaturity == type(uint256).max) {  // After maturity, but chi not yet recorded. Let's record it, and accrual is then 1.
+        if (chiAtMaturity == CHI_NOT_SET) {  // After maturity, but chi not yet recorded. Let's record it, and accrual is then 1.
             _mature();
         } else {
             (uint256 chi,) = oracle.get(underlyingId, CHI, 1e18);

--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -140,7 +140,6 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit 
         join.exit(to, redeemed.u128());
         
         emit Redeemed(msg.sender, to, amount, redeemed);
-        return amount;
     }
 
     /// @dev Mint fyTokens.

--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -56,7 +56,8 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit 
         join = join_;
         maturity = maturity_;
         underlying = address(IJoin(join_).asset());
-        setOracle(oracle_);
+        oracle = oracle_;
+        emit OracleSet(address(oracle_));
     }
 
     modifier afterMaturity() {
@@ -77,7 +78,7 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit 
 
     /// @dev Set the oracle parameter
     function setOracle(IOracle oracle_)
-        public
+        external
         auth    
     {
         oracle = oracle_;

--- a/contracts/Join.sol
+++ b/contracts/Join.sol
@@ -94,7 +94,10 @@ contract Join is IJoin, IERC3156FlashLender, AccessControl() {
      * @param token The loan currency. It must be a FYDai contract.
      * @return The amount of `token` that can be borrowed.
      */
-    function maxFlashLoan(address token) public view override returns (uint256) {
+    function maxFlashLoan(address token)
+        external view override
+        returns (uint256)
+    {
         return token == asset ? storedBalance : 0;
     }
 
@@ -104,7 +107,10 @@ contract Join is IJoin, IERC3156FlashLender, AccessControl() {
      * @param amount The amount of tokens lent.
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
-    function flashFee(address token, uint256 amount) public view override returns (uint256) {
+    function flashFee(address token, uint256 amount)
+        external view override
+        returns (uint256)
+    {
         require(token == asset, "Unsupported currency");
         return _flashFee(amount);
     }
@@ -126,7 +132,10 @@ contract Join is IJoin, IERC3156FlashLender, AccessControl() {
      * @param amount The amount of tokens lent.
      * @param data A data parameter to be passed on to the `receiver` for any custom use.
      */
-    function flashLoan(IERC3156FlashBorrower receiver, address token, uint256 amount, bytes memory data) public override returns(bool) {
+    function flashLoan(IERC3156FlashBorrower receiver, address token, uint256 amount, bytes memory data)
+        external override
+        returns(bool)
+    {
         require(token == asset, "Unsupported currency");
         uint128 _amount = amount.u128();
         uint128 _fee = _flashFee(amount).u128();

--- a/contracts/Join.sol
+++ b/contracts/Join.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "erc3156/contracts/interfaces/IERC3156FlashBorrower.sol";
 import "erc3156/contracts/interfaces/IERC3156FlashLender.sol";

--- a/contracts/Join.sol
+++ b/contracts/Join.sol
@@ -23,7 +23,7 @@ contract Join is IJoin, IERC3156FlashLender, AccessControl() {
 
     address public immutable override asset;
     uint256 public storedBalance;
-    uint256 public flashFeeFactor; // Fee on flash loans, as a percentage in fixed point with 18 decimals
+    uint256 public flashFeeFactor = type(uint256).max; // Fee on flash loans, as a percentage in fixed point with 18 decimals. Flash loans disabled by default.
 
     constructor(address asset_) {
         asset = asset_;

--- a/contracts/Join.sol
+++ b/contracts/Join.sol
@@ -20,10 +20,11 @@ contract Join is IJoin, IERC3156FlashLender, AccessControl() {
     event FlashFeeFactorSet(uint256 indexed fee);
 
     bytes32 constant internal FLASH_LOAN_RETURN = keccak256("ERC3156FlashBorrower.onFlashLoan");
+    uint256 constant FLASH_LOANS_DISABLED = type(uint256).max;
 
     address public immutable override asset;
     uint256 public storedBalance;
-    uint256 public flashFeeFactor = type(uint256).max; // Fee on flash loans, as a percentage in fixed point with 18 decimals. Flash loans disabled by default.
+    uint256 public flashFeeFactor = FLASH_LOANS_DISABLED; // Fee on flash loans, as a percentage in fixed point with 18 decimals. Flash loans disabled by default.
 
     constructor(address asset_) {
         asset = asset_;

--- a/contracts/Join.sol
+++ b/contracts/Join.sol
@@ -25,8 +25,8 @@ contract Join is IJoin, IERC3156FlashLender, AccessControl() {
     uint256 public storedBalance;
     uint256 public flashFeeFactor; // Fee on flash loans, as a percentage in fixed point with 18 decimals
 
-    constructor() {
-        asset = IJoinFactory(msg.sender).nextAsset();
+    constructor(address asset_) {
+        asset = asset_;
     }
 
     /// @dev Set the flash loan fee factor

--- a/contracts/Join.sol
+++ b/contracts/Join.sol
@@ -31,7 +31,7 @@ contract Join is IJoin, IERC3156FlashLender, AccessControl() {
 
     /// @dev Set the flash loan fee factor
     function setFlashFeeFactor(uint256 flashFeeFactor_)
-        public
+        external
         auth
     {
         flashFeeFactor = flashFeeFactor_;

--- a/contracts/JoinFactory.sol
+++ b/contracts/JoinFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >= 0.8.0;
+pragma solidity 0.8.1;
 
 import "@yield-protocol/vault-interfaces/IJoinFactory.sol";
 import "./Join.sol";

--- a/contracts/JoinFactory.sol
+++ b/contracts/JoinFactory.sol
@@ -7,64 +7,12 @@ import "./Join.sol";
 
 /// @dev The JoinFactory can deterministically create new join instances.
 contract JoinFactory is IJoinFactory {
-  /// Pre-hashing the bytecode allows calculateJoinAddress to be cheaper, and
-  /// makes client-side address calculation easier
-  bytes32 public constant override JOIN_BYTECODE_HASH = keccak256(type(Join).creationCode);
-
-  address private _nextAsset;
-
-  /// @dev Returns true if `account` is a contract.
-  function isContract(address account) internal view returns (bool) {
-      // This method relies on extcodesize, which returns 0 for contracts in
-      // construction, since the code is only stored at the end of the
-      // constructor execution.
-
-      uint256 size;
-      // solhint-disable-next-line no-inline-assembly
-      assembly { size := extcodesize(account) }
-      return size > 0;
-  }
-
-  /// @dev Calculate the deterministic addreess of a join, based on the asset token.
-  /// @param asset Address of the asset token.
-  /// @return The calculated join address.
-  function calculateJoinAddress(address asset) external view override returns (address) {
-    return _calculateJoinAddress(asset);
-  }
-
-  /// @dev Create2 calculation
-  function _calculateJoinAddress(address asset)
-    private view returns (address calculatedAddress)
-  {
-    calculatedAddress = address(uint160(uint256(keccak256(abi.encodePacked(
-      bytes1(0xff),
-      address(this),
-      keccak256(abi.encodePacked(asset)),
-      JOIN_BYTECODE_HASH
-    )))));
-  }
-
-  /// @dev Calculate the address of a join, and return address(0) if not deployed.
-  /// @param asset Address of the asset token.
-  /// @return join The deployed join address.
-  function getJoin(address asset) external view override returns (address join) {
-    join = _calculateJoinAddress(asset);
-
-    if(!isContract(join)) {
-      join = address(0);
-    }
-  }
 
   /// @dev Deploys a new join.
-  /// The asset address is written to a temporary storage slot to allow for simpler
-  /// address calculation, while still allowing the Join contract to store the values as
-  /// immutable.
   /// @param asset Address of the asset token.
   /// @return join The join address.
   function createJoin(address asset) external override returns (address) {
-    _nextAsset = asset;
-    Join join = new Join{salt: keccak256(abi.encodePacked(asset))}();
-    _nextAsset = address(0);
+    Join join = new Join(asset);
 
     join.grantRole(join.ROOT(), msg.sender);
     join.renounceRole(join.ROOT(), address(this));
@@ -72,11 +20,5 @@ contract JoinFactory is IJoinFactory {
     emit JoinCreated(asset, address(join));
 
     return address(join);
-  }
-
-  /// @dev Only used by the Join constructor.
-  /// @return The address token for the currently-constructing join.
-  function nextAsset() external view override returns (address) {
-    return _nextAsset;
   }
 }

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/vault-interfaces/IFYToken.sol";
 import "@yield-protocol/vault-interfaces/IJoin.sol";
 import "@yield-protocol/vault-interfaces/ICauldron.sol";

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -553,7 +553,7 @@ contract Ladle is LadleStorage, AccessControl() {
     {
         ethTransferred = address(this).balance;
         IJoin wethJoin = getJoin(etherId);
-        weth.deposit{ value: ethTransferred }();   // TODO: Test gas savings using WETH10 `depositTo`
+        weth.deposit{ value: ethTransferred }();
         IERC20(address(weth)).safeTransfer(address(wethJoin), ethTransferred);
     }
 
@@ -564,7 +564,7 @@ contract Ladle is LadleStorage, AccessControl() {
         returns (uint256 ethTransferred)
     {
         ethTransferred = weth.balanceOf(address(this));
-        weth.withdraw(ethTransferred);   // TODO: Test gas savings using WETH10 `withdrawTo`
+        weth.withdraw(ethTransferred);
         to.safeTransferETH(ethTransferred);
     }
 

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -131,10 +131,12 @@ contract Ladle is LadleStorage, AccessControl() {
     function batch(
         Operation[] calldata operations,
         bytes[] calldata data
-    ) external payable {
+    ) external payable returns(bytes[] memory results) {
         require(operations.length == data.length, "Mismatched operation data");
         bytes12 cachedId;
         DataTypes.Vault memory vault;
+
+        results = new bytes[](operations.length);
 
         // Execute all operations in the batch. Conditionals ordered by expected frequency.
         for (uint256 i = 0; i < operations.length; i += 1) {
@@ -144,99 +146,110 @@ contract Ladle is LadleStorage, AccessControl() {
             if (operation == Operation.BUILD) {
                 (bytes6 seriesId, bytes6 ilkId) = abi.decode(data[i], (bytes6, bytes6));
                 (cachedId, vault) = _build(seriesId, ilkId, 0);   // Cache the vault that was just built
+                results[i] = abi.encode(cachedId);  // We only return the data that changed
             
             } else if (operation == Operation.FORWARD_PERMIT) {
                 (bytes6 id, bool isAsset, address spender, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) =
                     abi.decode(data[i], (bytes6, bool, address, uint256, uint256, uint8, bytes32, bytes32));
                 _forwardPermit(id, isAsset, spender, amount, deadline, v, r, s);
+                results[i] = abi.encode(true);
             
             } else if (operation == Operation.JOIN_ETHER) {
                 (bytes6 etherId) = abi.decode(data[i], (bytes6));
-                _joinEther(etherId);
+                results[i] = abi.encode(_joinEther(etherId));
             
             } else if (operation == Operation.POUR) {
                 (bytes12 vaultId, address to, int128 ink, int128 art) = abi.decode(data[i], (bytes12, address, int128, int128));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _pour(vaultId, vault, to, ink, art);
+                results[i] = abi.encode(true);
             
             } else if (operation == Operation.SERVE) {
                 (bytes12 vaultId, address to, uint128 ink, uint128 base, uint128 max) = abi.decode(data[i], (bytes12, address, uint128, uint128, uint128));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                _serve(vaultId, vault, to, ink, base, max);
+                results[i] = abi.encode(_serve(vaultId, vault, to, ink, base, max));
 
             } else if (operation == Operation.ROLL) {
                 (bytes12 vaultId, bytes6 newSeriesId, uint8 loan, uint128 max) = abi.decode(data[i], (bytes12, bytes6, uint8, uint128));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                (vault,) = _roll(vaultId, vault, newSeriesId, loan, max);
+                uint256 newDebt;
+                (vault, newDebt) = _roll(vaultId, vault, newSeriesId, loan, max);
+                results[i] = abi.encode(newDebt);
             
             } else if (operation == Operation.FORWARD_DAI_PERMIT) {
                 (bytes6 id, bool isAsset, address spender, uint256 nonce, uint256 deadline, bool allowed, uint8 v, bytes32 r, bytes32 s) =
                     abi.decode(data[i], (bytes6, bool, address, uint256, uint256, bool, uint8, bytes32, bytes32));
                 _forwardDaiPermit(id, isAsset, spender, nonce, deadline, allowed, v, r, s);
+                results[i] = abi.encode(true);
             
             } else if (operation == Operation.TRANSFER_TO_POOL) {
                 (bytes6 seriesId, bool base, uint128 wad) =
                     abi.decode(data[i], (bytes6, bool, uint128));
                 IPool pool = getPool(seriesId);
                 _transferToPool(pool, base, wad);
+                results[i] = abi.encode(true);
             
             } else if (operation == Operation.ROUTE) {
                 (bytes6 seriesId, bytes memory poolCall) =
                     abi.decode(data[i], (bytes6, bytes));
                 IPool pool = getPool(seriesId);
-                _route(pool, poolCall);
+                results[i] = _route(pool, poolCall);
             
             } else if (operation == Operation.EXIT_ETHER) {
                 (address to) = abi.decode(data[i], (address));
-                _exitEther(payable(to));
+                results[i] = abi.encode(_exitEther(payable(to)));
             
             } else if (operation == Operation.CLOSE) {
                 (bytes12 vaultId, address to, int128 ink, int128 art) = abi.decode(data[i], (bytes12, address, int128, int128));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                _close(vaultId, vault, to, ink, art);
+                results[i] = abi.encode(_close(vaultId, vault, to, ink, art));
             
             } else if (operation == Operation.REPAY) {
                 (bytes12 vaultId, address to, int128 ink, uint128 min) = abi.decode(data[i], (bytes12, address, int128, uint128));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                _repay(vaultId, vault, to, ink, min);
+                results[i] = abi.encode(_repay(vaultId, vault, to, ink, min));
             
             } else if (operation == Operation.REPAY_VAULT) {
                 (bytes12 vaultId, address to, int128 ink, uint128 max) = abi.decode(data[i], (bytes12, address, int128, uint128));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                _repayVault(vaultId, vault, to, ink, max);
+                results[i] = abi.encode(_repayVault(vaultId, vault, to, ink, max));
 
             } else if (operation == Operation.REPAY_LADLE) {
                 (bytes12 vaultId) = abi.decode(data[i], (bytes12));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                _repayLadle(vaultId, vault);
+                results[i] = abi.encode(_repayLadle(vaultId, vault));
 
             } else if (operation == Operation.RETRIEVE) {
                 (bytes6 assetId, bool isAsset, address to) = abi.decode(data[i], (bytes6, bool, address));
-                _retrieve(assetId, isAsset, to);
+                results[i] = abi.encode(_retrieve(assetId, isAsset, to));
 
             } else if (operation == Operation.TRANSFER_TO_FYTOKEN) {
                 (bytes6 seriesId, uint256 amount) = abi.decode(data[i], (bytes6, uint256));
                 IFYToken fyToken = getSeries(seriesId).fyToken;
                 _transferToFYToken(fyToken, amount);
+                results[i] = abi.encode(true);
             
             } else if (operation == Operation.REDEEM) {
                 (bytes6 seriesId, address to, uint256 amount) = abi.decode(data[i], (bytes6, address, uint256));
                 IFYToken fyToken = getSeries(seriesId).fyToken;
-                _redeem(fyToken, to, amount);
+                results[i] = abi.encode(_redeem(fyToken, to, amount));
             
             } else if (operation == Operation.STIR) {
                 (bytes12 from, bytes12 to, uint128 ink, uint128 art) = abi.decode(data[i], (bytes12, bytes12, uint128, uint128));
                 _stir(from, to, ink, art);  // Too complicated to use caching here
+                results[i] = abi.encode(true);
             
             } else if (operation == Operation.TWEAK) {
                 (bytes12 vaultId, bytes6 seriesId, bytes6 ilkId) = abi.decode(data[i], (bytes12, bytes6, bytes6));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
                 vault = _tweak(vaultId, seriesId, ilkId);
+                results[i] = abi.encode(true);
 
             } else if (operation == Operation.GIVE) {
                 (bytes12 vaultId, address to) = abi.decode(data[i], (bytes12, address));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
                 _give(vaultId, to);
+                results[i] = abi.encode(true);
                 delete vault;   // Clear the cache, since the vault doesn't necessarily belong to msg.sender anymore
                 cachedId = bytes12(0);
 
@@ -244,12 +257,13 @@ contract Ladle is LadleStorage, AccessControl() {
                 (bytes12 vaultId) = abi.decode(data[i], (bytes12));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
                 _destroy(vaultId);
+                results[i] = abi.encode(true);
                 delete vault;   // Clear the cache
                 cachedId = bytes12(0);
             
             } else if (operation == Operation.MODULE) {
                 (address module, bytes memory moduleCall) = abi.decode(data[i], (address, bytes));
-                _moduleCall(module, moduleCall);
+                results[i] = _moduleCall(module, moduleCall);
             
             }
         }
@@ -304,11 +318,10 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Move collateral and debt between vaults.
     function _stir(bytes12 from, bytes12 to, uint128 ink, uint128 art)
         private
-        returns (DataTypes.Balances memory, DataTypes.Balances memory)
     {
         if (ink > 0) require (cauldron.vaults(from).owner == msg.sender, "Only origin vault owner");
         if (art > 0) require (cauldron.vaults(to).owner == msg.sender, "Only destination vault owner");
-        return cauldron.stir(from, to, ink, art);
+        cauldron.stir(from, to, ink, art);
     }
 
     /// @dev Add collateral and borrow from vault, pull assets from and push borrowed asset to user
@@ -316,7 +329,6 @@ contract Ladle is LadleStorage, AccessControl() {
     /// Borrow only before maturity.
     function _pour(bytes12 vaultId, DataTypes.Vault memory vault, address to, int128 ink, int128 art)
         private
-        returns (DataTypes.Balances memory balances)
     {
         DataTypes.Series memory series;
         if (art != 0) series = getSeries(vault.seriesId);
@@ -325,7 +337,7 @@ contract Ladle is LadleStorage, AccessControl() {
         if (art > 0) fee = ((series.maturity - block.timestamp) * uint256(int256(art)).wmul(borrowingFee)).u128().i128();
 
         // Update accounting
-        balances = cauldron.pour(vaultId, ink, art + fee);
+        cauldron.pour(vaultId, ink, art + fee);
 
         // Manage collateral
         if (ink != 0) {
@@ -346,12 +358,12 @@ contract Ladle is LadleStorage, AccessControl() {
     /// Only before maturity.
     function _serve(bytes12 vaultId, DataTypes.Vault memory vault, address to, uint128 ink, uint128 base, uint128 max)
         private
-        returns (DataTypes.Balances memory balances, uint128 art)
+        returns (uint128 art)
     {
         IPool pool = getPool(vault.seriesId);
         
         art = pool.buyBasePreview(base);
-        balances = _pour(vaultId, vault, address(pool), ink.i128(), art.i128());
+        _pour(vaultId, vault, address(pool), ink.i128(), art.i128());
         pool.buyBase(to, base, max);
     }
 
@@ -362,16 +374,16 @@ contract Ladle is LadleStorage, AccessControl() {
     /// Debt cannot be acquired with this function.
     function _close(bytes12 vaultId, DataTypes.Vault memory vault, address to, int128 ink, int128 art)
         private
-        returns (DataTypes.Balances memory balances)
+        returns (uint128 base)
     {
         require (art < 0, "Only repay debt");                                          // When repaying debt in `frob`, art is a negative value. Here is the same for consistency.
 
         // Calculate debt in fyToken terms
         DataTypes.Series memory series = getSeries(vault.seriesId);
-        uint128 base = cauldron.debtToBase(vault.seriesId, uint128(-art));
+        base = cauldron.debtToBase(vault.seriesId, uint128(-art));
 
         // Update accounting
-        balances = cauldron.pour(vaultId, ink, art);
+        cauldron.pour(vaultId, ink, art);
 
         // Manage collateral
         if (ink != 0) {
@@ -390,13 +402,13 @@ contract Ladle is LadleStorage, AccessControl() {
     /// Only before maturity. After maturity use close.
     function _repay(bytes12 vaultId, DataTypes.Vault memory vault, address to, int128 ink, uint128 min)
         private
-        returns (DataTypes.Balances memory balances, uint128 art)
+        returns (uint128 art)
     {
         DataTypes.Series memory series = getSeries(vault.seriesId);
         IPool pool = getPool(vault.seriesId);
 
         art = pool.sellBase(address(series.fyToken), min);
-        balances = _pour(vaultId, vault, to, ink, -(art.i128()));
+        _pour(vaultId, vault, to, ink, -(art.i128()));
     }
 
     /// @dev Repay all debt in a vault by buying fyToken from a pool with base.
@@ -404,27 +416,26 @@ contract Ladle is LadleStorage, AccessControl() {
     /// Only before maturity. After maturity use close.
     function _repayVault(bytes12 vaultId, DataTypes.Vault memory vault, address to, int128 ink, uint128 max)
         private
-        returns (DataTypes.Balances memory balances, uint128 base)
+        returns (uint128 base)
     {
         DataTypes.Series memory series = getSeries(vault.seriesId);
         IPool pool = getPool(vault.seriesId);
 
-        balances = cauldron.balances(vaultId);
+        DataTypes.Balances memory balances = cauldron.balances(vaultId);
         base = pool.buyFYToken(address(series.fyToken), balances.art, max);
-        balances = _pour(vaultId, vault, to, ink, -(balances.art.i128()));
+        _pour(vaultId, vault, to, ink, -(balances.art.i128()));
         pool.retrieveBase(msg.sender);
     }
 
     /// @dev Change series and debt of a vault.
     function _roll(bytes12 vaultId, DataTypes.Vault memory vault, bytes6 newSeriesId, uint8 loan, uint128 max)
         private
-        returns (DataTypes.Vault memory, DataTypes.Balances memory)
+        returns (DataTypes.Vault memory vault_, uint128 newDebt)
     {
         DataTypes.Series memory series = getSeries(vault.seriesId);
         DataTypes.Series memory newSeries = getSeries(newSeriesId);
         DataTypes.Balances memory balances = cauldron.balances(vaultId);
         
-        uint128 newDebt;
         {
             IPool pool = getPool(newSeriesId);
             IFYToken fyToken = IFYToken(newSeries.fyToken);
@@ -446,7 +457,9 @@ contract Ladle is LadleStorage, AccessControl() {
 
         newDebt += ((newSeries.maturity - block.timestamp) * uint256(newDebt).wmul(borrowingFee)).u128();  // Add borrowing fee, also stops users form rolling to a mature series
 
-        return cauldron.roll(vaultId, newSeriesId, newDebt.i128() - balances.art.i128()); // Change the series and debt for the vault
+        (vault_,) = cauldron.roll(vaultId, newSeriesId, newDebt.i128() - balances.art.i128()); // Change the series and debt for the vault
+        
+        return (vault_, newDebt);
     }
 
     // ---- Ladle as a token holder ----
@@ -454,17 +467,17 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Use fyToken in the Ladle to repay debt.
     function _repayLadle(bytes12 vaultId, DataTypes.Vault memory vault)
         private
-        returns (DataTypes.Balances memory balances)
+        returns (uint256 repaid)
     {
         DataTypes.Series memory series = getSeries(vault.seriesId);
-        balances = cauldron.balances(vaultId);
+        DataTypes.Balances memory balances = cauldron.balances(vaultId);
         
         uint256 amount = series.fyToken.balanceOf(address(this));
-        amount = amount <= balances.art ? amount : balances.art;
+        repaid = amount <= balances.art ? amount : balances.art;
 
         // Update accounting
-        balances = cauldron.pour(vaultId, 0, -(amount.u128().i128()));
-        series.fyToken.burn(address(this), amount);
+        cauldron.pour(vaultId, 0, -(repaid.u128().i128()));
+        series.fyToken.burn(address(this), repaid);
     }
 
     /// @dev Retrieve any asset or fyToken in the Ladle
@@ -567,8 +580,9 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Allow users to route calls to a pool, to be used with batch
     function _route(IPool pool, bytes memory data)
         private
-        returns (bool success, bytes memory result)
+        returns (bytes memory result)
     {
+        bool success;
         (success, result) = address(pool).call(data);
         if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
     }
@@ -598,9 +612,10 @@ contract Ladle is LadleStorage, AccessControl() {
     /// it would be disastrous in combination with batch vault caching 
     function _moduleCall(address module, bytes memory moduleCall)
         private
-        returns (bool success, bytes memory result)
+        returns (bytes memory result)
     {
         require (modules[module], "Unregistered module");
+        bool success;
         (success, result) = module.delegatecall(moduleCall);
         if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
     }

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -368,7 +368,7 @@ contract Ladle is LadleStorage, AccessControl() {
 
         // Calculate debt in fyToken terms
         DataTypes.Series memory series = getSeries(vault.seriesId);
-        uint128 amt = _debtInBase(vault.seriesId, series, uint128(-art));
+        uint128 base = cauldron.debtToBase(vault.seriesId, uint128(-art));
 
         // Update accounting
         balances = cauldron.pour(vaultId, ink, art);
@@ -382,19 +382,7 @@ contract Ladle is LadleStorage, AccessControl() {
 
         // Manage underlying
         IJoin baseJoin = getJoin(series.baseId);
-        baseJoin.join(msg.sender, amt);
-    }
-
-    /// @dev Calculate a debt amount for a series in base terms
-    function _debtInBase(bytes6 seriesId, DataTypes.Series memory series, uint128 art)
-        private
-        returns (uint128 amt)
-    {
-        if (uint32(block.timestamp) >= series.maturity) {
-            amt = uint256(art).wmul(cauldron.accrual(seriesId)).u128();
-        } else {
-            amt = art;
-        }
+        baseJoin.join(msg.sender, base);
     }
 
     /// @dev Repay debt by selling base in a pool and using the resulting fyToken
@@ -443,17 +431,17 @@ contract Ladle is LadleStorage, AccessControl() {
             IJoin baseJoin = getJoin(series.baseId);
 
             // Calculate debt in fyToken terms
-            uint128 amt = _debtInBase(vault.seriesId, series, balances.art);
+            uint128 base = cauldron.debtToBase(vault.seriesId, balances.art);
 
             // Mint fyToken to the pool, as a kind of flash loan
-            fyToken.mint(address(pool), amt * loan);                // Loan is the size of the flash loan relative to the debt amount, 2 should be safe most of the time
+            fyToken.mint(address(pool), base * loan);                // Loan is the size of the flash loan relative to the debt amount, 2 should be safe most of the time
 
             // Buy the base required to pay off the debt in series 1, and find out the debt in series 2
-            newDebt = pool.buyBase(address(baseJoin), amt, max);
-            baseJoin.join(address(baseJoin), amt);                  // Repay the old series debt
+            newDebt = pool.buyBase(address(baseJoin), base, max);
+            baseJoin.join(address(baseJoin), base);                  // Repay the old series debt
 
             pool.retrieveFYToken(address(fyToken));                 // Get the surplus fyToken
-            fyToken.burn(address(fyToken), (amt * loan) - newDebt);    // Burn the surplus
+            fyToken.burn(address(fyToken), (base * loan) - newDebt);    // Burn the surplus
         }
 
         newDebt += ((newSeries.maturity - block.timestamp) * uint256(newDebt).wmul(borrowingFee)).u128();  // Add borrowing fee, also stops users form rolling to a mature series
@@ -498,8 +486,6 @@ contract Ladle is LadleStorage, AccessControl() {
     {
         DataTypes.Vault memory vault = getOwnedVault(vaultId);
         DataTypes.Series memory series = getSeries(vault.seriesId);
-
-        cauldron.slurp(vaultId, ink, art);                                                  // Remove debt and collateral from the vault
 
         if (ink != 0) {                                                                     // Give collateral to the user
             IJoin ilkJoin = getJoin(vault.ilkId);
@@ -571,10 +557,10 @@ contract Ladle is LadleStorage, AccessControl() {
     // ---- Pool router ----
 
     /// @dev Allow users to trigger a token transfer to a pool through the ladle, to be used with batch
-    function _transferToPool(IPool pool, bool base, uint128 wad)
+    function _transferToPool(IPool pool, bool isBase, uint128 wad)
         private
     {
-        IERC20 token = base ? pool.base() : pool.fyToken();
+        IERC20 token = isBase ? pool.base() : pool.fyToken();
         token.safeTransferFrom(msg.sender, address(pool), wad);
     }
 

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -236,7 +236,7 @@ contract Ladle is LadleStorage, AccessControl() {
             } else if (operation == Operation.GIVE) {
                 (bytes12 vaultId, address to) = abi.decode(data[i], (bytes12, address));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
-                vault = _give(vaultId, to);
+                _give(vaultId, to);
                 delete vault;   // Clear the cache, since the vault doesn't necessarily belong to msg.sender anymore
                 cachedId = bytes12(0);
 

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -540,7 +540,9 @@ contract Ladle is LadleStorage, AccessControl() {
     // ---- Ether management ----
 
     /// @dev The WETH9 contract will send ether to BorrowProxy on `weth.withdraw` using this function.
-    receive() external payable { }
+    receive() external payable { 
+        require (msg.sender == address(weth), "Only receive from WETH");
+    }
 
     /// @dev Accept Ether, wrap it and forward it to the WethJoin
     /// This function should be called first in a batch, and the Join should keep track of stored reserves
@@ -616,4 +618,5 @@ contract Ladle is LadleStorage, AccessControl() {
         (success, result) = module.delegatecall(moduleCall);
         if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
     }
+
 }

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -114,6 +114,16 @@ contract Ladle is LadleStorage, AccessControl() {
 
     // ---- Batching ----
 
+    /// @dev Return the cached vault if necessary, preceded by the current vaultId (needed if vaultId == bytes(0)) and cachedId (which is the same as the vaultId)
+    /// If refreshing the cache, verifies that msg.sender is the owner of the vault
+    function getCachedVault(bytes12 vaultId, bytes12 cachedId, DataTypes.Vault memory vault)
+        private view
+        returns (bytes12, bytes12, DataTypes.Vault memory)
+    {
+        require(vaultId != bytes12(0) || cachedId != bytes12(0), "Vault not cached");           // Can't use the cache
+        if (vaultId == bytes12(0) || vaultId == cachedId) return (cachedId, cachedId, vault);   // Use the cache
+        else return (vaultId, vaultId, getOwnedVault(vaultId));                                 // Refresh the cache
+    } 
 
     /// @dev Submit a series of calls for execution.
     /// Unlike `batch`, this function calls private functions, saving a CALL per function.
@@ -132,8 +142,8 @@ contract Ladle is LadleStorage, AccessControl() {
             Operation operation = operations[i];
 
             if (operation == Operation.BUILD) {
-                (bytes12 vaultId, bytes6 seriesId, bytes6 ilkId) = abi.decode(data[i], (bytes12, bytes6, bytes6));
-                (cachedId, vault) = (vaultId, _build(vaultId, seriesId, ilkId));   // Cache the vault that was just built
+                (bytes6 seriesId, bytes6 ilkId) = abi.decode(data[i], (bytes6, bytes6));
+                (cachedId, vault) = _build(seriesId, ilkId, 0);   // Cache the vault that was just built
             
             } else if (operation == Operation.FORWARD_PERMIT) {
                 (bytes6 id, bool isAsset, address spender, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) =
@@ -146,17 +156,17 @@ contract Ladle is LadleStorage, AccessControl() {
             
             } else if (operation == Operation.POUR) {
                 (bytes12 vaultId, address to, int128 ink, int128 art) = abi.decode(data[i], (bytes12, address, int128, int128));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _pour(vaultId, vault, to, ink, art);
             
             } else if (operation == Operation.SERVE) {
                 (bytes12 vaultId, address to, uint128 ink, uint128 base, uint128 max) = abi.decode(data[i], (bytes12, address, uint128, uint128, uint128));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _serve(vaultId, vault, to, ink, base, max);
 
             } else if (operation == Operation.ROLL) {
                 (bytes12 vaultId, bytes6 newSeriesId, uint8 loan, uint128 max) = abi.decode(data[i], (bytes12, bytes6, uint8, uint128));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 (vault,) = _roll(vaultId, vault, newSeriesId, loan, max);
             
             } else if (operation == Operation.FORWARD_DAI_PERMIT) {
@@ -182,22 +192,22 @@ contract Ladle is LadleStorage, AccessControl() {
             
             } else if (operation == Operation.CLOSE) {
                 (bytes12 vaultId, address to, int128 ink, int128 art) = abi.decode(data[i], (bytes12, address, int128, int128));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _close(vaultId, vault, to, ink, art);
             
             } else if (operation == Operation.REPAY) {
                 (bytes12 vaultId, address to, int128 ink, uint128 min) = abi.decode(data[i], (bytes12, address, int128, uint128));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _repay(vaultId, vault, to, ink, min);
             
             } else if (operation == Operation.REPAY_VAULT) {
                 (bytes12 vaultId, address to, int128 ink, uint128 max) = abi.decode(data[i], (bytes12, address, int128, uint128));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _repayVault(vaultId, vault, to, ink, max);
 
             } else if (operation == Operation.REPAY_LADLE) {
                 (bytes12 vaultId) = abi.decode(data[i], (bytes12));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _repayLadle(vaultId, vault);
 
             } else if (operation == Operation.RETRIEVE) {
@@ -220,19 +230,19 @@ contract Ladle is LadleStorage, AccessControl() {
             
             } else if (operation == Operation.TWEAK) {
                 (bytes12 vaultId, bytes6 seriesId, bytes6 ilkId) = abi.decode(data[i], (bytes12, bytes6, bytes6));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
                 vault = _tweak(vaultId, seriesId, ilkId);
 
             } else if (operation == Operation.GIVE) {
                 (bytes12 vaultId, address to) = abi.decode(data[i], (bytes12, address));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
                 vault = _give(vaultId, to);
                 delete vault;   // Clear the cache, since the vault doesn't necessarily belong to msg.sender anymore
                 cachedId = bytes12(0);
 
             } else if (operation == Operation.DESTROY) {
                 (bytes12 vaultId) = abi.decode(data[i], (bytes12));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
                 _destroy(vaultId);
                 delete vault;   // Clear the cache
                 cachedId = bytes12(0);
@@ -247,12 +257,22 @@ contract Ladle is LadleStorage, AccessControl() {
 
     // ---- Vault management ----
 
+    /// @dev Generate a vaultId. A keccak256 is cheaper than using a counter with a SSTORE, even accounting for eventual collision retries.
+    function _generateVaultId(uint8 salt) private view returns (bytes12) {
+        return bytes12(keccak256(abi.encodePacked(msg.sender, block.timestamp, salt)));
+    }
+
     /// @dev Create a new vault, linked to a series (and therefore underlying) and a collateral
-    function _build(bytes12 vaultId, bytes6 seriesId, bytes6 ilkId)
+    function _build(bytes6 seriesId, bytes6 ilkId, uint8 salt)
         private
-        returns(DataTypes.Vault memory vault)
+        returns(bytes12, DataTypes.Vault memory)
     {
-        return cauldron.build(msg.sender, vaultId, seriesId, ilkId);
+        bytes12 vaultId = _generateVaultId(salt);
+        try cauldron.build(msg.sender, vaultId, seriesId, ilkId) returns (DataTypes.Vault memory vault) {
+            return (vaultId, vault);
+        } catch Error (string memory) {
+            return _build(seriesId, ilkId, salt + 1);
+        }
     }
 
     /// @dev Change a vault series or collateral.
@@ -586,6 +606,8 @@ contract Ladle is LadleStorage, AccessControl() {
     // ---- Module router ----
 
     /// @dev Allow users to use functionality coded in a module, to be used with batch
+    /// @notice Modules must not do any changes to the vault (owner, seriesId, ilkId),
+    /// it would be disastrous in combination with batch vault caching 
     function _moduleCall(address module, bytes memory moduleCall)
         private
         returns (bool success, bytes memory result)

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -105,7 +105,7 @@ contract Ladle is LadleStorage, AccessControl() {
 
     /// @dev Set the fee parameter
     function setFee(uint256 fee)
-        public
+        external
         auth    
     {
         borrowingFee = fee;

--- a/contracts/LadleStorage.sol
+++ b/contracts/LadleStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/vault-interfaces/ICauldron.sol";
 import "@yield-protocol/vault-interfaces/IJoin.sol";
 import "@yield-protocol/yieldspace-interfaces/IPool.sol";

--- a/contracts/Wand.sol
+++ b/contracts/Wand.sol
@@ -8,6 +8,8 @@ import "@yield-protocol/vault-interfaces/IJoin.sol";
 import "@yield-protocol/vault-interfaces/DataTypes.sol";
 import "@yield-protocol/yieldspace-interfaces/IPoolFactory.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
+import "./constants/Constants.sol";
+import "./math/CastBytes32Bytes6.sol";
 import "./FYToken.sol";
 
 
@@ -16,15 +18,13 @@ interface IOwnable {
 }
 
 /// @dev Ladle orchestrates contract calls throughout the Yield Protocol v2 into useful and efficient governance features.
-contract Wand is AccessControl {
+contract Wand is AccessControl, Constants {
+    using CastBytes32Bytes6 for bytes32;
 
     bytes4 public constant JOIN = bytes4(keccak256("join(address,uint128)"));
     bytes4 public constant EXIT = bytes4(keccak256("exit(address,uint128)"));
     bytes4 public constant MINT = bytes4(keccak256("mint(address,uint256)"));
     bytes4 public constant BURN = bytes4(keccak256("burn(address,uint256)"));
-    
-    bytes6 public constant CHI = "chi";
-    bytes6 public constant RATE = "rate";
 
     ICauldronGov public immutable cauldron;
     ILadleGov public immutable ladle;
@@ -67,8 +67,8 @@ contract Wand is AccessControl {
         require (rateSource != address(0), "Rate source required");
         require (chiSource != address(0), "Chi source required");
 
-        oracle.setSource(assetId, RATE, rateSource);
-        oracle.setSource(assetId, CHI, chiSource);
+        oracle.setSource(assetId, RATE.b6(), rateSource);
+        oracle.setSource(assetId, CHI.b6(), chiSource);
         cauldron.setRateOracle(assetId, IOracle(address(oracle))); // TODO: Consider adding a registry of chi oracles in cauldron as well
     }
 

--- a/contracts/Wand.sol
+++ b/contracts/Wand.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/vault-interfaces/ICauldronGov.sol";
 import "@yield-protocol/vault-interfaces/ILadleGov.sol";
 import "@yield-protocol/vault-interfaces/IMultiOracleGov.sol";

--- a/contracts/Wand.sol
+++ b/contracts/Wand.sol
@@ -69,7 +69,7 @@ contract Wand is AccessControl, Constants {
 
         oracle.setSource(assetId, RATE.b6(), rateSource);
         oracle.setSource(assetId, CHI.b6(), chiSource);
-        cauldron.setRateOracle(assetId, IOracle(address(oracle))); // TODO: Consider adding a registry of chi oracles in cauldron as well
+        cauldron.setRateOracle(assetId, IOracle(address(oracle)));
     }
 
     /// @dev Make an ilk asset out of a generic asset, by adding a spot oracle against a base asset, collateralization ratio, and debt ceiling.
@@ -105,7 +105,7 @@ contract Wand is AccessControl, Constants {
             maturity,
             name,     // Derive from base and maturity, perhaps
             symbol    // Derive from base and maturity, perhaps
-        ); // TODO: Use a FYTokenFactory to make Wand deployable at 20000 runs
+        );
 
         // Allow the fyToken to pull from the base join for redemption
         bytes4[] memory sigs = new bytes4[](1);

--- a/contracts/Wand.sol
+++ b/contracts/Wand.sol
@@ -46,7 +46,7 @@ contract Wand is AccessControl {
     function addAsset(
         bytes6 assetId,
         address asset
-    ) public auth {
+    ) external auth {
         // Add asset to cauldron, deploy new Join, and add it to the ladle
         require (address(asset) != address(0), "Asset required");
         cauldron.addAsset(assetId, asset);
@@ -62,7 +62,7 @@ contract Wand is AccessControl {
 
     /// @dev Make a base asset out of a generic asset, by adding rate and chi oracles.
     /// This assumes CompoundMultiOracles, which deliver both rate and chi.
-    function makeBase(bytes6 assetId, IMultiOracleGov oracle, address rateSource, address chiSource) public auth {
+    function makeBase(bytes6 assetId, IMultiOracleGov oracle, address rateSource, address chiSource) external auth {
         require (address(oracle) != address(0), "Oracle required");
         require (rateSource != address(0), "Rate source required");
         require (chiSource != address(0), "Chi source required");
@@ -73,7 +73,7 @@ contract Wand is AccessControl {
     }
 
     /// @dev Make an ilk asset out of a generic asset, by adding a spot oracle against a base asset, collateralization ratio, and debt ceiling.
-    function makeIlk(bytes6 baseId, bytes6 ilkId, IMultiOracleGov oracle, address spotSource, uint32 ratio, uint96 max, uint24 min, uint8 dec) public auth {
+    function makeIlk(bytes6 baseId, bytes6 ilkId, IMultiOracleGov oracle, address spotSource, uint32 ratio, uint96 max, uint24 min, uint8 dec) external auth {
         oracle.setSource(baseId, ilkId, spotSource);
         cauldron.setSpotOracle(baseId, ilkId, IOracle(address(oracle)), ratio);
         cauldron.setDebtLimits(baseId, ilkId, max, min, dec);
@@ -88,7 +88,7 @@ contract Wand is AccessControl {
         bytes6[] memory ilkIds,
         string memory name,
         string memory symbol
-    ) public auth {
+    ) external auth {
         address base = cauldron.assets(baseId);
         require(base != address(0), "Base not found");
 

--- a/contracts/Witch.sol
+++ b/contracts/Witch.sol
@@ -47,14 +47,18 @@ contract Witch is AccessControl() {
     }
 
     /// @dev Put an undercollateralized vault up for liquidation.
-    function grab(bytes12 vaultId) public {
+    function grab(bytes12 vaultId)
+        external
+    {
         DataTypes.Vault memory vault = cauldron.vaults(vaultId);
         vaultOwners[vaultId] = vault.owner;
         cauldron.grab(vaultId, address(this));
     }
 
     /// @dev Buy an amount of collateral off a vault in liquidation, paying at most `max` underlying.
-    function buy(bytes12 vaultId, uint128 art, uint128 min) public {
+    function buy(bytes12 vaultId, uint128 art, uint128 min)
+        external
+    {
         DataTypes.Balances memory balances_ = cauldron.balances(vaultId);
 
         require (balances_.art > 0, "Nothing to buy");                                      // Cheapest way of failing gracefully if given a non existing vault

--- a/contracts/Witch.sol
+++ b/contracts/Witch.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/vault-interfaces/ILadle.sol";

--- a/contracts/Witch.sol
+++ b/contracts/Witch.sol
@@ -9,6 +9,7 @@ import "./math/WMul.sol";
 import "./math/WDiv.sol";
 import "./math/WDivUp.sol";
 import "./math/CastU256U128.sol";
+import "./math/CastU256U32.sol";
 
 
 contract Witch is AccessControl() {
@@ -16,76 +17,134 @@ contract Witch is AccessControl() {
     using WDiv for uint256;
     using WDivUp for uint256;
     using CastU256U128 for uint256;
+    using CastU256U32 for uint256;
 
-    event AuctionTimeSet(uint128 indexed auctionTime);
-    event InitialProportionSet(uint128 indexed initialProportion);
+    event DurationSet(uint32 indexed duration);
+    event InitialOfferSet(uint64 indexed initialOffer);
+    event DustSet(uint128 indexed dust);
     event Bought(bytes12 indexed vaultId, address indexed buyer, uint256 ink, uint256 art);
+    event Auctioned(bytes12 indexed vaultId, uint256 indexed start);
   
-    uint128 public auctionTime = 4 * 60 * 60; // Time that auctions take to go to minimal price and stay there.
-    uint128 public initialProportion = 5e17;  // Proportion of collateral that is sold at auction start.
+    struct Auction {
+        address owner;
+        uint32 start;
+    }
+
+    uint32 public duration = 4 * 60 * 60; // Time that auctions take to go to minimal price and stay there.
+    uint64 public initialOffer = 5e17;  // Proportion of collateral that is sold at auction start (1e18 = 100%)
+    uint128 public dust;                     // Minimum collateral that must be left when buying, unless buying all
 
     ICauldron immutable public cauldron;
     ILadle immutable public ladle;
-    mapping(bytes12 => address) public vaultOwners;
+    mapping(bytes12 => Auction) public auctions;
 
     constructor (ICauldron cauldron_, ILadle ladle_) {
         cauldron = cauldron_;
         ladle = ladle_;
     }
 
-    /// @dev Set the auction time to calculate liquidation prices
-    function setAuctionTime(uint128 auctionTime_) external auth {
-        auctionTime = auctionTime_;
-        emit AuctionTimeSet(auctionTime_);
+    /// @dev Set the auction duration to calculate liquidation prices
+    function setDuration(uint32 duration_) external auth {
+        duration = duration_;
+        emit DurationSet(duration_);
     }
 
     /// @dev Set the proportion of the collateral that will be sold at auction start
-    function setInitialProportion(uint128 initialProportion_) external auth {
-        require (initialProportion_ <= 1e18, "Only at or under 100%");
-        initialProportion = initialProportion_;
-        emit InitialProportionSet(initialProportion_);
+    function setInitialOffer(uint64 initialOffer_) external auth {
+        require (initialOffer_ <= 1e18, "Only at or under 100%");
+        initialOffer = initialOffer_;
+        emit InitialOfferSet(initialOffer_);
+    }
+
+    /// @dev Set the minimum collateral that must be left when buying, unless buying all
+    function setDust(uint128 dust_) external auth {
+        dust = dust_;
+        emit DustSet(dust_);
     }
 
     /// @dev Put an undercollateralized vault up for liquidation.
-    function grab(bytes12 vaultId)
+    function auction(bytes12 vaultId)
         external
     {
+        require (auctions[vaultId].start == 0, "Vault already under auction");
         DataTypes.Vault memory vault = cauldron.vaults(vaultId);
-        vaultOwners[vaultId] = vault.owner;
+        auctions[vaultId] = Auction({
+            owner: vault.owner,
+            start: block.timestamp.u32()
+        });
         cauldron.grab(vaultId, address(this));
+        emit Auctioned(vaultId, block.timestamp.u32());
     }
 
-    /// @dev Buy an amount of collateral off a vault in liquidation, paying at most `max` underlying.
-    function buy(bytes12 vaultId, uint128 art, uint128 min)
+    /// @dev Pay `base` of the debt in a vault in liquidation, getting at least `min` collateral.
+    function buy(bytes12 vaultId, uint128 base, uint128 min)
         external
+        returns (uint256 ink)
     {
         DataTypes.Balances memory balances_ = cauldron.balances(vaultId);
+        DataTypes.Vault memory vault_ = cauldron.vaults(vaultId);
+        Auction memory auction_ = auctions[vaultId];
+        (uint256 duration_, uint256 initialOffer_, uint256 dust_) = (duration, initialOffer, dust);
 
         require (balances_.art > 0, "Nothing to buy");                                      // Cheapest way of failing gracefully if given a non existing vault
-        uint256 elapsed = uint32(block.timestamp) - cauldron.auctions(vaultId);           // Auctions will malfunction on the 7th of February 2106, at 06:28:16 GMT, we should replace this contract before then.
-        uint256 price;
+        uint256 art = cauldron.debtFromBase(vault_.seriesId, base);
         {
-            // Price of a collateral unit, in underlying, at the present moment, for a given vault
-            //
-            //                ink                     min(auction, elapsed)
-            // price = 1 / (------- * (p + (1 - p) * -----------------------))
-            //                art                          auction
-            (uint256 auctionTime_, uint256 initialProportion_) = (auctionTime, initialProportion);
-            uint256 term1 = uint256(balances_.ink).wdiv(balances_.art);
-            uint256 dividend2 = auctionTime_ < elapsed ? auctionTime_ : elapsed;
-            uint256 divisor2 = auctionTime_;
-            uint256 term2 = initialProportion_ + (1e18 - initialProportion_).wmul(dividend2.wdiv(divisor2));
-            price = uint256(1e18).wdiv(term1.wmul(term2));
+            uint256 elapsed = uint32(block.timestamp) - auction_.start;                      // Auctions will malfunction on the 7th of February 2106, at 06:28:16 GMT, we should replace this contract before then.
+            uint256 price = inkPrice(balances_, initialOffer_, duration_, elapsed);
+            ink = uint256(art).wmul(price);                                                    // Calculate collateral to sell. Using divdrup stops rounding from leaving 1 stray wei in vaults.
+            require (ink >= min, "Not enough bought");
+            require (ink == balances_.ink || balances_.ink - ink >= dust_, "Leaves dust");
         }
-        uint256 ink = uint256(art).wdivup(price);                                                    // Calculate collateral to sell. Using divdrup stops rounding from leaving 1 stray wei in vaults.
-        require (ink >= min, "Not enough bought");
 
-        ladle.settle(vaultId, msg.sender, ink.u128(), art);                                        // Move the assets
+        cauldron.slurp(vaultId, ink.u128(), art.u128());                                            // Remove debt and collateral from the vault
+        ladle.settle(vaultId, msg.sender, ink.u128(), base);                                        // Move the assets
         if (balances_.art - art == 0) {                                                             // If there is no debt left, return the vault with the collateral to the owner
-            cauldron.give(vaultId, vaultOwners[vaultId]);
-            delete vaultOwners[vaultId];
+            cauldron.give(vaultId, auction_.owner);
+            delete auctions[vaultId];
         }
 
         emit Bought(vaultId, msg.sender, ink, art);
+    }
+
+
+    /// @dev Pay all debt from a vault in liquidation, getting at least `min` collateral.
+    function payAll(bytes12 vaultId, uint128 min)
+        external
+        returns (uint256 ink)
+    {
+        DataTypes.Balances memory balances_ = cauldron.balances(vaultId);
+        DataTypes.Vault memory vault_ = cauldron.vaults(vaultId);
+        Auction memory auction_ = auctions[vaultId];
+        (uint256 duration_, uint256 initialOffer_, uint256 dust_) = (duration, initialOffer, dust);
+
+        require (balances_.art > 0, "Nothing to buy");                                      // Cheapest way of failing gracefully if given a non existing vault
+        {
+            uint256 elapsed = uint32(block.timestamp) - auction_.start;                      // Auctions will malfunction on the 7th of February 2106, at 06:28:16 GMT, we should replace this contract before then.
+            uint256 price = inkPrice(balances_, initialOffer_, duration_, elapsed);
+            ink = uint256(balances_.art).wmul(price);                                                    // Calculate collateral to sell. Using divdrup stops rounding from leaving 1 stray wei in vaults.
+            require (ink >= min, "Not enough bought");
+            require (ink == balances_.ink || balances_.ink - ink >= dust_, "Leaves dust");
+        }
+
+        cauldron.slurp(vaultId, ink.u128(), balances_.art);                                                     // Remove debt and collateral from the vault
+        ladle.settle(vaultId, msg.sender, ink.u128(), cauldron.debtToBase(vault_.seriesId, balances_.art));                                        // Move the assets
+        cauldron.give(vaultId, auction_.owner);
+
+        emit Bought(vaultId, msg.sender, ink, balances_.art); // Still the initailly read `art` value, not the updated one
+    }
+
+    /// @dev Price of a collateral unit, in underlying, at the present moment, for a given vault
+    ///            ink                     min(auction, elapsed)
+    /// price = (------- * (p + (1 - p) * -----------------------))
+    ///            art                          auction
+    function inkPrice(DataTypes.Balances memory balances, uint256 initialOffer_, uint256 duration_, uint256 elapsed)
+        private pure
+        returns (uint256 price)
+    {
+            uint256 term1 = uint256(balances.ink).wdiv(balances.art);
+            uint256 dividend2 = duration_ < elapsed ? duration_ : elapsed;
+            uint256 divisor2 = duration_;
+            uint256 term2 = initialOffer_ + (1e18 - initialOffer_).wmul(dividend2.wdiv(divisor2));
+            price = term1.wmul(term2);
     }
 }

--- a/contracts/Witch.sol
+++ b/contracts/Witch.sol
@@ -34,13 +34,13 @@ contract Witch is AccessControl() {
     }
 
     /// @dev Set the auction time to calculate liquidation prices
-    function setAuctionTime(uint128 auctionTime_) public auth {
+    function setAuctionTime(uint128 auctionTime_) external auth {
         auctionTime = auctionTime_;
         emit AuctionTimeSet(auctionTime_);
     }
 
     /// @dev Set the proportion of the collateral that will be sold at auction start
-    function setInitialProportion(uint128 initialProportion_) public auth {
+    function setInitialProportion(uint128 initialProportion_) external auth {
         require (initialProportion_ <= 1e18, "Only at or under 100%");
         initialProportion = initialProportion_;
         emit InitialProportionSet(initialProportion_);

--- a/contracts/constants/Constants.sol
+++ b/contracts/constants/Constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 contract Constants {
     bytes32 CHI = "chi";

--- a/contracts/constants/Constants.sol
+++ b/contracts/constants/Constants.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+contract Constants {
+    bytes32 CHI = "chi";
+    bytes32 RATE = "rate";
+}

--- a/contracts/math/CastBytes32Bytes6.sol
+++ b/contracts/math/CastBytes32Bytes6.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 
 library CastBytes32Bytes6 {

--- a/contracts/math/CastI128U128.sol
+++ b/contracts/math/CastI128U128.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 
 library CastI128U128 {

--- a/contracts/math/CastU128I128.sol
+++ b/contracts/math/CastU128I128.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 
 library CastU128I128 {

--- a/contracts/math/CastU256I256.sol
+++ b/contracts/math/CastU256I256.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 
 library CastU256I256 {

--- a/contracts/math/CastU256U128.sol
+++ b/contracts/math/CastU256U128.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 
 library CastU256U128 {

--- a/contracts/math/CastU256U32.sol
+++ b/contracts/math/CastU256U32.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 
 library CastU256U32 {

--- a/contracts/math/WDiv.sol
+++ b/contracts/math/WDiv.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 
 library WDiv { // Fixed point arithmetic in 18 decimal units

--- a/contracts/math/WDivUp.sol
+++ b/contracts/math/WDivUp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 
 library WDivUp { // Fixed point arithmetic in 18 decimal units

--- a/contracts/math/WMul.sol
+++ b/contracts/math/WMul.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 
 library WMul {

--- a/contracts/math/WMulUp.sol
+++ b/contracts/math/WMulUp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 
 library WMulUp { // Fixed point arithmetic in 18 decimal units

--- a/contracts/mocks/DAIMock.sol
+++ b/contracts/mocks/DAIMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
 
 

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/utils-v2/contracts/token/ERC20Permit.sol";
 
 

--- a/contracts/mocks/FlashBorrower.sol
+++ b/contracts/mocks/FlashBorrower.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "erc3156/contracts/interfaces/IERC3156FlashBorrower.sol";

--- a/contracts/mocks/PoolFactoryMock.sol
+++ b/contracts/mocks/PoolFactoryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >= 0.8.0;
+pragma solidity 0.8.1;
 
 import "@yield-protocol/yieldspace-interfaces/IPoolFactory.sol";
 import "./PoolMock.sol";

--- a/contracts/mocks/PoolMock.sol
+++ b/contracts/mocks/PoolMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/utils-v2/contracts/access/Ownable.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";

--- a/contracts/mocks/PoolRouterMock.sol
+++ b/contracts/mocks/PoolRouterMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity >= 0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/utils-v2/contracts/utils/RevertMsgExtractor.sol";
 
 

--- a/contracts/mocks/RestrictedERC20Mock.sol
+++ b/contracts/mocks/RestrictedERC20Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/utils-v2/contracts/token/ERC20Permit.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 

--- a/contracts/mocks/RestrictedERC20Mock.sol
+++ b/contracts/mocks/RestrictedERC20Mock.sol
@@ -11,12 +11,12 @@ contract RestrictedERC20Mock is AccessControl(), ERC20Permit  {
     ) ERC20Permit(name, symbol, 18) { }
 
     /// @dev Give tokens to whoever.
-    function mint(address to, uint256 amount) public virtual auth {
+    function mint(address to, uint256 amount) external virtual auth {
         _mint(to, amount);
     }
 
     /// @dev Burn tokens from whoever.
-    function burn(address from, uint256 amount) public virtual auth {
+    function burn(address from, uint256 amount) external virtual auth {
         _burn(from, amount);
     }
 }

--- a/contracts/mocks/TLMMock.sol
+++ b/contracts/mocks/TLMMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >=0.8.0;
+pragma solidity 0.8.1;
 
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "./ERC20Mock.sol";

--- a/contracts/mocks/USDCMock.sol
+++ b/contracts/mocks/USDCMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity >= 0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/utils-v2/contracts/token/ERC20Permit.sol";
 
 

--- a/contracts/mocks/WETH9Mock.sol
+++ b/contracts/mocks/WETH9Mock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 
 contract WETH9Mock is ERC20 {

--- a/contracts/mocks/oracles/ISourceMock.sol
+++ b/contracts/mocks/oracles/ISourceMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 interface ISourceMock {
     function set(uint) external;

--- a/contracts/mocks/oracles/OracleMock.sol
+++ b/contracts/mocks/oracles/OracleMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/vault-interfaces/IOracle.sol";
 
 

--- a/contracts/mocks/oracles/chainlink/ChainlinkAggregatorV3Mock.sol
+++ b/contracts/mocks/oracles/chainlink/ChainlinkAggregatorV3Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "../ISourceMock.sol";
 
 

--- a/contracts/mocks/oracles/compound/CTokenChiMock.sol
+++ b/contracts/mocks/oracles/compound/CTokenChiMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "../ISourceMock.sol";
 
 

--- a/contracts/mocks/oracles/compound/CTokenRateMock.sol
+++ b/contracts/mocks/oracles/compound/CTokenRateMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "../ISourceMock.sol";
 
 

--- a/contracts/mocks/oracles/uniswap/UniswapV2PairMock.sol
+++ b/contracts/mocks/oracles/uniswap/UniswapV2PairMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 contract UniswapV2PairMock {
     uint112 public reserves0;

--- a/contracts/mocks/oracles/uniswap/UniswapV3FactoryMock.sol
+++ b/contracts/mocks/oracles/uniswap/UniswapV3FactoryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "./UniswapV3PoolMock.sol";
 

--- a/contracts/mocks/oracles/uniswap/UniswapV3OracleLibraryMock.sol
+++ b/contracts/mocks/oracles/uniswap/UniswapV3OracleLibraryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "../../../math/WMul.sol";
 import "../../../math/WDiv.sol";

--- a/contracts/mocks/oracles/uniswap/UniswapV3PoolMock.sol
+++ b/contracts/mocks/oracles/uniswap/UniswapV3PoolMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "../ISourceMock.sol";
 import "../../../oracles/uniswap/IUniswapV3PoolImmutables.sol";

--- a/contracts/modules/MakerImportModule.sol
+++ b/contracts/modules/MakerImportModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/vault-interfaces/ICauldron.sol";
 import "@yield-protocol/vault-interfaces/IFYToken.sol";
 import "@yield-protocol/vault-interfaces/DataTypes.sol";

--- a/contracts/modules/TLMModule.sol
+++ b/contracts/modules/TLMModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 import "@yield-protocol/vault-interfaces/ICauldron.sol";
 import "@yield-protocol/vault-interfaces/IFYToken.sol";
 import "@yield-protocol/vault-interfaces/DataTypes.sol";

--- a/contracts/oracles/chainlink/ChainlinkMultiOracle.sol
+++ b/contracts/oracles/chainlink/ChainlinkMultiOracle.sol
@@ -62,7 +62,7 @@ contract ChainlinkMultiOracle is IOracle, AccessControl {
      * @return value
      */
     function get(bytes32 base, bytes32 quote, uint256 amount)
-        external view virtual override
+        external virtual override
         returns (uint256 value, uint256 updateTime)
     {
         uint256 price;

--- a/contracts/oracles/chainlink/ChainlinkMultiOracle.sol
+++ b/contracts/oracles/chainlink/ChainlinkMultiOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/vault-interfaces/IOracle.sol";

--- a/contracts/oracles/chainlink/ChainlinkMultiOracle.sol
+++ b/contracts/oracles/chainlink/ChainlinkMultiOracle.sol
@@ -48,7 +48,10 @@ contract ChainlinkMultiOracle is IOracle, AccessControl {
      * @notice Retrieve the value of the amount at the latest oracle price.
      * @return value
      */
-    function peek(bytes32 base, bytes32 quote, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
+    function peek(bytes32 base, bytes32 quote, uint256 amount)
+        external view virtual override
+        returns (uint256 value, uint256 updateTime)
+    {
         uint256 price;
         (price, updateTime) = _peek(base.b6(), quote.b6());
         value = price * amount / 1e18;
@@ -58,7 +61,10 @@ contract ChainlinkMultiOracle is IOracle, AccessControl {
      * @notice Retrieve the value of the amount at the latest oracle price.. Same as `peek` for this oracle.
      * @return value
      */
-    function get(bytes32 base, bytes32 quote, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
+    function get(bytes32 base, bytes32 quote, uint256 amount)
+        external view virtual override
+        returns (uint256 value, uint256 updateTime)
+    {
         uint256 price;
         (price, updateTime) = _peek(base.b6(), quote.b6());
         value = price * amount / 1e18;

--- a/contracts/oracles/chainlink/ChainlinkOracle.sol
+++ b/contracts/oracles/chainlink/ChainlinkOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "@yield-protocol/vault-interfaces/IOracle.sol";
 import "./AggregatorV3Interface.sol";

--- a/contracts/oracles/chainlink/ChainlinkOracle.sol
+++ b/contracts/oracles/chainlink/ChainlinkOracle.sol
@@ -53,7 +53,7 @@ contract ChainlinkOracle is IOracle {
      * @return value
      */
     function get(bytes32, bytes32, uint256 amount)
-        external view virtual override
+        external virtual override
         returns (uint256 value, uint256 updateTime)
     {
         uint256 price;

--- a/contracts/oracles/chainlink/ChainlinkOracle.sol
+++ b/contracts/oracles/chainlink/ChainlinkOracle.sol
@@ -39,7 +39,10 @@ contract ChainlinkOracle is IOracle {
      * @notice Retrieve the value of the amount at the latest oracle price.
      * @return value
      */
-    function peek(bytes32, bytes32, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
+    function peek(bytes32, bytes32, uint256 amount)
+        external view virtual override
+        returns (uint256 value, uint256 updateTime)
+    {
         uint256 price;
         (price, updateTime) = _peek();
         value = price * amount / 1e18;
@@ -49,7 +52,10 @@ contract ChainlinkOracle is IOracle {
      * @notice Retrieve the value of the amount at the latest oracle price.. Same as `peek` for this oracle.
      * @return value
      */
-    function get(bytes32, bytes32, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
+    function get(bytes32, bytes32, uint256 amount)
+        external view virtual override
+        returns (uint256 value, uint256 updateTime)
+    {
         uint256 price;
         (price, updateTime) = _peek();
         value = price * amount / 1e18;

--- a/contracts/oracles/compound/CompoundChiOracle.sol
+++ b/contracts/oracles/compound/CompoundChiOracle.sol
@@ -30,7 +30,10 @@ contract CompoundChiOracle is IOracle {
      * @notice Retrieve the value of the amount at the latest oracle price.
      * @return value
      */
-    function peek(bytes32, bytes32, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
+    function peek(bytes32, bytes32, uint256 amount)
+        external view virtual override
+        returns (uint256 value, uint256 updateTime)
+    {
         uint256 price;
         (price, updateTime) = _peek();
         value = price * amount / 1e18;
@@ -40,7 +43,10 @@ contract CompoundChiOracle is IOracle {
      * @notice Retrieve the value of the amount at the latest oracle price. Same as `peek` for this oracle.
      * @return value
      */
-    function get(bytes32, bytes32, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
+    function get(bytes32, bytes32, uint256 amount)
+        external view virtual override
+        returns (uint256 value, uint256 updateTime)
+    {
         uint256 price;
         (price, updateTime) = _peek();
         value = price * amount / 1e18;

--- a/contracts/oracles/compound/CompoundChiOracle.sol
+++ b/contracts/oracles/compound/CompoundChiOracle.sol
@@ -44,7 +44,7 @@ contract CompoundChiOracle is IOracle {
      * @return value
      */
     function get(bytes32, bytes32, uint256 amount)
-        external view virtual override
+        external virtual override
         returns (uint256 value, uint256 updateTime)
     {
         uint256 price;

--- a/contracts/oracles/compound/CompoundChiOracle.sol
+++ b/contracts/oracles/compound/CompoundChiOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "@yield-protocol/vault-interfaces/IOracle.sol";
 import "./CTokenInterface.sol";

--- a/contracts/oracles/compound/CompoundMultiOracle.sol
+++ b/contracts/oracles/compound/CompoundMultiOracle.sol
@@ -51,7 +51,7 @@ contract CompoundMultiOracle is IOracle, AccessControl, Constants {
      * @return value
      */
     function get(bytes32 base, bytes32 kind, uint256 amount)
-        external view virtual override
+        external virtual override
         returns (uint256 value, uint256 updateTime)
     {
         uint256 price;

--- a/contracts/oracles/compound/CompoundMultiOracle.sol
+++ b/contracts/oracles/compound/CompoundMultiOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/vault-interfaces/IOracle.sol";

--- a/contracts/oracles/compound/CompoundMultiOracle.sol
+++ b/contracts/oracles/compound/CompoundMultiOracle.sol
@@ -3,11 +3,12 @@ pragma solidity ^0.8.0;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/vault-interfaces/IOracle.sol";
+import "../../constants/Constants.sol";
 import "../../math/CastBytes32Bytes6.sol";
 import "./CTokenInterface.sol";
 
 
-contract CompoundMultiOracle is IOracle, AccessControl {
+contract CompoundMultiOracle is IOracle, AccessControl, Constants {
     using CastBytes32Bytes6 for bytes32;
 
     event SourceSet(bytes6 indexed baseId, bytes6 indexed kind, address indexed source);
@@ -63,8 +64,8 @@ contract CompoundMultiOracle is IOracle, AccessControl {
         address source = sources[base][kind];
         require (source != address(0), "Source not found");
 
-        if (kind == "rate") rawPrice = CTokenInterface(source).borrowIndex();
-        else if (kind == "chi") rawPrice = CTokenInterface(source).exchangeRateStored();
+        if (kind == RATE.b6()) rawPrice = CTokenInterface(source).borrowIndex();
+        else if (kind == CHI.b6()) rawPrice = CTokenInterface(source).exchangeRateStored();
         else revert("Unknown oracle type");
 
         require(rawPrice > 0, "Compound price is zero");

--- a/contracts/oracles/compound/CompoundMultiOracle.sol
+++ b/contracts/oracles/compound/CompoundMultiOracle.sol
@@ -36,7 +36,10 @@ contract CompoundMultiOracle is IOracle, AccessControl {
      * @notice Retrieve the value of the amount at the latest oracle price.
      * @return value
      */
-    function peek(bytes32 base, bytes32 kind, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
+    function peek(bytes32 base, bytes32 kind, uint256 amount)
+        external view virtual override
+        returns (uint256 value, uint256 updateTime)
+    {
         uint256 price;
         (price, updateTime) = _peek(base.b6(), kind.b6());
         value = price * amount / 1e18;
@@ -46,7 +49,10 @@ contract CompoundMultiOracle is IOracle, AccessControl {
      * @notice Retrieve the value of the amount at the latest oracle price. Same as `peek` for this oracle.
      * @return value
      */
-    function get(bytes32 base, bytes32 kind, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
+    function get(bytes32 base, bytes32 kind, uint256 amount)
+        external view virtual override
+        returns (uint256 value, uint256 updateTime)
+    {
         uint256 price;
         (price, updateTime) = _peek(base.b6(), kind.b6());
         value = price * amount / 1e18;

--- a/contracts/oracles/compound/CompoundMultiOracle.sol
+++ b/contracts/oracles/compound/CompoundMultiOracle.sol
@@ -19,37 +19,17 @@ contract CompoundMultiOracle is IOracle, AccessControl {
     /**
      * @notice Set or reset one source
      */
-    function setSource(bytes6 base, bytes6 kind, address source) public auth {
-        sources[base][kind] = source;
-        emit SourceSet(base, kind, source);
+    function setSource(bytes6 base, bytes6 kind, address source) external auth {
+        _setSource(base, kind, source);
     }
 
     /**
      * @notice Set or reset an oracle source
      */
-    function setSources(bytes6[] memory bases, bytes6[] memory kinds, address[] memory sources_) public auth {
+    function setSources(bytes6[] memory bases, bytes6[] memory kinds, address[] memory sources_) external auth {
         require(bases.length == kinds.length && kinds.length == sources_.length, "Mismatched inputs");
         for (uint256 i = 0; i < bases.length; i++)
-            setSource(bases[i], kinds[i], sources_[i]);
-    }
-
-    /**
-     * @notice Retrieve the latest price of a given source.
-     * @return price
-     */
-    function _peek(bytes6 base, bytes6 kind) private view returns (uint price, uint updateTime) {
-        uint256 rawPrice;
-        address source = sources[base][kind];
-        require (source != address(0), "Source not found");
-
-        if (kind == "rate") rawPrice = CTokenInterface(source).borrowIndex();
-        else if (kind == "chi") rawPrice = CTokenInterface(source).exchangeRateStored();
-        else revert("Unknown oracle type");
-
-        require(rawPrice > 0, "Compound price is zero");
-
-        price = rawPrice * SCALE_FACTOR;
-        updateTime = block.timestamp;
+            _setSource(bases[i], kinds[i], sources_[i]);
     }
 
     /**
@@ -70,5 +50,25 @@ contract CompoundMultiOracle is IOracle, AccessControl {
         uint256 price;
         (price, updateTime) = _peek(base.b6(), kind.b6());
         value = price * amount / 1e18;
+    }
+
+    function _peek(bytes6 base, bytes6 kind) private view returns (uint price, uint updateTime) {
+        uint256 rawPrice;
+        address source = sources[base][kind];
+        require (source != address(0), "Source not found");
+
+        if (kind == "rate") rawPrice = CTokenInterface(source).borrowIndex();
+        else if (kind == "chi") rawPrice = CTokenInterface(source).exchangeRateStored();
+        else revert("Unknown oracle type");
+
+        require(rawPrice > 0, "Compound price is zero");
+
+        price = rawPrice * SCALE_FACTOR;
+        updateTime = block.timestamp;
+    }
+
+    function _setSource(bytes6 base, bytes6 kind, address source) internal {
+        sources[base][kind] = source;
+        emit SourceSet(base, kind, source);
     }
 }

--- a/contracts/oracles/compound/CompoundRateOracle.sol
+++ b/contracts/oracles/compound/CompoundRateOracle.sol
@@ -44,7 +44,7 @@ contract CompoundRateOracle is IOracle {
      * @return value
      */
     function get(bytes32, bytes32, uint256 amount)
-        external view virtual override
+        external virtual override
         returns (uint256 value, uint256 updateTime)
     {
         uint256 price;

--- a/contracts/oracles/compound/CompoundRateOracle.sol
+++ b/contracts/oracles/compound/CompoundRateOracle.sol
@@ -30,7 +30,10 @@ contract CompoundRateOracle is IOracle {
      * @notice Retrieve the value of the amount at the latest oracle price.
      * @return value
      */
-    function peek(bytes32, bytes32, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
+    function peek(bytes32, bytes32, uint256 amount)
+        external view virtual override
+        returns (uint256 value, uint256 updateTime)
+    {
         uint256 price;
         (price, updateTime) = _peek();
         value = price * amount / 1e18;
@@ -40,7 +43,10 @@ contract CompoundRateOracle is IOracle {
      * @notice Retrieve the value of the amount at the latest oracle price. Same as `peek` for this oracle.
      * @return value
      */
-    function get(bytes32, bytes32, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
+    function get(bytes32, bytes32, uint256 amount)
+        external view virtual override
+        returns (uint256 value, uint256 updateTime)
+    {
         uint256 price;
         (price, updateTime) = _peek();
         value = price * amount / 1e18;

--- a/contracts/oracles/compound/CompoundRateOracle.sol
+++ b/contracts/oracles/compound/CompoundRateOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "@yield-protocol/vault-interfaces/IOracle.sol";
 import "./CTokenInterface.sol";

--- a/contracts/oracles/uniswap/UniswapV3Oracle.sol
+++ b/contracts/oracles/uniswap/UniswapV3Oracle.sol
@@ -76,7 +76,7 @@ contract UniswapV3Oracle is IOracle, AccessControl {
      * @return value
      */
     function get(bytes32 base, bytes32 quote, uint256 amount)
-        external view virtual override
+        external virtual override
         returns (uint256 value, uint256 updateTime)
     {
         return _peek(base.b6(), quote.b6(), amount);

--- a/contracts/oracles/uniswap/UniswapV3Oracle.sol
+++ b/contracts/oracles/uniswap/UniswapV3Oracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.0;
+pragma solidity 0.8.1;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/vault-interfaces/IOracle.sol";

--- a/contracts/oracles/uniswap/UniswapV3Oracle.sol
+++ b/contracts/oracles/uniswap/UniswapV3Oracle.sol
@@ -82,7 +82,10 @@ contract UniswapV3Oracle is IOracle, AccessControl {
         return _peek(base.b6(), quote.b6(), amount);
     }
 
-    function _peek(bytes6 base, bytes6 quote, uint256 amount) public virtual view returns (uint256 value, uint256 updateTime) {
+    function _peek(bytes6 base, bytes6 quote, uint256 amount)
+        private view
+        returns (uint256 value, uint256 updateTime)
+    {
         Source memory source = sources[base][quote];
         SourceData memory sourceData;
         require(source.source != address(0), "Source not found");

--- a/contracts/oracles/uniswap/UniswapV3Oracle.sol
+++ b/contracts/oracles/uniswap/UniswapV3Oracle.sol
@@ -64,7 +64,10 @@ contract UniswapV3Oracle is IOracle, AccessControl {
      * @notice Retrieve the value of the amount at the latest oracle price.
      * @return value
      */
-    function peek(bytes32 base, bytes32 quote, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
+    function peek(bytes32 base, bytes32 quote, uint256 amount)
+        external view virtual override
+        returns (uint256 value, uint256 updateTime)
+    {
         return _peek(base.b6(), quote.b6(), amount);
     }
 
@@ -72,7 +75,10 @@ contract UniswapV3Oracle is IOracle, AccessControl {
      * @notice Retrieve the value of the amount at the latest oracle price. Same as `peek` for this oracle.
      * @return value
      */
-    function get(bytes32 base, bytes32 quote, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
+    function get(bytes32 base, bytes32 quote, uint256 amount)
+        external view virtual override
+        returns (uint256 value, uint256 updateTime)
+    {
         return _peek(base.b6(), quote.b6(), amount);
     }
 

--- a/contracts/oracles/uniswap/UniswapV3Oracle.sol
+++ b/contracts/oracles/uniswap/UniswapV3Oracle.sol
@@ -37,7 +37,7 @@ contract UniswapV3Oracle is IOracle, AccessControl {
     /**
      * @notice Set or reset the number of seconds Uniswap will use for its Time Weighted Average Price computation
      */
-    function setSecondsAgo(uint32 secondsAgo_) public auth {
+    function setSecondsAgo(uint32 secondsAgo_) external auth {
         require(secondsAgo_ != 0, "Uniswap must look into the past.");
         secondsAgo = secondsAgo_;
         emit SecondsAgoSet(secondsAgo_);
@@ -46,44 +46,18 @@ contract UniswapV3Oracle is IOracle, AccessControl {
     /**
      * @notice Set or reset an oracle source and its inverse
      */
-    function setSource(bytes6 base, bytes6 quote, address source) public auth {
-        sources[base][quote] = Source(source, false);
-        sources[quote][base] = Source(source, true);
-        sourcesData[source] = SourceData(
-            IUniswapV3PoolImmutables(source).factory(),
-            IUniswapV3PoolImmutables(source).token0(),
-            IUniswapV3PoolImmutables(source).token1(),
-            IUniswapV3PoolImmutables(source).fee()
-        );
-        emit SourceSet(base, quote, source);
-        emit SourceSet(quote, base, source);
+    function setSource(bytes6 base, bytes6 quote, address source) external auth {
+        _setSource(base, quote, source);
     }
 
     /**
      * @notice Set or reset a number of oracle sources
      */
-    function setSources(bytes6[] memory bases, bytes6[] memory quotes, address[] memory sources_) public auth {
+    function setSources(bytes6[] memory bases, bytes6[] memory quotes, address[] memory sources_) external auth {
         require(bases.length == quotes.length && quotes.length == sources_.length, "Mismatched inputs");
         for (uint256 i = 0; i < bases.length; i++) {
-            setSource(bases[i], quotes[i], sources_[i]);
+            _setSource(bases[i], quotes[i], sources_[i]);
         }
-    }
-
-    /**
-     * @notice Retrieve the value of the amount at the latest oracle price.
-     * @return value
-     */
-    function _peek(bytes6 base, bytes6 quote, uint256 amount) public virtual view returns (uint256 value, uint256 updateTime) {
-        Source memory source = sources[base][quote];
-        SourceData memory sourceData;
-        require(source.source != address(0), "Source not found");
-        sourceData = sourcesData[source.source];
-        if (source.inverse) {
-            value = UniswapV3OracleLibraryMock.consult(sourceData.factory, sourceData.quoteToken, sourceData.baseToken, sourceData.fee, amount, secondsAgo);
-        } else {
-            value = UniswapV3OracleLibraryMock.consult(sourceData.factory, sourceData.baseToken, sourceData.quoteToken, sourceData.fee, amount, secondsAgo);
-        }
-        updateTime = block.timestamp - secondsAgo;
     }
 
     /**
@@ -100,5 +74,31 @@ contract UniswapV3Oracle is IOracle, AccessControl {
      */
     function get(bytes32 base, bytes32 quote, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
         return _peek(base.b6(), quote.b6(), amount);
+    }
+
+    function _peek(bytes6 base, bytes6 quote, uint256 amount) public virtual view returns (uint256 value, uint256 updateTime) {
+        Source memory source = sources[base][quote];
+        SourceData memory sourceData;
+        require(source.source != address(0), "Source not found");
+        sourceData = sourcesData[source.source];
+        if (source.inverse) {
+            value = UniswapV3OracleLibraryMock.consult(sourceData.factory, sourceData.quoteToken, sourceData.baseToken, sourceData.fee, amount, secondsAgo);
+        } else {
+            value = UniswapV3OracleLibraryMock.consult(sourceData.factory, sourceData.baseToken, sourceData.quoteToken, sourceData.fee, amount, secondsAgo);
+        }
+        updateTime = block.timestamp - secondsAgo;
+    }
+
+    function _setSource(bytes6 base, bytes6 quote, address source) internal {
+        sources[base][quote] = Source(source, false);
+        sources[quote][base] = Source(source, true);
+        sourcesData[source] = SourceData(
+            IUniswapV3PoolImmutables(source).factory(),
+            IUniswapV3PoolImmutables(source).token0(),
+            IUniswapV3PoolImmutables(source).token1(),
+            IUniswapV3PoolImmutables(source).fee()
+        );
+        emit SourceSet(base, quote, source);
+        emit SourceSet(quote, base, source);
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -11,6 +11,8 @@ import 'solidity-coverage'
 import 'hardhat-deploy'
 
 import { task } from 'hardhat/config'
+import { TASK_TEST } from 'hardhat/builtin-tasks/task-names'
+import { TaskArguments, HardhatRuntimeEnvironment, RunSuperFunction } from 'hardhat/types'
 
 // REQUIRED TO ENSURE METADATA IS SAVED IN DEPLOYMENTS (because solidity-coverage disable it otherwise)
 /* import {
@@ -21,6 +23,15 @@ task(TASK_COMPILE_GET_COMPILER_INPUT).setAction(async (_, bre, runSuper) => {
   input.settings.metadata.useLiteralContent = bre.network.name !== "coverage"
   return input
 }) */
+
+// Periodically, one needs to remove the 'artifacts' and 'typechain' folder (and hence, do a yarn build). Yet, if running yarn build, the tests shouldn't run the compilation again, so the hook below accomplishes just that.
+task(
+  TASK_TEST,
+  "Runs the tests",
+  async (args: TaskArguments, hre: HardhatRuntimeEnvironment, runSuper: RunSuperFunction<TaskArguments>) => {
+    return runSuper({...args, noCompile: true});
+  }
+);
 
 task("lint:collisions", "Checks all contracts for function signatures collisions with ROOT (0x00000000) and LOCK (0xffffffff)",
   async (taskArguments, hre, runSuper) => {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -87,7 +87,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 2500,
+        runs: 1000,
       }
     }
   },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -11,8 +11,6 @@ import 'solidity-coverage'
 import 'hardhat-deploy'
 
 import { task } from 'hardhat/config'
-import { TASK_TEST } from 'hardhat/builtin-tasks/task-names'
-import { TaskArguments, HardhatRuntimeEnvironment, RunSuperFunction } from 'hardhat/types'
 
 // REQUIRED TO ENSURE METADATA IS SAVED IN DEPLOYMENTS (because solidity-coverage disable it otherwise)
 /* import {
@@ -23,15 +21,6 @@ task(TASK_COMPILE_GET_COMPILER_INPUT).setAction(async (_, bre, runSuper) => {
   input.settings.metadata.useLiteralContent = bre.network.name !== "coverage"
   return input
 }) */
-
-// Periodically, one needs to remove the 'artifacts' and 'typechain' folder (and hence, do a yarn build). Yet, if running yarn build, the tests shouldn't run the compilation again, so the hook below accomplishes just that.
-task(
-  TASK_TEST,
-  "Runs the tests",
-  async (args: TaskArguments, hre: HardhatRuntimeEnvironment, runSuper: RunSuperFunction<TaskArguments>) => {
-    return runSuper({...args, noCompile: true});
-  }
-);
 
 task("lint:collisions", "Checks all contracts for function signatures collisions with ROOT (0x00000000) and LOCK (0xffffffff)",
   async (taskArguments, hre, runSuper) => {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -54,7 +54,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 5000,
+        runs: 2500,
       }
     }
   },
@@ -75,7 +75,7 @@ module.exports = {
     disambiguatePaths: false,
   },
   gasReporter: {
-    enabled: true,
+    enabled: false,
   },
   defaultNetwork: 'hardhat',
   namedAccounts: {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@truffle/hdwallet-provider": "^1.0.40",
     "@types/mocha": "^8.0.0",
     "@yield-protocol/utils-v2": "^2.2.10",
-    "@yield-protocol/vault-interfaces": "^2.0.35",
+    "@yield-protocol/vault-interfaces": "^2.0.36",
     "@yield-protocol/yieldspace-interfaces": "^2.0.17",
     "chai": "4.2.0",
     "dss-interfaces": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/mocha": "^8.0.0",
     "@yield-protocol/utils-v2": "^2.2.5",
     "@yield-protocol/vault-interfaces": "^2.0.35",
-    "@yield-protocol/yieldspace-interfaces": "^2.0.14",
+    "@yield-protocol/yieldspace-interfaces": "^2.0.17",
     "chai": "4.2.0",
     "dss-interfaces": "0.1.1",
     "erc3156": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@truffle/hdwallet-provider": "^1.0.40",
     "@types/mocha": "^8.0.0",
-    "@yield-protocol/utils-v2": "^2.2.5",
+    "@yield-protocol/utils-v2": "^2.2.10",
     "@yield-protocol/vault-interfaces": "^2.0.35",
     "@yield-protocol/yieldspace-interfaces": "^2.0.17",
     "chai": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf artifacts typechain && hardhat compile",
-    "test": "yarn build && hardhat test --show-stack-traces",
+    "test": "hardhat test --show-stack-traces",
     "test:deploy": "hardhat deploy --tags DeployTest",
     "coverage": "hardhat coverage",
     "lint:collisions": "yarn build && hardhat lint:collisions",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.6.0-rc0",
+  "version": "0.7.0-rc1",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [
     "contracts/*.sol",
     "contracts/math/*.sol",
+    "contracts/constants/*.sol",
     "contracts/oracles/chainlink/*.sol",
     "contracts/oracles/compound/*.sol",
     "contracts/oracles/uniswap/*.sol",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf artifacts typechain && hardhat compile",
-    "test": "hardhat test --show-stack-traces",
+    "test": "yarn build && hardhat test --show-stack-traces",
     "test:deploy": "hardhat deploy --tags DeployTest",
     "coverage": "hardhat coverage",
     "lint:collisions": "yarn build && hardhat lint:collisions",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "hardhat test --show-stack-traces",
     "test:deploy": "hardhat deploy --tags DeployTest",
     "coverage": "hardhat coverage",
-    "lint:sol": "solhint -f table contracts/*.sol",
+    "lint:collisions": "yarn build && hardhat lint:collisions",
+    "lint:sol": "yarn lint:collisions && solhint -f table contracts/*.sol",
     "lint:ts": "prettier ./test/*.ts --check",
     "lint:ts:fix": "prettier ./test/*.ts --write",
     "prepublishOnly": "npx tsdx build --tsconfig ./tsconfig-publish.json"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf artifacts typechain && hardhat compile",
-    "test": "hardhat test",
+    "test": "hardhat test --show-stack-traces",
     "test:deploy": "hardhat deploy --tags DeployTest",
     "coverage": "hardhat coverage",
     "lint:sol": "solhint -f table contracts/*.sol",
@@ -31,7 +31,7 @@
     "@truffle/hdwallet-provider": "^1.0.40",
     "@types/mocha": "^8.0.0",
     "@yield-protocol/utils-v2": "^2.2.5",
-    "@yield-protocol/vault-interfaces": "^2.0.33",
+    "@yield-protocol/vault-interfaces": "^2.0.35",
     "@yield-protocol/yieldspace-interfaces": "^2.0.14",
     "chai": "4.2.0",
     "dss-interfaces": "0.1.1",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,7 @@
+import { Cauldron } from '../typechain/Cauldron'
+
+export async function getLastVaultId(cauldron: Cauldron): Promise<string> {
+  const logs = await cauldron.queryFilter(cauldron.filters.VaultBuilt(null, null, null, null))
+  const event = logs[logs.length - 1]
+  return event.args.vaultId
+}

--- a/src/ladleWrapper.ts
+++ b/src/ladleWrapper.ts
@@ -87,12 +87,12 @@ export class LadleWrapper {
     else return this.ladle.batch(ops, data, overrides)
   }
 
-  public buildAction(vaultId: string, seriesId: string, ilkId: string): BatchAction {
-    return new BatchAction(OPS.BUILD, ethers.utils.defaultAbiCoder.encode(['bytes12', 'bytes6', 'bytes6'], [vaultId, seriesId, ilkId]))
+  public buildAction(seriesId: string, ilkId: string): BatchAction {
+    return new BatchAction(OPS.BUILD, ethers.utils.defaultAbiCoder.encode(['bytes6', 'bytes6'], [seriesId, ilkId]))
   }
 
-  public async build(vaultId: string, seriesId: string, ilkId: string): Promise<ContractTransaction> {
-    return this.batch([this.buildAction(vaultId, seriesId, ilkId)])
+  public async build(seriesId: string, ilkId: string): Promise<ContractTransaction> {
+    return this.batch([this.buildAction(seriesId, ilkId)])
   }
 
   public tweakAction(vaultId: string, seriesId: string, ilkId: string): BatchAction {

--- a/test/011_oracles.ts
+++ b/test/011_oracles.ts
@@ -2,7 +2,11 @@ import { constants, id } from '@yield-protocol/utils-v2'
 const { WAD } = constants
 import { CHI, RATE } from '../src/constants'
 
+import { sendStatic } from './shared/helpers'
+
+import { Contract } from '@ethersproject/contracts'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+
 import OracleArtifact from '../artifacts/contracts/mocks/oracles/OracleMock.sol/OracleMock.json'
 import ChainlinkMultiOracleArtifact from '../artifacts/contracts/oracles/chainlink/ChainlinkMultiOracle.sol/ChainlinkMultiOracle.json'
 import CompoundMultiOracleArtifact from '../artifacts/contracts/oracles/compound/CompoundMultiOracle.sol/CompoundMultiOracle.json'
@@ -84,8 +88,7 @@ describe('Oracle', function () {
     uniswapV3Factory = (await deployContract(ownerAcc, UniswapV3FactoryMockArtifact, [])) as UniswapV3FactoryMock
     const token0: string = ethers.utils.HDNode.fromSeed('0x0123456789abcdef0123456789abcdef').address
     const token1: string = ethers.utils.HDNode.fromSeed('0xfedcba9876543210fedcba9876543210').address
-    uniswapV3PoolAddress = await uniswapV3Factory.callStatic.createPool(token0, token1, 0)
-    await uniswapV3Factory.createPool(token0, token1, 0)
+    uniswapV3PoolAddress = await sendStatic(uniswapV3Factory as Contract, 'createPool', ownerAcc, [token0, token1, 0])
     uniswapV3Pool = (await ethers.getContractAt('UniswapV3PoolMock', uniswapV3PoolAddress)) as UniswapV3PoolMock
     uniswapV3Oracle = (await deployContract(ownerAcc, UniswapV3OracleArtifact, [])) as UniswapV3Oracle
     uniswapV3Oracle.grantRole(id('setSources(bytes6[],bytes6[],address[])'), owner)

--- a/test/021_join.ts
+++ b/test/021_join.ts
@@ -1,5 +1,12 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 import { constants, id } from '@yield-protocol/utils-v2'
+
+import { sendStatic } from './shared/helpers'
+
+import { Contract } from '@ethersproject/contracts'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { Event } from '@ethersproject/contracts/lib/index'
+import { Result } from '@ethersproject/abi'
+
 const { WAD, MAX256 } = constants
 const MAX = MAX256
 
@@ -39,9 +46,11 @@ describe('Join', function () {
     token = (await deployContract(ownerAcc, ERC20MockArtifact, ['MTK', 'Mock Token'])) as ERC20Mock
     otherToken = (await deployContract(ownerAcc, ERC20MockArtifact, ['OTH', 'Other Token'])) as ERC20Mock
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
-    const joinAddress = await joinFactory.calculateJoinAddress(token.address) // Get the address
-    await joinFactory.createJoin(token.address) // Create the Join (doesn't return anything outside a contract call)
-    join = (await ethers.getContractAt('Join', joinAddress, ownerAcc)) as Join
+    join = (await ethers.getContractAt(
+      'Join',
+      await sendStatic(joinFactory as Contract, 'createJoin', ownerAcc, [token.address]),
+      ownerAcc
+    )) as Join
 
     await join.grantRoles(
       [id('join(address,uint128)'), id('exit(address,uint128)'), id('retrieve(address,address)')],

--- a/test/022_join_flash.ts
+++ b/test/022_join_flash.ts
@@ -70,70 +70,81 @@ describe('Join - flash', function () {
     borrower = (await deployContract(ownerAcc, FlashBorrowerArtifact, [join.address])) as FlashBorrower
   })
 
-  it('the receiver needs to approve the repayment', async () => {
-    await expect(join.flashLoan(borrower.address, token.address, WAD, actions.none)).to.be.revertedWith(
-      'ERC20: Insufficient approval'
-    )
+  it('flash loans are disabled by default', async () => {
+    await expect(join.flashLoan(borrower.address, token.address, 1, actions.none)).to.be.reverted
   })
 
-  it('should do a simple flash loan', async () => {
-    await borrower.flashBorrow(token.address, WAD, actions.none)
-
-    expect(await token.balanceOf(owner)).to.equal(0)
-    expect(await borrower.flashBalance()).to.equal(WAD)
-    expect(await borrower.flashToken()).to.equal(token.address)
-    expect(await borrower.flashAmount()).to.equal(WAD)
-    expect(await borrower.flashInitiator()).to.equal(borrower.address)
-  })
-
-  it('can repay the flash loan by transfer', async () => {
-    await expect(borrower.flashBorrow(token.address, WAD, actions.transfer))
-      .to.emit(token, 'Transfer')
-      .withArgs(borrower.address, join.address, WAD)
-
-    expect(await token.balanceOf(owner)).to.equal(0)
-    expect(await borrower.flashBalance()).to.equal(WAD)
-    expect(await borrower.flashToken()).to.equal(token.address)
-    expect(await borrower.flashAmount()).to.equal(WAD)
-    expect(await borrower.flashInitiator()).to.equal(borrower.address)
-  })
-
-  it('needs to have enough funds to repay a flash loan', async () => {
-    await expect(borrower.flashBorrow(token.address, WAD, actions.steal)).to.be.revertedWith(
-      'ERC20: Insufficient balance'
-    )
-  })
-
-  it('should do two nested flash loans', async () => {
-    await borrower.flashBorrow(token.address, WAD, actions.reenter) // It will borrow WAD, and then reenter and borrow WAD * 2
-    expect(await borrower.flashBalance()).to.equal(WAD.mul(3))
-  })
-
-  it('sets the flash fee factor', async () => {
-    const feeFactor = WAD.mul(5).div(100) // 5%
-    await expect(join.setFlashFeeFactor(feeFactor)).to.emit(join, 'FlashFeeFactorSet').withArgs(feeFactor)
-    expect(await join.flashFeeFactor()).to.equal(feeFactor)
-  })
-
-  describe('with a non-zero fee', async () => {
+  describe('with a zero fee', async () => {
     beforeEach(async () => {
-      const feeFactor = WAD.mul(5).div(100) // 5%
+      const feeFactor = 0
       await join.setFlashFeeFactor(feeFactor)
     })
 
+    it('the receiver needs to approve the repayment', async () => {
+      await expect(join.flashLoan(borrower.address, token.address, WAD, actions.none)).to.be.revertedWith(
+        'ERC20: Insufficient approval'
+      )
+    })
+
     it('should do a simple flash loan', async () => {
-      const principal = WAD
-      const fee = principal.mul(5).div(100)
-      await token.mint(borrower.address, fee)
-      await expect(borrower.flashBorrow(token.address, principal, actions.none))
-        .to.emit(token, 'Transfer')
-        .withArgs(borrower.address, join.address, principal.add(fee))
+      await borrower.flashBorrow(token.address, WAD, actions.none)
 
       expect(await token.balanceOf(owner)).to.equal(0)
-      expect(await borrower.flashBalance()).to.equal(principal.add(fee))
+      expect(await borrower.flashBalance()).to.equal(WAD)
       expect(await borrower.flashToken()).to.equal(token.address)
-      expect(await borrower.flashAmount()).to.equal(principal)
+      expect(await borrower.flashAmount()).to.equal(WAD)
       expect(await borrower.flashInitiator()).to.equal(borrower.address)
+    })
+
+    it('can repay the flash loan by transfer', async () => {
+      await expect(borrower.flashBorrow(token.address, WAD, actions.transfer))
+        .to.emit(token, 'Transfer')
+        .withArgs(borrower.address, join.address, WAD)
+
+      expect(await token.balanceOf(owner)).to.equal(0)
+      expect(await borrower.flashBalance()).to.equal(WAD)
+      expect(await borrower.flashToken()).to.equal(token.address)
+      expect(await borrower.flashAmount()).to.equal(WAD)
+      expect(await borrower.flashInitiator()).to.equal(borrower.address)
+    })
+
+    it('needs to have enough funds to repay a flash loan', async () => {
+      await expect(borrower.flashBorrow(token.address, WAD, actions.steal)).to.be.revertedWith(
+        'ERC20: Insufficient balance'
+      )
+    })
+
+    it('should do two nested flash loans', async () => {
+      await borrower.flashBorrow(token.address, WAD, actions.reenter) // It will borrow WAD, and then reenter and borrow WAD * 2
+      expect(await borrower.flashBalance()).to.equal(WAD.mul(3))
+    })
+
+    it('sets the flash fee factor', async () => {
+      const feeFactor = WAD.mul(5).div(100) // 5%
+      await expect(join.setFlashFeeFactor(feeFactor)).to.emit(join, 'FlashFeeFactorSet').withArgs(feeFactor)
+      expect(await join.flashFeeFactor()).to.equal(feeFactor)
+    })
+
+    describe('with a non-zero fee', async () => {
+      beforeEach(async () => {
+        const feeFactor = WAD.mul(5).div(100) // 5%
+        await join.setFlashFeeFactor(feeFactor)
+      })
+
+      it('should do a simple flash loan', async () => {
+        const principal = WAD
+        const fee = principal.mul(5).div(100)
+        await token.mint(borrower.address, fee)
+        await expect(borrower.flashBorrow(token.address, principal, actions.none))
+          .to.emit(token, 'Transfer')
+          .withArgs(borrower.address, join.address, principal.add(fee))
+
+        expect(await token.balanceOf(owner)).to.equal(0)
+        expect(await borrower.flashBalance()).to.equal(principal.add(fee))
+        expect(await borrower.flashToken()).to.equal(token.address)
+        expect(await borrower.flashAmount()).to.equal(principal)
+        expect(await borrower.flashInitiator()).to.equal(borrower.address)
+      })
     })
   })
 })

--- a/test/031_fyToken.ts
+++ b/test/031_fyToken.ts
@@ -41,6 +41,10 @@ describe('FYToken', function () {
     owner = await ownerAcc.getAddress()
   })
 
+  after(async () => {
+    await loadFixture(fixture) // We advance the time to test maturity features, this rolls it back after the tests
+  })
+
   const baseId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const ilkId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const seriesId = ethers.utils.hexlify(ethers.utils.randomBytes(6))

--- a/test/031_fyToken.ts
+++ b/test/031_fyToken.ts
@@ -57,6 +57,7 @@ describe('FYToken', function () {
     chiSource = (await ethers.getContractAt('ISourceMock', await chiOracle.sources(baseId, CHI))) as ISourceMock
 
     await baseJoin.grantRoles([id('join(address,uint128)'), id('exit(address,uint128)')], fyToken.address)
+    await baseJoin.grantRoles([id('join(address,uint128)'), id('exit(address,uint128)')], owner)
 
     await fyToken.grantRoles(
       [id('mint(address,uint256)'), id('burn(address,uint256)'), id('setOracle(address)')],
@@ -109,7 +110,9 @@ describe('FYToken', function () {
     it('matures if needed on first redemption after maturity', async () => {
       const baseOwnerBefore = await base.balanceOf(owner)
       const baseJoinBefore = await base.balanceOf(baseJoin.address)
-      await expect(fyToken.redeem(owner, WAD)).to.emit(fyToken, 'Redeemed').withArgs(owner, owner, WAD, WAD)
+      expect(await fyToken.redeem(owner, WAD))
+        .to.emit(fyToken, 'Redeemed')
+        .withArgs(owner, owner, WAD, WAD)
       expect(await base.balanceOf(baseJoin.address)).to.equal(baseJoinBefore.sub(WAD))
       expect(await base.balanceOf(owner)).to.equal(baseOwnerBefore.add(WAD))
       expect(await fyToken.balanceOf(owner)).to.equal(0)

--- a/test/032_fyToken_flash.ts
+++ b/test/032_fyToken_flash.ts
@@ -40,6 +40,10 @@ describe('FYToken - flash', function () {
     owner = await ownerAcc.getAddress()
   })
 
+  after(async () => {
+    await loadFixture(fixture) // We advance the time to test maturity features, this rolls it back after the tests
+  })
+
   const baseId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const ilkId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const seriesId = ethers.utils.hexlify(ethers.utils.randomBytes(6))

--- a/test/051_cauldron_admin.ts
+++ b/test/051_cauldron_admin.ts
@@ -89,7 +89,6 @@ describe('Cauldron - admin', function () {
 
     await cauldron.grantRoles(
       [
-        id('setAuctionInterval(uint32)'),
         id('addAsset(bytes6,address)'),
         id('setDebtLimits(bytes6,bytes6,uint96,uint24,uint8)'),
         id('setRateOracle(bytes6,address)'),
@@ -99,13 +98,6 @@ describe('Cauldron - admin', function () {
       ],
       owner
     )
-  })
-
-  it('sets the protection period', async () => {
-    expect(await cauldron.setAuctionInterval(1))
-      .to.emit(cauldron, 'AuctionIntervalSet')
-      .withArgs(1)
-    expect(await cauldron.auctionInterval()).to.equal(1)
   })
 
   it('does not allow using zero as an asset identifier', async () => {

--- a/test/051_cauldron_admin.ts
+++ b/test/051_cauldron_admin.ts
@@ -1,5 +1,11 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 import { id } from '@yield-protocol/utils-v2'
+
+import { sendStatic } from './shared/helpers'
+
+import { Contract } from '@ethersproject/contracts'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { Event } from '@ethersproject/contracts/lib/index'
+import { Result } from '@ethersproject/abi'
 
 import CauldronArtifact from '../artifacts/contracts/Cauldron.sol/Cauldron.json'
 import JoinFactoryArtifact from '../artifacts/contracts/JoinFactory.sol/JoinFactory.json'
@@ -56,9 +62,11 @@ describe('Cauldron - admin', function () {
     ilk1 = (await deployContract(ownerAcc, ERC20MockArtifact, [ilkId1, 'Mock Ilk'])) as ERC20Mock
     ilk2 = (await deployContract(ownerAcc, ERC20MockArtifact, [ilkId2, 'Mock Ilk'])) as ERC20Mock
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
-    const joinAddress = await joinFactory.calculateJoinAddress(base.address) // Get the address
-    await joinFactory.createJoin(base.address) // Create the Join (doesn't return anything outside a contract call)
-    join = (await ethers.getContractAt('Join', joinAddress, ownerAcc)) as Join
+    join = (await ethers.getContractAt(
+      'Join',
+      await sendStatic(joinFactory as Contract, 'createJoin', ownerAcc, [base.address]),
+      ownerAcc
+    )) as Join
     fyToken = (await deployContract(ownerAcc, FYTokenArtifact, [
       baseId,
       base.address,

--- a/test/053_cauldron_level.ts
+++ b/test/053_cauldron_level.ts
@@ -47,6 +47,10 @@ describe('Cauldron - level', function () {
     owner = await ownerAcc.getAddress()
   })
 
+  after(async () => {
+    await loadFixture(fixture) // We advance the time to test maturity features, this rolls it back after the tests
+  })
+
   beforeEach(async function () {
     this.timeout(0)
     env = await loadFixture(fixture)

--- a/test/054_cauldron_stir.ts
+++ b/test/054_cauldron_stir.ts
@@ -62,6 +62,10 @@ describe('Cauldron - stir', function () {
     await cauldron.build(owner, vaultToId, seriesId, ilkId)
   })
 
+  it('does not allow moving collateral or debt from and to the same vault', async () => {
+    await expect(cauldron.stir(vaultFromId, vaultFromId, WAD, WAD)).to.be.revertedWith('Identical vaults')
+  })
+
   it('does not allow moving collateral or debt to an uninitialized vault', async () => {
     await expect(cauldron.stir(mockVaultId, vaultToId, WAD, 0)).to.be.revertedWith('Vault not found')
     await expect(cauldron.stir(vaultFromId, mockVaultId, WAD, 0)).to.be.revertedWith('Vault not found')

--- a/test/060_ladle_admin.ts
+++ b/test/060_ladle_admin.ts
@@ -3,8 +3,7 @@ import { constants, id } from '@yield-protocol/utils-v2'
 import { sendStatic } from './shared/helpers'
 
 import { Contract } from '@ethersproject/contracts'
-import { Event } from '@ethersproject/contracts/lib/index'
-import { Result } from '@ethersproject/abi'
+import { ContractFactory } from 'ethers'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
 const { WAD, THREE_MONTHS } = constants
@@ -24,6 +23,7 @@ import { ERC20Mock } from '../typechain/ERC20Mock'
 import { OracleMock } from '../typechain/OracleMock'
 import { PoolMock } from '../typechain/PoolMock'
 import { PoolFactoryMock } from '../typechain/PoolFactoryMock'
+import { SafeERC20Namer } from '../typechain/SafeERC20Namer'
 
 import { ethers, waffle } from 'hardhat'
 import { expect } from 'chai'
@@ -42,6 +42,7 @@ describe('Ladle - admin', function () {
   let other: string
   let cauldron: Cauldron
   let fyToken: FYToken
+  let fyTokenFactory: ContractFactory
   let base: ERC20Mock
   let baseJoin: Join
   let joinFactory: JoinFactory
@@ -109,14 +110,26 @@ describe('Ladle - admin', function () {
     // Deploy a series
     const { timestamp } = await ethers.provider.getBlock('latest')
     maturity = timestamp + THREE_MONTHS
-    fyToken = (await deployContract(ownerAcc, FYTokenArtifact, [
+
+    const SafeERC20NamerFactory = await ethers.getContractFactory('SafeERC20Namer')
+    const safeERC20NamerLibrary = ((await SafeERC20NamerFactory.deploy()) as unknown) as SafeERC20Namer
+    await safeERC20NamerLibrary.deployed()
+
+    fyTokenFactory = await ethers.getContractFactory('FYToken', {
+      libraries: {
+        SafeERC20Namer: safeERC20NamerLibrary.address,
+      },
+    })
+    fyToken = ((await fyTokenFactory.deploy(
       baseId,
       rateOracle.address,
       baseJoin.address,
       maturity,
       seriesId,
-      'Mock FYToken',
-    ])) as FYToken
+      'Mock FYToken'
+    )) as unknown) as FYToken
+    await fyToken.deployed()
+
     await cauldron.addSeries(seriesId, baseId, fyToken.address)
     await cauldron.addIlks(seriesId, [ilkId])
 
@@ -167,14 +180,16 @@ describe('Ladle - admin', function () {
 
     it('does not allow adding a pool with a mismatched fyToken', async () => {
       // Deploy other series
-      const otherFYToken = (await deployContract(ownerAcc, FYTokenArtifact, [
+      const otherFYToken = ((await fyTokenFactory.deploy(
         baseId,
         rateOracle.address,
         baseJoin.address,
         maturity,
         seriesId,
-        'Mock FYToken',
-      ])) as FYToken
+        'Mock FYToken'
+      )) as unknown) as FYToken
+      await otherFYToken.deployed()
+
       await cauldron.addSeries(otherSeriesId, baseId, otherFYToken.address)
       await cauldron.addIlks(otherSeriesId, [ilkId])
 

--- a/test/060_ladle_admin.ts
+++ b/test/060_ladle_admin.ts
@@ -1,6 +1,12 @@
+import { constants, id } from '@yield-protocol/utils-v2'
+
+import { sendStatic } from './shared/helpers'
+
+import { Contract } from '@ethersproject/contracts'
+import { Event } from '@ethersproject/contracts/lib/index'
+import { Result } from '@ethersproject/abi'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
-import { constants, id } from '@yield-protocol/utils-v2'
 const { WAD, THREE_MONTHS } = constants
 import { RATE } from '../src/constants'
 
@@ -93,9 +99,11 @@ describe('Ladle - admin', function () {
 
     // Deploy a join
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
-    const joinAddress = await joinFactory.calculateJoinAddress(ilk.address) // Get the address
-    await joinFactory.createJoin(ilk.address) // Create the Join (doesn't return anything outside a contract call)
-    ilkJoin = (await ethers.getContractAt('Join', joinAddress, ownerAcc)) as Join
+    ilkJoin = (await ethers.getContractAt(
+      'Join',
+      await sendStatic(joinFactory as Contract, 'createJoin', ownerAcc, [ilk.address]),
+      ownerAcc
+    )) as Join
     await ilkJoin.grantRoles([id('join(address,uint128)'), id('exit(address,uint128)')], ladle.address)
 
     // Deploy a series

--- a/test/062_ladle_close.ts
+++ b/test/062_ladle_close.ts
@@ -55,6 +55,10 @@ describe('Ladle - close', function () {
     other = await otherAcc.getAddress()
   })
 
+  after(async () => {
+    await loadFixture(fixture) // We advance the time to test maturity features, this rolls it back after the tests
+  })
+
   const baseId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const ilkId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const seriesId = ethers.utils.hexlify(ethers.utils.randomBytes(6))

--- a/test/063_ladle_vaults.ts
+++ b/test/063_ladle_vaults.ts
@@ -55,9 +55,14 @@ describe('Ladle - vaults', function () {
   })
 
   it('builds a vault', async () => {
-    await expect(ladle.build(otherVaultId, seriesId, ilkId))
-      .to.emit(cauldron, 'VaultBuilt')
-      .withArgs(otherVaultId, owner, seriesId, ilkId)
+    await expect(ladle.build(seriesId, ilkId)).to.emit(cauldron, 'VaultBuilt')
+
+    const logs = await cauldron.queryFilter(cauldron.filters.VaultBuilt(null, null, null, null))
+    const event = logs[logs.length - 1]
+    const otherVaultId = event.args.vaultId
+    expect(event.args.owner).to.equal(owner)
+    expect(event.args.seriesId).to.equal(seriesId)
+    expect(event.args.ilkId).to.equal(ilkId)
 
     const vault = await cauldron.vaults(otherVaultId)
     expect(vault.owner).to.equal(owner)

--- a/test/064_ladle_stir.ts
+++ b/test/064_ladle_stir.ts
@@ -13,6 +13,7 @@ const { loadFixture } = waffle
 
 import { YieldEnvironment } from './shared/fixtures'
 import { LadleWrapper } from '../src/ladleWrapper'
+import { getLastVaultId } from '../src/helpers'
 
 describe('Ladle - stir', function () {
   this.timeout(0)
@@ -44,8 +45,8 @@ describe('Ladle - stir', function () {
   const baseId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const ilkId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const seriesId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
-  const vaultToId = ethers.utils.hexlify(ethers.utils.randomBytes(12))
   const otherIlkId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
+  let vaultToId: string
 
   let vaultFromId: string
 
@@ -60,7 +61,8 @@ describe('Ladle - stir', function () {
     vaultFromId = (env.vaults.get(seriesId) as Map<string, string>).get(ilkId) as string
 
     // ==== Set testing environment ====
-    await ladle.build(vaultToId, seriesId, ilkId)
+    await ladle.build(seriesId, ilkId)
+    vaultToId = await getLastVaultId(cauldron)
   })
 
   it('does not allow moving collateral other than to the origin vault owner', async () => {

--- a/test/065_ladle_roll.ts
+++ b/test/065_ladle_roll.ts
@@ -44,6 +44,10 @@ describe('Ladle - roll', function () {
     other = await otherAcc.getAddress()
   })
 
+  after(async () => {
+    await loadFixture(fixture) // We advance the time to test maturity features, this rolls it back after the tests
+  })
+
   const baseId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const ilkId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const seriesId = ethers.utils.hexlify(ethers.utils.randomBytes(6))

--- a/test/066_remove_and_repay.ts
+++ b/test/066_remove_and_repay.ts
@@ -46,6 +46,10 @@ describe('Ladle - remove and repay', function () {
     other = await otherAcc.getAddress()
   })
 
+  after(async () => {
+    await loadFixture(fixture) // We advance the time to test maturity features, this rolls it back after the tests
+  })
+
   const baseId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const ilkId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const seriesId = ethers.utils.hexlify(ethers.utils.randomBytes(6))

--- a/test/066_remove_and_repay.ts
+++ b/test/066_remove_and_repay.ts
@@ -1,6 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
-import { constants } from '@yield-protocol/utils-v2'
+import { constants, id } from '@yield-protocol/utils-v2'
 const { WAD, MAX128 } = constants
 const MAX = MAX128
 
@@ -63,6 +63,8 @@ describe('Ladle - remove and repay', function () {
     pool = env.pools.get(seriesId) as PoolMock
 
     vaultId = (env.vaults.get(seriesId) as Map<string, string>).get(ilkId) as string
+
+    await baseJoin.grantRoles([id('join(address,uint128)'), id('exit(address,uint128)')], owner)
 
     // Borrow and add liquidity
     await ladle.serve(vaultId, pool.address, WAD, WAD, MAX)

--- a/test/068_ladle_eth.ts
+++ b/test/068_ladle_eth.ts
@@ -76,6 +76,12 @@ describe('Ladle - eth', function () {
     await ladle.batch([ladle.joinEtherAction(ethId), ladle.pourAction(ethVaultId, owner, WAD, 0)], { value: WAD })
   })
 
+  it('ladle will only receive from WETH', async () => {
+    await expect(ownerAcc.sendTransaction({ to: ladle.address, value: WAD })).to.be.revertedWith(
+      'Only receive from WETH'
+    )
+  })
+
   describe('with ETH posted', async () => {
     beforeEach(async () => {
       expect(await ladle.joinEther(ethId, { value: WAD }))

--- a/test/069_ladle_permit.ts
+++ b/test/069_ladle_permit.ts
@@ -118,7 +118,7 @@ describe('Ladle - permit', function () {
 
     expect(
       await ladle.batch([
-        ladle.buildAction(vaultId, seriesId, ilkId),
+        ladle.buildAction(seriesId, ilkId),
         ladle.forwardPermitAction(seriesId, false, ladle.address, amount, deadline, v, r, s),
       ])
     )
@@ -165,7 +165,7 @@ describe('Ladle - permit', function () {
 
     expect(
       await ladle.batch([
-        ladle.buildAction(vaultId, seriesId, ilkId),
+        ladle.buildAction(seriesId, ilkId),
         ladle.forwardDaiPermitAction(DAI, true, ladle.address, nonce, deadline, true, v, r, s),
       ])
     )

--- a/test/081_witch.ts
+++ b/test/081_witch.ts
@@ -53,6 +53,10 @@ describe('Witch', function () {
     other = await otherAcc.getAddress()
   })
 
+  after(async () => {
+    await loadFixture(fixture) // We advance the time to test maturity features, this rolls it back after the tests
+  })
+
   const baseId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const ilkId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const seriesId = ethers.utils.hexlify(ethers.utils.randomBytes(6))

--- a/test/081_witch.ts
+++ b/test/081_witch.ts
@@ -2,15 +2,16 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-wit
 
 import { constants } from '@yield-protocol/utils-v2'
 const { WAD } = constants
+import { RATE } from '../src/constants'
 
 import { Cauldron } from '../typechain/Cauldron'
 import { Join } from '../typechain/Join'
 import { Witch } from '../typechain/Witch'
 import { FYToken } from '../typechain/FYToken'
 import { ERC20Mock } from '../typechain/ERC20Mock'
-import { OracleMock } from '../typechain/OracleMock'
 import { ChainlinkMultiOracle } from '../typechain/ChainlinkMultiOracle'
 import { ISourceMock } from '../typechain/ISourceMock'
+import { CompoundMultiOracle } from '../typechain/CompoundMultiOracle'
 
 import { ethers, waffle } from 'hardhat'
 import { expect } from 'chai'
@@ -18,6 +19,10 @@ const { loadFixture } = waffle
 
 import { YieldEnvironment } from './shared/fixtures'
 import { LadleWrapper } from '../src/ladleWrapper'
+
+function bytes6ToBytes32(x: string): string {
+  return x + '00'.repeat(26)
+}
 
 describe('Witch', function () {
   this.timeout(0)
@@ -37,6 +42,8 @@ describe('Witch', function () {
   let ilkJoin: Join
   let spotOracle: ChainlinkMultiOracle
   let spotSource: ISourceMock
+  let rateOracle: CompoundMultiOracle
+  let rateSource: ISourceMock
 
   const mockVaultId = ethers.utils.hexlify(ethers.utils.randomBytes(12))
 
@@ -76,6 +83,8 @@ describe('Witch', function () {
       'ISourceMock',
       (await spotOracle.sources(baseId, ilkId))[0]
     )) as ISourceMock
+    rateOracle = (env.oracles.get(RATE) as unknown) as CompoundMultiOracle
+    rateSource = (await ethers.getContractAt('ISourceMock', await rateOracle.sources(baseId, RATE))) as ISourceMock
 
     witchFromOther = witch.connect(otherAcc)
 
@@ -84,53 +93,60 @@ describe('Witch', function () {
   })
 
   it('does not allow to set the initial proportion over 100%', async () => {
-    await expect(witch.setInitialProportion(WAD.mul(2))).to.be.revertedWith('Only at or under 100%')
+    await expect(witch.setInitialOffer(WAD.mul(2))).to.be.revertedWith('Only at or under 100%')
   })
 
   it('allows to set the initial proportion', async () => {
-    expect(await witch.setInitialProportion(1))
-      .to.emit(witch, 'InitialProportionSet')
+    expect(await witch.setInitialOffer(1))
+      .to.emit(witch, 'InitialOfferSet')
       .withArgs(1)
-    expect(await witch.initialProportion()).to.equal(1)
+    expect(await witch.initialOffer()).to.equal(1)
   })
 
-  it('allows to set the auction time', async () => {
-    expect(await witch.setAuctionTime(1))
-      .to.emit(witch, 'AuctionTimeSet')
+  it('allows to set the auction duration', async () => {
+    expect(await witch.setDuration(1))
+      .to.emit(witch, 'DurationSet')
       .withArgs(1)
-    expect(await witch.auctionTime()).to.equal(1)
+    expect(await witch.duration()).to.equal(1)
   })
 
-  it('does not allow to grab collateralized vaults', async () => {
-    await expect(witch.grab(vaultId)).to.be.revertedWith('Not undercollateralized')
+  it('allows to set the dust level', async () => {
+    expect(await witch.setDust(1))
+      .to.emit(witch, 'DustSet')
+      .withArgs(1)
+    expect(await witch.dust()).to.equal(1)
   })
 
-  it('does not allow to grab uninitialized vaults', async () => {
-    await expect(witch.grab(mockVaultId)).to.be.revertedWith('Vault not found')
+  it('does not allow to auction collateralized vaults', async () => {
+    await expect(witch.auction(vaultId)).to.be.revertedWith('Not undercollateralized')
+  })
+
+  it('does not allow to auction uninitialized vaults', async () => {
+    await expect(witch.auction(mockVaultId)).to.be.revertedWith('Vault not found')
   })
 
   it('does not allow to buy from uninitialized vaults', async () => {
     await expect(witch.buy(mockVaultId, 0, 0)).to.be.revertedWith('Nothing to buy')
   })
 
-  it('grabs undercollateralized vaults', async () => {
+  it('auctions undercollateralized vaults', async () => {
     await spotSource.set(WAD.div(2))
-    await witch.grab(vaultId)
-    const event = (await cauldron.queryFilter(cauldron.filters.VaultLocked(null, null)))[0]
+    await witch.auction(vaultId)
+    const event = (await witch.queryFilter(witch.filters.Auctioned(null, null)))[0]
     expect((await cauldron.vaults(vaultId)).owner).to.equal(witch.address)
-    expect(await witch.vaultOwners(vaultId)).to.equal(owner)
-    expect(event.args.timestamp.toNumber()).to.be.greaterThan(0)
-    expect(await cauldron.auctions(vaultId)).to.equal(event.args.timestamp)
+    expect((await witch.auctions(vaultId)).owner).to.equal(owner)
+    expect(event.args.start.toNumber()).to.be.greaterThan(0)
+    expect((await witch.auctions(vaultId)).start).to.equal(event.args.start)
   })
 
-  describe('once a vault has been grabbed', async () => {
+  describe('once a vault has been auctioned', async () => {
     beforeEach(async () => {
       await spotSource.set(WAD.div(2))
-      await witch.grab(vaultId)
+      await witch.auction(vaultId)
     })
 
-    it("it can't be grabbed again", async () => {
-      await expect(witch.grab(vaultId)).to.be.revertedWith('Vault under auction')
+    it("it can't be auctioned again", async () => {
+      await expect(witch.auction(vaultId)).to.be.revertedWith('Vault already under auction')
     })
 
     it('does not buy if minimum collateral not reached', async () => {
@@ -159,10 +175,15 @@ describe('Witch', function () {
       expect((await cauldron.vaults(vaultId)).owner).to.equal(owner) // The vault was returned once all the debt was paid off
     })
 
+    it('does not buy if leaving dust', async () => {
+      await witch.setDust(WAD)
+      await expect(witch.buy(vaultId, WAD, 0)).to.be.revertedWith('Leaves dust')
+    })
+
     describe('once the auction time has passed', async () => {
       beforeEach(async () => {
         const { timestamp } = await ethers.provider.getBlock('latest')
-        await ethers.provider.send('evm_mine', [timestamp + (await witch.auctionTime()).toNumber()])
+        await ethers.provider.send('evm_mine', [timestamp + (await witch.duration())])
       })
 
       it('allows to buy all of the collateral for the whole debt at the end', async () => {
@@ -174,6 +195,46 @@ describe('Witch', function () {
         expect(ink).to.equal(WAD)
         expect(await base.balanceOf(owner)).to.equal(baseBalanceBefore.sub(WAD))
         expect(await ilk.balanceOf(owner)).to.equal(ilkBalanceBefore.add(ink))
+      })
+
+      describe('after maturity, with a rate increase', async () => {
+        beforeEach(async () => {
+          await ethers.provider.send('evm_mine', [(await fyToken.maturity()).toNumber()])
+          await cauldron.mature(seriesId)
+          const rate = await cauldron.ratesAtMaturity(seriesId)
+          await rateSource.set(rate.mul(110).div(100))
+        })
+
+        it('debt to repay grows with rate after maturity', async () => {
+          const baseBalanceBefore = await base.balanceOf(owner)
+          const ilkBalanceBefore = await ilk.balanceOf(owner)
+          await expect(witch.buy(vaultId, WAD, 0))
+            .to.emit(witch, 'Bought')
+            .withArgs(
+              vaultId,
+              owner,
+              WAD.sub((await cauldron.balances(vaultId)).art),
+              WAD.sub((await cauldron.balances(vaultId)).ink)
+            )
+
+          const art = WAD.sub((await cauldron.balances(vaultId)).art)
+          const ink = WAD.sub((await cauldron.balances(vaultId)).ink)
+          expect(art).to.equal(WAD.mul(100).div(110)) // The rate increased by a 10%, so by paying WAD base we only repay 100/110 of the debt in fyToken terms
+          expect(ink).to.equal(WAD.mul(100).div(110)) // We only pay 100/110 of the debt, so we get 100/110 of the collateral
+          expect(await base.balanceOf(owner)).to.equal(baseBalanceBefore.sub(WAD))
+          expect(await ilk.balanceOf(owner)).to.equal(ilkBalanceBefore.add(ink))
+        })
+
+        it('allows to pay all of the debt', async () => {
+          const baseBalanceBefore = await base.balanceOf(owner)
+          const ilkBalanceBefore = await ilk.balanceOf(owner)
+          await expect(witch.payAll(vaultId, WAD)).to.emit(witch, 'Bought').withArgs(vaultId, owner, WAD, WAD)
+
+          expect((await cauldron.balances(vaultId)).art).to.equal(0)
+          expect((await cauldron.balances(vaultId)).ink).to.equal(0)
+          expect(await base.balanceOf(owner)).to.equal(baseBalanceBefore.sub(WAD.mul(110).div(100)))
+          expect(await ilk.balanceOf(owner)).to.equal(ilkBalanceBefore.add(WAD))
+        })
       })
     })
   })

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -102,7 +102,6 @@ export class YieldEnvironment {
   public static async cauldronGovAuth(cauldron: Cauldron, receiver: string) {
     await cauldron.grantRoles(
       [
-        id('setAuctionInterval(uint32)'),
         id('addAsset(bytes6,address)'),
         id('addSeries(bytes6,bytes6,address)'),
         id('addIlks(bytes6,bytes6[])'),
@@ -124,14 +123,20 @@ export class YieldEnvironment {
         id('pour(bytes12,int128,int128)'),
         id('stir(bytes12,bytes12,uint128,uint128)'),
         id('roll(bytes12,bytes6,int128)'),
-        id('slurp(bytes12,uint128,uint128)'),
       ],
       receiver
     )
   }
 
   public static async cauldronWitchAuth(cauldron: Cauldron, receiver: string) {
-    await cauldron.grantRoles([id('give(bytes12,address)'), id('grab(bytes12,address)')], receiver)
+    await cauldron.grantRoles(
+      [
+        id('give(bytes12,address)'),
+        id('grab(bytes12,address)'),
+        id('slurp(bytes12,uint128,uint128)')
+      ],
+      receiver
+    )
   }
 
   public static async ladleGovAuth(ladle: LadleWrapper, receiver: string) {
@@ -164,7 +169,14 @@ export class YieldEnvironment {
   }
 
   public static async witchGovAuth(witch: Witch, receiver: string) {
-    await witch.grantRoles([id('setAuctionTime(uint128)'), id('setInitialProportion(uint128)')], receiver)
+    await witch.grantRoles(
+      [
+        id('setDuration(uint32)'),
+        id('setInitialOffer(uint64)'),
+        id('setDust(uint128)')
+      ],
+      receiver
+    )
   }
 
   // Initialize an asset for testing purposes. Gives the owner powers over it, and approves the join to take the asset from the owner.
@@ -305,9 +317,6 @@ export class YieldEnvironment {
     await this.cauldronGovAuth(cauldron, ownerAdd)
     await this.ladleGovAuth(ladle, ownerAdd)
     await this.witchGovAuth(witch, ownerAdd)
-
-    // ==== Set protection period for vaults in liquidation ====
-    await cauldron.setAuctionInterval(24 * 60 * 60)
 
     // ==== Add assets and joins ====
     for (let assetId of assetIds) {

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -1,6 +1,12 @@
+import { id, constants } from '@yield-protocol/utils-v2'
+
+import { sendStatic } from './helpers'
+
+import { Contract } from '@ethersproject/contracts'
+import { Event } from '@ethersproject/contracts/lib/index'
+import { Result } from '@ethersproject/abi'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
-import { id, constants } from '@yield-protocol/utils-v2'
 const { WAD, THREE_MONTHS, ETH, DAI, USDC } = constants
 import { CHI, RATE } from '../../src/constants'
 
@@ -304,7 +310,8 @@ export class YieldEnvironment {
     for (let assetId of assetIds) {
       const asset = assets.get(assetId) as ERC20Mock
       await wand.addAsset(assetId, asset.address)
-      const join = await ethers.getContractAt('Join', await joinFactory.calculateJoinAddress(asset.address), owner) as Join
+      const joinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(asset.address, null)))[0].args[1]
+      const join = await ethers.getContractAt('Join', joinAddress, owner) as Join
 
       await this.initAsset(owner, ladle, assetId, asset)
       joins.set(assetId, join)
@@ -312,7 +319,8 @@ export class YieldEnvironment {
 
     // Add WETH9
     await wand.addAsset(ETH, weth.address)
-    const wethJoin = await ethers.getContractAt('Join', await joinFactory.calculateJoinAddress(weth.address), owner) as Join
+    const wethJoinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(weth.address, null)))[0].args[1]
+    const wethJoin = await ethers.getContractAt('Join', wethJoinAddress, owner) as Join
 
     await this.initAsset(owner, ladle, ETH, weth)
     assets.set(ETH, weth as unknown as ERC20Mock)
@@ -321,7 +329,8 @@ export class YieldEnvironment {
 
     // Add Dai
     await wand.addAsset(DAI, dai.address)
-    const daiJoin = await ethers.getContractAt('Join', await joinFactory.calculateJoinAddress(dai.address), owner) as Join
+    const daiJoinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(dai.address, null)))[0].args[1]
+    const daiJoin = await ethers.getContractAt('Join', daiJoinAddress, owner) as Join
     
     await this.initAsset(owner, ladle, DAI, dai)
     assets.set(DAI, dai as unknown as ERC20Mock)
@@ -330,7 +339,8 @@ export class YieldEnvironment {
 
     // Add USDC
     await wand.addAsset(USDC, usdc.address)
-    const usdcJoin = await ethers.getContractAt('Join', await joinFactory.calculateJoinAddress(usdc.address), owner) as Join
+    const usdcJoinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(usdc.address, null)))[0].args[1]
+    const usdcJoin = await ethers.getContractAt('Join', usdcJoinAddress, owner) as Join
 
     await this.initAsset(owner, ladle, USDC, usdc)
     assets.set(USDC, usdc as unknown as ERC20Mock)

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -48,6 +48,7 @@ import { DAIMock } from '../../typechain/DAIMock'
 import { USDCMock } from '../../typechain/USDCMock'
 
 import { LadleWrapper } from '../../src/ladleWrapper'
+import { getLastVaultId } from '../../src/helpers'
 
 import { ethers, waffle } from 'hardhat'
 const { deployContract } = waffle
@@ -388,10 +389,8 @@ export class YieldEnvironment {
     for (let seriesId of seriesIds) {
       const seriesVaults: Map<string, string> = new Map()
       for (let ilkId of ilkIds) {
-        await cauldron.build(ownerAdd, ethers.utils.hexlify(ethers.utils.randomBytes(12)), seriesId, ilkId)
-        const vaultEvents = (await cauldron.queryFilter(cauldron.filters.VaultBuilt(null, null, null, null)))
-        const vaultId = vaultEvents[vaultEvents.length - 1].args.vaultId
-        seriesVaults.set(ilkId, vaultId)
+        await ladle.build(seriesId, ilkId)
+        seriesVaults.set(ilkId, await getLastVaultId(cauldron))
       }
       vaults.set(seriesId, seriesVaults)
     }

--- a/test/shared/helpers.ts
+++ b/test/shared/helpers.ts
@@ -2,19 +2,15 @@ import { Contract } from '@ethersproject/contracts'
 import { Signer } from '@ethersproject/abstract-signer/src.ts/index'
 
 export const sendStatic = async (
-    contractInstance: Contract,
-    contractMethod: string,
-    contractCaller: Signer,
-    contractParams: Array<any>,
-    callValue = '0'
+  contractInstance: Contract,
+  contractMethod: string,
+  contractCaller: Signer,
+  contractParams: Array<any>,
+  callValue = '0'
 ): Promise<any> => {
-    const returnValue = await contractInstance.connect(contractCaller).callStatic[contractMethod](
-        ...contractParams,
-        { value: callValue }
-    );
-    await contractInstance.connect(contractCaller)[contractMethod](
-        ...contractParams,
-        { value: callValue }
-    );
-    return returnValue;
+  const returnValue = await contractInstance
+    .connect(contractCaller)
+    .callStatic[contractMethod](...contractParams, { value: callValue })
+  await contractInstance.connect(contractCaller)[contractMethod](...contractParams, { value: callValue })
+  return returnValue
 }

--- a/test/shared/helpers.ts
+++ b/test/shared/helpers.ts
@@ -1,0 +1,20 @@
+import { Contract } from '@ethersproject/contracts'
+import { Signer } from '@ethersproject/abstract-signer/src.ts/index'
+
+export const sendStatic = async (
+    contractInstance: Contract,
+    contractMethod: string,
+    contractCaller: Signer,
+    contractParams: Array<any>,
+    callValue = '0'
+): Promise<any> => {
+    const returnValue = await contractInstance.connect(contractCaller).callStatic[contractMethod](
+        ...contractParams,
+        { value: callValue }
+    );
+    await contractInstance.connect(contractCaller)[contractMethod](
+        ...contractParams,
+        { value: callValue }
+    );
+    return returnValue;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,10 +2289,10 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
-"@yield-protocol/utils-v2@^2.2.5":
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/@yield-protocol/utils-v2/-/utils-v2-2.2.5.tgz#b6f8b8d5eee11eb664217af62587a7628fbd42c1"
-  integrity sha512-Lu8bDQgnmA9m0hhCn6ko235mm95UszIn0+qyR6tLoJ5CPaJ1qQFuQtB2iEel24Wq8WP1B8tAYdfjI7N5XXwKcA==
+"@yield-protocol/utils-v2@^2.2.10":
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/utils-v2/-/utils-v2-2.2.10.tgz#dcd89ad8fdb5d230205b46ade7ffa36eb8548c91"
+  integrity sha512-y1/f8vHlCcAHVKWuTwe3Sp6h7i7HN3EbRNVcyo9ri7m4N8aExJWy9iFi1zEIuRSQWz6mMsyi5b4aOmDt5TZ6ug==
   dependencies:
     ethereumjs-util "^7.0.8"
     ethers "^5.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,10 +2297,10 @@
     ethereumjs-util "^7.0.8"
     ethers "^5.0.7"
 
-"@yield-protocol/vault-interfaces@^2.0.35":
-  version "2.0.35"
-  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.0.35.tgz#1a6d5d8ca60039cfa5375186563f38c5456eb84b"
-  integrity sha512-xIY23pFerspk6wckyukhlDkyUzEiu+AyC8W2PpqvC4mqT1iYic51MMNn4CInIyCh34YgaVJbDhzHQ32ZccjpIQ==
+"@yield-protocol/vault-interfaces@^2.0.36":
+  version "2.0.36"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.0.36.tgz#6f896257cee9eb5cd93071533059f58e05e32980"
+  integrity sha512-vsKemfPBFE+IaMkcBzgWf1k73s0EccZNI7C7lrZLyKmlg8QxbKbr1TyeY7+Rx0Sbgoh9hgmtlbuSUDid1kGmIg==
 
 "@yield-protocol/yieldspace-interfaces@^2.0.17":
   version "2.0.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,10 +2302,10 @@
   resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.0.35.tgz#1a6d5d8ca60039cfa5375186563f38c5456eb84b"
   integrity sha512-xIY23pFerspk6wckyukhlDkyUzEiu+AyC8W2PpqvC4mqT1iYic51MMNn4CInIyCh34YgaVJbDhzHQ32ZccjpIQ==
 
-"@yield-protocol/yieldspace-interfaces@^2.0.14":
-  version "2.0.14"
-  resolved "https://registry.yarnpkg.com/@yield-protocol/yieldspace-interfaces/-/yieldspace-interfaces-2.0.14.tgz#b54adfcde6f8149b910fa77062f24ce5f62f988f"
-  integrity sha512-M/6Q++878++40en39Bl4UPkTXeYR0N+HitUJmx0qpXLrrwCML7u2pMCgGfrf6zTowcQYBPDwsG7A5n1bwzhzpA==
+"@yield-protocol/yieldspace-interfaces@^2.0.17":
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/yieldspace-interfaces/-/yieldspace-interfaces-2.0.17.tgz#69be5f01761c98c7b0d776710782e6225633c758"
+  integrity sha512-Y54fnKdFRv+3CMaYjWBMbQ79mJrGgkHJ3x8QYygwghh/D9S2/BDO7c0I9G5eu2u5XUxMz6lJXv2uuSYZ1Paw4w==
 
 abab@^2.0.0:
   version "2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,10 +2297,10 @@
     ethereumjs-util "^7.0.8"
     ethers "^5.0.7"
 
-"@yield-protocol/vault-interfaces@^2.0.33":
-  version "2.0.33"
-  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.0.33.tgz#9d76aec8698b6377713c7e0cf1add0c06ed986b5"
-  integrity sha512-GUhA5UpnVrZjaoBt1jy7yubz5pAkDkegZXSRdSpznVwmSJBMMm7hs/tF/Yfkma7Ru+30kxIVvuhYOT1Y/q8P5g==
+"@yield-protocol/vault-interfaces@^2.0.35":
+  version "2.0.35"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.0.35.tgz#1a6d5d8ca60039cfa5375186563f38c5456eb84b"
+  integrity sha512-xIY23pFerspk6wckyukhlDkyUzEiu+AyC8W2PpqvC4mqT1iYic51MMNn4CInIyCh34YgaVJbDhzHQ32ZccjpIQ==
 
 "@yield-protocol/yieldspace-interfaces@^2.0.14":
   version "2.0.14"


### PR DESCRIPTION
Fixes from the Code Arena review.
 - Check seriesId, ilkId, and vaultId can't be zero
 - Random vault ids
 - Block `stir` to the same address
 - Replace `public auth` with `external auth`
 - Make JoinFactory use `CREATE` and `wand.addAsset` deploys the Join
 - Only receive Ether from WETH
 - PoolRouter.batch returns the return values of the batch actions
 - Check for function signature collisions in CI