### PR TITLE
Rc7 clean

### DIFF
--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -270,6 +270,7 @@ contract Cauldron is AccessControl() {
         auth
         returns (DataTypes.Balances memory, DataTypes.Balances memory)
     {
+        require (from != to, "Identical vaults");
         (DataTypes.Vault memory vaultFrom, , DataTypes.Balances memory balancesFrom) = vaultData(from, false);
         (DataTypes.Vault memory vaultTo, , DataTypes.Balances memory balancesTo) = vaultData(to, false);
 

--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -177,6 +177,8 @@ contract Cauldron is AccessControl() {
         returns(DataTypes.Vault memory vault)
     {
         require (vaultId != bytes12(0), "Vault id is zero");
+        require (seriesId != bytes12(0), "Series id is zero");
+        require (ilkId != bytes12(0), "Ilk id is zero");
         require (vaults[vaultId].seriesId == bytes6(0), "Vault already exists");   // Series can't take bytes6(0) as their id
         require (ilks[seriesId][ilkId] == true, "Ilk not added to series");
         vault = DataTypes.Vault({
@@ -205,6 +207,8 @@ contract Cauldron is AccessControl() {
     function _tweak(bytes12 vaultId, DataTypes.Vault memory vault)
         internal
     {
+        require (vault.seriesId != bytes6(0), "Series id is zero");
+        require (vault.ilkId != bytes6(0), "Ilk id is zero");
         require (ilks[vault.seriesId][vault.ilkId] == true, "Ilk not added to series");
 
         vaults[vaultId] = vault;
@@ -236,6 +240,7 @@ contract Cauldron is AccessControl() {
         internal
         returns(DataTypes.Vault memory vault)
     {
+        require (vaultId != bytes12(0), "Vault id is zero");
         vault = vaults[vaultId];
         vault.owner = receiver;
         vaults[vaultId] = vault;

--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -140,7 +140,6 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit 
         join.exit(to, redeemed.u128());
         
         emit Redeemed(msg.sender, to, amount, redeemed);
-        return amount;
     }
 
     /// @dev Mint fyTokens.

--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -56,7 +56,8 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit 
         join = join_;
         maturity = maturity_;
         underlying = address(IJoin(join_).asset());
-        setOracle(oracle_);
+        oracle = oracle_;
+        emit OracleSet(address(oracle_));
     }
 
     modifier afterMaturity() {
@@ -77,7 +78,7 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit 
 
     /// @dev Set the oracle parameter
     function setOracle(IOracle oracle_)
-        public
+        external
         auth    
     {
         oracle = oracle_;

--- a/contracts/Join.sol
+++ b/contracts/Join.sol
@@ -25,8 +25,8 @@ contract Join is IJoin, IERC3156FlashLender, AccessControl() {
     uint256 public storedBalance;
     uint256 public flashFeeFactor; // Fee on flash loans, as a percentage in fixed point with 18 decimals
 
-    constructor() {
-        asset = IJoinFactory(msg.sender).nextAsset();
+    constructor(address asset_) {
+        asset = asset_;
     }
 
     /// @dev Set the flash loan fee factor

--- a/contracts/Join.sol
+++ b/contracts/Join.sol
@@ -31,7 +31,7 @@ contract Join is IJoin, IERC3156FlashLender, AccessControl() {
 
     /// @dev Set the flash loan fee factor
     function setFlashFeeFactor(uint256 flashFeeFactor_)
-        public
+        external
         auth
     {
         flashFeeFactor = flashFeeFactor_;

--- a/contracts/JoinFactory.sol
+++ b/contracts/JoinFactory.sol
@@ -7,64 +7,12 @@ import "./Join.sol";
 
 /// @dev The JoinFactory can deterministically create new join instances.
 contract JoinFactory is IJoinFactory {
-  /// Pre-hashing the bytecode allows calculateJoinAddress to be cheaper, and
-  /// makes client-side address calculation easier
-  bytes32 public constant override JOIN_BYTECODE_HASH = keccak256(type(Join).creationCode);
-
-  address private _nextAsset;
-
-  /// @dev Returns true if `account` is a contract.
-  function isContract(address account) internal view returns (bool) {
-      // This method relies on extcodesize, which returns 0 for contracts in
-      // construction, since the code is only stored at the end of the
-      // constructor execution.
-
-      uint256 size;
-      // solhint-disable-next-line no-inline-assembly
-      assembly { size := extcodesize(account) }
-      return size > 0;
-  }
-
-  /// @dev Calculate the deterministic addreess of a join, based on the asset token.
-  /// @param asset Address of the asset token.
-  /// @return The calculated join address.
-  function calculateJoinAddress(address asset) external view override returns (address) {
-    return _calculateJoinAddress(asset);
-  }
-
-  /// @dev Create2 calculation
-  function _calculateJoinAddress(address asset)
-    private view returns (address calculatedAddress)
-  {
-    calculatedAddress = address(uint160(uint256(keccak256(abi.encodePacked(
-      bytes1(0xff),
-      address(this),
-      keccak256(abi.encodePacked(asset)),
-      JOIN_BYTECODE_HASH
-    )))));
-  }
-
-  /// @dev Calculate the address of a join, and return address(0) if not deployed.
-  /// @param asset Address of the asset token.
-  /// @return join The deployed join address.
-  function getJoin(address asset) external view override returns (address join) {
-    join = _calculateJoinAddress(asset);
-
-    if(!isContract(join)) {
-      join = address(0);
-    }
-  }
 
   /// @dev Deploys a new join.
-  /// The asset address is written to a temporary storage slot to allow for simpler
-  /// address calculation, while still allowing the Join contract to store the values as
-  /// immutable.
   /// @param asset Address of the asset token.
   /// @return join The join address.
   function createJoin(address asset) external override returns (address) {
-    _nextAsset = asset;
-    Join join = new Join{salt: keccak256(abi.encodePacked(asset))}();
-    _nextAsset = address(0);
+    Join join = new Join(asset);
 
     join.grantRole(join.ROOT(), msg.sender);
     join.renounceRole(join.ROOT(), address(this));
@@ -72,11 +20,5 @@ contract JoinFactory is IJoinFactory {
     emit JoinCreated(asset, address(join));
 
     return address(join);
-  }
-
-  /// @dev Only used by the Join constructor.
-  /// @return The address token for the currently-constructing join.
-  function nextAsset() external view override returns (address) {
-    return _nextAsset;
   }
 }

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -114,6 +114,16 @@ contract Ladle is LadleStorage, AccessControl() {
 
     // ---- Batching ----
 
+    /// @dev Return the cached vault if necessary, preceded by the current vaultId (needed if vaultId == bytes(0)) and cachedId (which is the same as the vaultId)
+    /// If refreshing the cache, verifies that msg.sender is the owner of the vault
+    function getCachedVault(bytes12 vaultId, bytes12 cachedId, DataTypes.Vault memory vault)
+        private view
+        returns (bytes12, bytes12, DataTypes.Vault memory)
+    {
+        require(vaultId != bytes12(0) || cachedId != bytes12(0), "Vault not cached");           // Can't use the cache
+        if (vaultId == bytes12(0) || vaultId == cachedId) return (cachedId, cachedId, vault);   // Use the cache
+        else return (vaultId, vaultId, getOwnedVault(vaultId));                                 // Refresh the cache
+    } 
 
     /// @dev Submit a series of calls for execution.
     /// Unlike `batch`, this function calls private functions, saving a CALL per function.
@@ -132,8 +142,8 @@ contract Ladle is LadleStorage, AccessControl() {
             Operation operation = operations[i];
 
             if (operation == Operation.BUILD) {
-                (bytes12 vaultId, bytes6 seriesId, bytes6 ilkId) = abi.decode(data[i], (bytes12, bytes6, bytes6));
-                (cachedId, vault) = (vaultId, _build(vaultId, seriesId, ilkId));   // Cache the vault that was just built
+                (bytes6 seriesId, bytes6 ilkId) = abi.decode(data[i], (bytes6, bytes6));
+                (cachedId, vault) = _build(seriesId, ilkId, 0);   // Cache the vault that was just built
             
             } else if (operation == Operation.FORWARD_PERMIT) {
                 (bytes6 id, bool isAsset, address spender, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) =
@@ -146,17 +156,17 @@ contract Ladle is LadleStorage, AccessControl() {
             
             } else if (operation == Operation.POUR) {
                 (bytes12 vaultId, address to, int128 ink, int128 art) = abi.decode(data[i], (bytes12, address, int128, int128));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _pour(vaultId, vault, to, ink, art);
             
             } else if (operation == Operation.SERVE) {
                 (bytes12 vaultId, address to, uint128 ink, uint128 base, uint128 max) = abi.decode(data[i], (bytes12, address, uint128, uint128, uint128));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _serve(vaultId, vault, to, ink, base, max);
 
             } else if (operation == Operation.ROLL) {
                 (bytes12 vaultId, bytes6 newSeriesId, uint8 loan, uint128 max) = abi.decode(data[i], (bytes12, bytes6, uint8, uint128));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 (vault,) = _roll(vaultId, vault, newSeriesId, loan, max);
             
             } else if (operation == Operation.FORWARD_DAI_PERMIT) {
@@ -182,22 +192,22 @@ contract Ladle is LadleStorage, AccessControl() {
             
             } else if (operation == Operation.CLOSE) {
                 (bytes12 vaultId, address to, int128 ink, int128 art) = abi.decode(data[i], (bytes12, address, int128, int128));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _close(vaultId, vault, to, ink, art);
             
             } else if (operation == Operation.REPAY) {
                 (bytes12 vaultId, address to, int128 ink, uint128 min) = abi.decode(data[i], (bytes12, address, int128, uint128));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _repay(vaultId, vault, to, ink, min);
             
             } else if (operation == Operation.REPAY_VAULT) {
                 (bytes12 vaultId, address to, int128 ink, uint128 max) = abi.decode(data[i], (bytes12, address, int128, uint128));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _repayVault(vaultId, vault, to, ink, max);
 
             } else if (operation == Operation.REPAY_LADLE) {
                 (bytes12 vaultId) = abi.decode(data[i], (bytes12));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _repayLadle(vaultId, vault);
 
             } else if (operation == Operation.RETRIEVE) {
@@ -220,19 +230,19 @@ contract Ladle is LadleStorage, AccessControl() {
             
             } else if (operation == Operation.TWEAK) {
                 (bytes12 vaultId, bytes6 seriesId, bytes6 ilkId) = abi.decode(data[i], (bytes12, bytes6, bytes6));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
                 vault = _tweak(vaultId, seriesId, ilkId);
 
             } else if (operation == Operation.GIVE) {
                 (bytes12 vaultId, address to) = abi.decode(data[i], (bytes12, address));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
                 vault = _give(vaultId, to);
                 delete vault;   // Clear the cache, since the vault doesn't necessarily belong to msg.sender anymore
                 cachedId = bytes12(0);
 
             } else if (operation == Operation.DESTROY) {
                 (bytes12 vaultId) = abi.decode(data[i], (bytes12));
-                if (cachedId != vaultId) (cachedId, vault) = (vaultId, getOwnedVault(vaultId));
+                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
                 _destroy(vaultId);
                 delete vault;   // Clear the cache
                 cachedId = bytes12(0);
@@ -247,12 +257,22 @@ contract Ladle is LadleStorage, AccessControl() {
 
     // ---- Vault management ----
 
+    /// @dev Generate a vaultId. A keccak256 is cheaper than using a counter with a SSTORE, even accounting for eventual collision retries.
+    function _generateVaultId(uint8 salt) private view returns (bytes12) {
+        return bytes12(keccak256(abi.encodePacked(msg.sender, block.timestamp, salt)));
+    }
+
     /// @dev Create a new vault, linked to a series (and therefore underlying) and a collateral
-    function _build(bytes12 vaultId, bytes6 seriesId, bytes6 ilkId)
+    function _build(bytes6 seriesId, bytes6 ilkId, uint8 salt)
         private
-        returns(DataTypes.Vault memory vault)
+        returns(bytes12, DataTypes.Vault memory)
     {
-        return cauldron.build(msg.sender, vaultId, seriesId, ilkId);
+        bytes12 vaultId = _generateVaultId(salt);
+        try cauldron.build(msg.sender, vaultId, seriesId, ilkId) returns (DataTypes.Vault memory vault) {
+            return (vaultId, vault);
+        } catch Error (string memory) {
+            return _build(seriesId, ilkId, salt + 1);
+        }
     }
 
     /// @dev Change a vault series or collateral.
@@ -520,7 +540,9 @@ contract Ladle is LadleStorage, AccessControl() {
     // ---- Ether management ----
 
     /// @dev The WETH9 contract will send ether to BorrowProxy on `weth.withdraw` using this function.
-    receive() external payable { }
+    receive() external payable { 
+        require (msg.sender == address(weth), "Only receive from WETH");
+    }
 
     /// @dev Accept Ether, wrap it and forward it to the WethJoin
     /// This function should be called first in a batch, and the Join should keep track of stored reserves
@@ -586,6 +608,8 @@ contract Ladle is LadleStorage, AccessControl() {
     // ---- Module router ----
 
     /// @dev Allow users to use functionality coded in a module, to be used with batch
+    /// @notice Modules must not do any changes to the vault (owner, seriesId, ilkId),
+    /// it would be disastrous in combination with batch vault caching 
     function _moduleCall(address module, bytes memory moduleCall)
         private
         returns (bool success, bytes memory result)
@@ -594,4 +618,5 @@ contract Ladle is LadleStorage, AccessControl() {
         (success, result) = module.delegatecall(moduleCall);
         if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
     }
+
 }

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -105,7 +105,7 @@ contract Ladle is LadleStorage, AccessControl() {
 
     /// @dev Set the fee parameter
     function setFee(uint256 fee)
-        public
+        external
         auth    
     {
         borrowingFee = fee;

--- a/contracts/Wand.sol
+++ b/contracts/Wand.sol
@@ -46,7 +46,7 @@ contract Wand is AccessControl {
     function addAsset(
         bytes6 assetId,
         address asset
-    ) public auth {
+    ) external auth {
         // Add asset to cauldron, deploy new Join, and add it to the ladle
         require (address(asset) != address(0), "Asset required");
         cauldron.addAsset(assetId, asset);
@@ -62,7 +62,7 @@ contract Wand is AccessControl {
 
     /// @dev Make a base asset out of a generic asset, by adding rate and chi oracles.
     /// This assumes CompoundMultiOracles, which deliver both rate and chi.
-    function makeBase(bytes6 assetId, IMultiOracleGov oracle, address rateSource, address chiSource) public auth {
+    function makeBase(bytes6 assetId, IMultiOracleGov oracle, address rateSource, address chiSource) external auth {
         require (address(oracle) != address(0), "Oracle required");
         require (rateSource != address(0), "Rate source required");
         require (chiSource != address(0), "Chi source required");
@@ -73,7 +73,7 @@ contract Wand is AccessControl {
     }
 
     /// @dev Make an ilk asset out of a generic asset, by adding a spot oracle against a base asset, collateralization ratio, and debt ceiling.
-    function makeIlk(bytes6 baseId, bytes6 ilkId, IMultiOracleGov oracle, address spotSource, uint32 ratio, uint96 max, uint24 min, uint8 dec) public auth {
+    function makeIlk(bytes6 baseId, bytes6 ilkId, IMultiOracleGov oracle, address spotSource, uint32 ratio, uint96 max, uint24 min, uint8 dec) external auth {
         oracle.setSource(baseId, ilkId, spotSource);
         cauldron.setSpotOracle(baseId, ilkId, IOracle(address(oracle)), ratio);
         cauldron.setDebtLimits(baseId, ilkId, max, min, dec);
@@ -88,7 +88,7 @@ contract Wand is AccessControl {
         bytes6[] memory ilkIds,
         string memory name,
         string memory symbol
-    ) public auth {
+    ) external auth {
         address base = cauldron.assets(baseId);
         require(base != address(0), "Base not found");
 

--- a/contracts/Witch.sol
+++ b/contracts/Witch.sol
@@ -34,13 +34,13 @@ contract Witch is AccessControl() {
     }
 
     /// @dev Set the auction time to calculate liquidation prices
-    function setAuctionTime(uint128 auctionTime_) public auth {
+    function setAuctionTime(uint128 auctionTime_) external auth {
         auctionTime = auctionTime_;
         emit AuctionTimeSet(auctionTime_);
     }
 
     /// @dev Set the proportion of the collateral that will be sold at auction start
-    function setInitialProportion(uint128 initialProportion_) public auth {
+    function setInitialProportion(uint128 initialProportion_) external auth {
         require (initialProportion_ <= 1e18, "Only at or under 100%");
         initialProportion = initialProportion_;
         emit InitialProportionSet(initialProportion_);

--- a/contracts/mocks/RestrictedERC20Mock.sol
+++ b/contracts/mocks/RestrictedERC20Mock.sol
@@ -11,12 +11,12 @@ contract RestrictedERC20Mock is AccessControl(), ERC20Permit  {
     ) ERC20Permit(name, symbol, 18) { }
 
     /// @dev Give tokens to whoever.
-    function mint(address to, uint256 amount) public virtual auth {
+    function mint(address to, uint256 amount) external virtual auth {
         _mint(to, amount);
     }
 
     /// @dev Burn tokens from whoever.
-    function burn(address from, uint256 amount) public virtual auth {
+    function burn(address from, uint256 amount) external virtual auth {
         _burn(from, amount);
     }
 }

--- a/contracts/oracles/compound/CompoundMultiOracle.sol
+++ b/contracts/oracles/compound/CompoundMultiOracle.sol
@@ -19,37 +19,17 @@ contract CompoundMultiOracle is IOracle, AccessControl {
     /**
      * @notice Set or reset one source
      */
-    function setSource(bytes6 base, bytes6 kind, address source) public auth {
-        sources[base][kind] = source;
-        emit SourceSet(base, kind, source);
+    function setSource(bytes6 base, bytes6 kind, address source) external auth {
+        _setSource(base, kind, source);
     }
 
     /**
      * @notice Set or reset an oracle source
      */
-    function setSources(bytes6[] memory bases, bytes6[] memory kinds, address[] memory sources_) public auth {
+    function setSources(bytes6[] memory bases, bytes6[] memory kinds, address[] memory sources_) external auth {
         require(bases.length == kinds.length && kinds.length == sources_.length, "Mismatched inputs");
         for (uint256 i = 0; i < bases.length; i++)
-            setSource(bases[i], kinds[i], sources_[i]);
-    }
-
-    /**
-     * @notice Retrieve the latest price of a given source.
-     * @return price
-     */
-    function _peek(bytes6 base, bytes6 kind) private view returns (uint price, uint updateTime) {
-        uint256 rawPrice;
-        address source = sources[base][kind];
-        require (source != address(0), "Source not found");
-
-        if (kind == "rate") rawPrice = CTokenInterface(source).borrowIndex();
-        else if (kind == "chi") rawPrice = CTokenInterface(source).exchangeRateStored();
-        else revert("Unknown oracle type");
-
-        require(rawPrice > 0, "Compound price is zero");
-
-        price = rawPrice * SCALE_FACTOR;
-        updateTime = block.timestamp;
+            _setSource(bases[i], kinds[i], sources_[i]);
     }
 
     /**
@@ -70,5 +50,25 @@ contract CompoundMultiOracle is IOracle, AccessControl {
         uint256 price;
         (price, updateTime) = _peek(base.b6(), kind.b6());
         value = price * amount / 1e18;
+    }
+
+    function _peek(bytes6 base, bytes6 kind) private view returns (uint price, uint updateTime) {
+        uint256 rawPrice;
+        address source = sources[base][kind];
+        require (source != address(0), "Source not found");
+
+        if (kind == "rate") rawPrice = CTokenInterface(source).borrowIndex();
+        else if (kind == "chi") rawPrice = CTokenInterface(source).exchangeRateStored();
+        else revert("Unknown oracle type");
+
+        require(rawPrice > 0, "Compound price is zero");
+
+        price = rawPrice * SCALE_FACTOR;
+        updateTime = block.timestamp;
+    }
+
+    function _setSource(bytes6 base, bytes6 kind, address source) internal {
+        sources[base][kind] = source;
+        emit SourceSet(base, kind, source);
     }
 }

--- a/contracts/oracles/uniswap/UniswapV3Oracle.sol
+++ b/contracts/oracles/uniswap/UniswapV3Oracle.sol
@@ -37,7 +37,7 @@ contract UniswapV3Oracle is IOracle, AccessControl {
     /**
      * @notice Set or reset the number of seconds Uniswap will use for its Time Weighted Average Price computation
      */
-    function setSecondsAgo(uint32 secondsAgo_) public auth {
+    function setSecondsAgo(uint32 secondsAgo_) external auth {
         require(secondsAgo_ != 0, "Uniswap must look into the past.");
         secondsAgo = secondsAgo_;
         emit SecondsAgoSet(secondsAgo_);
@@ -46,44 +46,18 @@ contract UniswapV3Oracle is IOracle, AccessControl {
     /**
      * @notice Set or reset an oracle source and its inverse
      */
-    function setSource(bytes6 base, bytes6 quote, address source) public auth {
-        sources[base][quote] = Source(source, false);
-        sources[quote][base] = Source(source, true);
-        sourcesData[source] = SourceData(
-            IUniswapV3PoolImmutables(source).factory(),
-            IUniswapV3PoolImmutables(source).token0(),
-            IUniswapV3PoolImmutables(source).token1(),
-            IUniswapV3PoolImmutables(source).fee()
-        );
-        emit SourceSet(base, quote, source);
-        emit SourceSet(quote, base, source);
+    function setSource(bytes6 base, bytes6 quote, address source) external auth {
+        _setSource(base, quote, source);
     }
 
     /**
      * @notice Set or reset a number of oracle sources
      */
-    function setSources(bytes6[] memory bases, bytes6[] memory quotes, address[] memory sources_) public auth {
+    function setSources(bytes6[] memory bases, bytes6[] memory quotes, address[] memory sources_) external auth {
         require(bases.length == quotes.length && quotes.length == sources_.length, "Mismatched inputs");
         for (uint256 i = 0; i < bases.length; i++) {
-            setSource(bases[i], quotes[i], sources_[i]);
+            _setSource(bases[i], quotes[i], sources_[i]);
         }
-    }
-
-    /**
-     * @notice Retrieve the value of the amount at the latest oracle price.
-     * @return value
-     */
-    function _peek(bytes6 base, bytes6 quote, uint256 amount) public virtual view returns (uint256 value, uint256 updateTime) {
-        Source memory source = sources[base][quote];
-        SourceData memory sourceData;
-        require(source.source != address(0), "Source not found");
-        sourceData = sourcesData[source.source];
-        if (source.inverse) {
-            value = UniswapV3OracleLibraryMock.consult(sourceData.factory, sourceData.quoteToken, sourceData.baseToken, sourceData.fee, amount, secondsAgo);
-        } else {
-            value = UniswapV3OracleLibraryMock.consult(sourceData.factory, sourceData.baseToken, sourceData.quoteToken, sourceData.fee, amount, secondsAgo);
-        }
-        updateTime = block.timestamp - secondsAgo;
     }
 
     /**
@@ -100,5 +74,31 @@ contract UniswapV3Oracle is IOracle, AccessControl {
      */
     function get(bytes32 base, bytes32 quote, uint256 amount) public virtual override view returns (uint256 value, uint256 updateTime) {
         return _peek(base.b6(), quote.b6(), amount);
+    }
+
+    function _peek(bytes6 base, bytes6 quote, uint256 amount) public virtual view returns (uint256 value, uint256 updateTime) {
+        Source memory source = sources[base][quote];
+        SourceData memory sourceData;
+        require(source.source != address(0), "Source not found");
+        sourceData = sourcesData[source.source];
+        if (source.inverse) {
+            value = UniswapV3OracleLibraryMock.consult(sourceData.factory, sourceData.quoteToken, sourceData.baseToken, sourceData.fee, amount, secondsAgo);
+        } else {
+            value = UniswapV3OracleLibraryMock.consult(sourceData.factory, sourceData.baseToken, sourceData.quoteToken, sourceData.fee, amount, secondsAgo);
+        }
+        updateTime = block.timestamp - secondsAgo;
+    }
+
+    function _setSource(bytes6 base, bytes6 quote, address source) internal {
+        sources[base][quote] = Source(source, false);
+        sources[quote][base] = Source(source, true);
+        sourcesData[source] = SourceData(
+            IUniswapV3PoolImmutables(source).factory(),
+            IUniswapV3PoolImmutables(source).token0(),
+            IUniswapV3PoolImmutables(source).token1(),
+            IUniswapV3PoolImmutables(source).fee()
+        );
+        emit SourceSet(base, quote, source);
+        emit SourceSet(quote, base, source);
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,6 +33,27 @@ task(
   }
 );
 
+task("lint:collisions", "Checks all contracts for function signatures collisions with ROOT (0x00000000) and LOCK (0xffffffff)",
+  async (taskArguments, hre, runSuper) => {
+    let ROOT = "0x00000000"
+    let LOCK = "0xffffffff"
+    const abiPath = path.join(__dirname, 'abi')
+    for (let contract of fs.readdirSync(abiPath)) {
+      const iface = new hre.ethers.utils.Interface(require(abiPath + "/" + contract))
+      for (let func in iface.functions) {
+        const sig = iface.getSighash(func)
+        if (sig == ROOT) {
+          console.error("Function " + func + " of contract " + contract.slice(0, contract.length - 5) + " has a role-colliding signature with ROOT.")
+        }
+        if (sig == LOCK) {
+          console.error("Function " + func + " of contract " + contract.slice(0, contract.length - 5) + " has a role-colliding signature with LOCK.")
+        }
+      }
+    }
+    console.log("No collisions, check passed.")
+  }
+)
+
 function nodeUrl(network: any) {
   let infuraKey
   try {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -54,7 +54,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 5000,
+        runs: 2500,
       }
     }
   },
@@ -75,7 +75,7 @@ module.exports = {
     disambiguatePaths: false,
   },
   gasReporter: {
-    enabled: true,
+    enabled: false,
   },
   defaultNetwork: 'hardhat',
   namedAccounts: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,6 +10,10 @@ import 'hardhat-typechain'
 import 'solidity-coverage'
 import 'hardhat-deploy'
 
+import { task } from 'hardhat/config'
+import { TASK_TEST } from 'hardhat/builtin-tasks/task-names'
+import { TaskArguments, HardhatRuntimeEnvironment, RunSuperFunction } from 'hardhat/types'
+
 // REQUIRED TO ENSURE METADATA IS SAVED IN DEPLOYMENTS (because solidity-coverage disable it otherwise)
 /* import {
   TASK_COMPILE_GET_COMPILER_INPUT
@@ -20,6 +24,14 @@ task(TASK_COMPILE_GET_COMPILER_INPUT).setAction(async (_, bre, runSuper) => {
   return input
 }) */
 
+// Periodically, one needs to remove the 'artifacts' and 'typechain' folder (and hence, do a yarn build). Yet, if running yarn build, the tests shouldn't run the compilation again, so the hook below accomplishes just that.
+task(
+  TASK_TEST,
+  "Runs the tests",
+  async (args: TaskArguments, hre: HardhatRuntimeEnvironment, runSuper: RunSuperFunction<TaskArguments>) => {
+    return runSuper({...args, noCompile: true});
+  }
+);
 
 function nodeUrl(network: any) {
   let infuraKey

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "yarn build && hardhat test --show-stack-traces",
     "test:deploy": "hardhat deploy --tags DeployTest",
     "coverage": "hardhat coverage",
-    "lint:sol": "solhint -f table contracts/*.sol",
+    "lint:collisions": "yarn build && hardhat lint:collisions",
+    "lint:sol": "yarn lint:collisions && solhint -f table contracts/*.sol",
     "lint:ts": "prettier ./test/*.ts --check",
     "lint:ts:fix": "prettier ./test/*.ts --write",
     "prepublishOnly": "npx tsdx build --tsconfig ./tsconfig-publish.json"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf artifacts typechain && hardhat compile",
-    "test": "hardhat test --show-stack-traces",
+    "test": "yarn build && hardhat test --show-stack-traces",
     "test:deploy": "hardhat deploy --tags DeployTest",
     "coverage": "hardhat coverage",
     "lint:sol": "solhint -f table contracts/*.sol",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "build": "rm -rf artifacts typechain && hardhat compile",
-    "test": "hardhat test",
+    "test": "hardhat test --show-stack-traces",
     "test:deploy": "hardhat deploy --tags DeployTest",
     "coverage": "hardhat coverage",
     "lint:sol": "solhint -f table contracts/*.sol",
@@ -31,7 +31,7 @@
     "@truffle/hdwallet-provider": "^1.0.40",
     "@types/mocha": "^8.0.0",
     "@yield-protocol/utils-v2": "^2.2.5",
-    "@yield-protocol/vault-interfaces": "^2.0.33",
+    "@yield-protocol/vault-interfaces": "^2.0.35",
     "@yield-protocol/yieldspace-interfaces": "^2.0.14",
     "chai": "4.2.0",
     "dss-interfaces": "0.1.1",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,7 @@
+import { Cauldron } from '../typechain/Cauldron'
+
+export async function getLastVaultId(cauldron: Cauldron): Promise<string> {
+  const logs = await cauldron.queryFilter(cauldron.filters.VaultBuilt(null, null, null, null))
+  const event = logs[logs.length - 1]
+  return event.args.vaultId
+}

--- a/src/ladleWrapper.ts
+++ b/src/ladleWrapper.ts
@@ -87,12 +87,12 @@ export class LadleWrapper {
     else return this.ladle.batch(ops, data, overrides)
   }
 
-  public buildAction(vaultId: string, seriesId: string, ilkId: string): BatchAction {
-    return new BatchAction(OPS.BUILD, ethers.utils.defaultAbiCoder.encode(['bytes12', 'bytes6', 'bytes6'], [vaultId, seriesId, ilkId]))
+  public buildAction(seriesId: string, ilkId: string): BatchAction {
+    return new BatchAction(OPS.BUILD, ethers.utils.defaultAbiCoder.encode(['bytes6', 'bytes6'], [seriesId, ilkId]))
   }
 
-  public async build(vaultId: string, seriesId: string, ilkId: string): Promise<ContractTransaction> {
-    return this.batch([this.buildAction(vaultId, seriesId, ilkId)])
+  public async build(seriesId: string, ilkId: string): Promise<ContractTransaction> {
+    return this.batch([this.buildAction(seriesId, ilkId)])
   }
 
   public tweakAction(vaultId: string, seriesId: string, ilkId: string): BatchAction {

--- a/test/011_oracles.ts
+++ b/test/011_oracles.ts
@@ -2,7 +2,11 @@ import { constants, id } from '@yield-protocol/utils-v2'
 const { WAD } = constants
 import { CHI, RATE } from '../src/constants'
 
+import { sendStatic } from './shared/helpers'
+
+import { Contract } from '@ethersproject/contracts'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+
 import OracleArtifact from '../artifacts/contracts/mocks/oracles/OracleMock.sol/OracleMock.json'
 import ChainlinkMultiOracleArtifact from '../artifacts/contracts/oracles/chainlink/ChainlinkMultiOracle.sol/ChainlinkMultiOracle.json'
 import CompoundMultiOracleArtifact from '../artifacts/contracts/oracles/compound/CompoundMultiOracle.sol/CompoundMultiOracle.json'
@@ -84,8 +88,7 @@ describe('Oracle', function () {
     uniswapV3Factory = (await deployContract(ownerAcc, UniswapV3FactoryMockArtifact, [])) as UniswapV3FactoryMock
     const token0: string = ethers.utils.HDNode.fromSeed('0x0123456789abcdef0123456789abcdef').address
     const token1: string = ethers.utils.HDNode.fromSeed('0xfedcba9876543210fedcba9876543210').address
-    uniswapV3PoolAddress = await uniswapV3Factory.callStatic.createPool(token0, token1, 0)
-    await uniswapV3Factory.createPool(token0, token1, 0)
+    uniswapV3PoolAddress = await sendStatic(uniswapV3Factory as Contract, 'createPool', ownerAcc, [token0, token1, 0])
     uniswapV3Pool = (await ethers.getContractAt('UniswapV3PoolMock', uniswapV3PoolAddress)) as UniswapV3PoolMock
     uniswapV3Oracle = (await deployContract(ownerAcc, UniswapV3OracleArtifact, [])) as UniswapV3Oracle
     uniswapV3Oracle.grantRole(id('setSources(bytes6[],bytes6[],address[])'), owner)

--- a/test/021_join.ts
+++ b/test/021_join.ts
@@ -1,5 +1,12 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 import { constants, id } from '@yield-protocol/utils-v2'
+
+import { sendStatic } from './shared/helpers'
+
+import { Contract } from '@ethersproject/contracts'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { Event } from '@ethersproject/contracts/lib/index'
+import { Result } from '@ethersproject/abi'
+
 const { WAD, MAX256 } = constants
 const MAX = MAX256
 
@@ -39,9 +46,11 @@ describe('Join', function () {
     token = (await deployContract(ownerAcc, ERC20MockArtifact, ['MTK', 'Mock Token'])) as ERC20Mock
     otherToken = (await deployContract(ownerAcc, ERC20MockArtifact, ['OTH', 'Other Token'])) as ERC20Mock
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
-    const joinAddress = await joinFactory.calculateJoinAddress(token.address) // Get the address
-    await joinFactory.createJoin(token.address) // Create the Join (doesn't return anything outside a contract call)
-    join = (await ethers.getContractAt('Join', joinAddress, ownerAcc)) as Join
+    join = (await ethers.getContractAt(
+      'Join',
+      await sendStatic(joinFactory as Contract, 'createJoin', ownerAcc, [token.address]),
+      ownerAcc
+    )) as Join
 
     await join.grantRoles(
       [id('join(address,uint128)'), id('exit(address,uint128)'), id('retrieve(address,address)')],

--- a/test/031_fyToken.ts
+++ b/test/031_fyToken.ts
@@ -57,6 +57,7 @@ describe('FYToken', function () {
     chiSource = (await ethers.getContractAt('ISourceMock', await chiOracle.sources(baseId, CHI))) as ISourceMock
 
     await baseJoin.grantRoles([id('join(address,uint128)'), id('exit(address,uint128)')], fyToken.address)
+    await baseJoin.grantRoles([id('join(address,uint128)'), id('exit(address,uint128)')], owner)
 
     await fyToken.grantRoles(
       [id('mint(address,uint256)'), id('burn(address,uint256)'), id('setOracle(address)')],
@@ -109,7 +110,9 @@ describe('FYToken', function () {
     it('matures if needed on first redemption after maturity', async () => {
       const baseOwnerBefore = await base.balanceOf(owner)
       const baseJoinBefore = await base.balanceOf(baseJoin.address)
-      await expect(fyToken.redeem(owner, WAD)).to.emit(fyToken, 'Redeemed').withArgs(owner, owner, WAD, WAD)
+      expect(await fyToken.redeem(owner, WAD))
+        .to.emit(fyToken, 'Redeemed')
+        .withArgs(owner, owner, WAD, WAD)
       expect(await base.balanceOf(baseJoin.address)).to.equal(baseJoinBefore.sub(WAD))
       expect(await base.balanceOf(owner)).to.equal(baseOwnerBefore.add(WAD))
       expect(await fyToken.balanceOf(owner)).to.equal(0)

--- a/test/051_cauldron_admin.ts
+++ b/test/051_cauldron_admin.ts
@@ -1,5 +1,11 @@
-import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 import { id } from '@yield-protocol/utils-v2'
+
+import { sendStatic } from './shared/helpers'
+
+import { Contract } from '@ethersproject/contracts'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { Event } from '@ethersproject/contracts/lib/index'
+import { Result } from '@ethersproject/abi'
 
 import CauldronArtifact from '../artifacts/contracts/Cauldron.sol/Cauldron.json'
 import JoinFactoryArtifact from '../artifacts/contracts/JoinFactory.sol/JoinFactory.json'
@@ -56,9 +62,11 @@ describe('Cauldron - admin', function () {
     ilk1 = (await deployContract(ownerAcc, ERC20MockArtifact, [ilkId1, 'Mock Ilk'])) as ERC20Mock
     ilk2 = (await deployContract(ownerAcc, ERC20MockArtifact, [ilkId2, 'Mock Ilk'])) as ERC20Mock
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
-    const joinAddress = await joinFactory.calculateJoinAddress(base.address) // Get the address
-    await joinFactory.createJoin(base.address) // Create the Join (doesn't return anything outside a contract call)
-    join = (await ethers.getContractAt('Join', joinAddress, ownerAcc)) as Join
+    join = (await ethers.getContractAt(
+      'Join',
+      await sendStatic(joinFactory as Contract, 'createJoin', ownerAcc, [base.address]),
+      ownerAcc
+    )) as Join
     fyToken = (await deployContract(ownerAcc, FYTokenArtifact, [
       baseId,
       base.address,

--- a/test/054_cauldron_stir.ts
+++ b/test/054_cauldron_stir.ts
@@ -62,6 +62,10 @@ describe('Cauldron - stir', function () {
     await cauldron.build(owner, vaultToId, seriesId, ilkId)
   })
 
+  it('does not allow moving collateral or debt from and to the same vault', async () => {
+    await expect(cauldron.stir(vaultFromId, vaultFromId, WAD, WAD)).to.be.revertedWith('Identical vaults')
+  })
+
   it('does not allow moving collateral or debt to an uninitialized vault', async () => {
     await expect(cauldron.stir(mockVaultId, vaultToId, WAD, 0)).to.be.revertedWith('Vault not found')
     await expect(cauldron.stir(vaultFromId, mockVaultId, WAD, 0)).to.be.revertedWith('Vault not found')

--- a/test/060_ladle_admin.ts
+++ b/test/060_ladle_admin.ts
@@ -1,6 +1,12 @@
+import { constants, id } from '@yield-protocol/utils-v2'
+
+import { sendStatic } from './shared/helpers'
+
+import { Contract } from '@ethersproject/contracts'
+import { Event } from '@ethersproject/contracts/lib/index'
+import { Result } from '@ethersproject/abi'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
-import { constants, id } from '@yield-protocol/utils-v2'
 const { WAD, THREE_MONTHS } = constants
 import { RATE } from '../src/constants'
 
@@ -93,9 +99,11 @@ describe('Ladle - admin', function () {
 
     // Deploy a join
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
-    const joinAddress = await joinFactory.calculateJoinAddress(ilk.address) // Get the address
-    await joinFactory.createJoin(ilk.address) // Create the Join (doesn't return anything outside a contract call)
-    ilkJoin = (await ethers.getContractAt('Join', joinAddress, ownerAcc)) as Join
+    ilkJoin = (await ethers.getContractAt(
+      'Join',
+      await sendStatic(joinFactory as Contract, 'createJoin', ownerAcc, [ilk.address]),
+      ownerAcc
+    )) as Join
     await ilkJoin.grantRoles([id('join(address,uint128)'), id('exit(address,uint128)')], ladle.address)
 
     // Deploy a series

--- a/test/063_ladle_vaults.ts
+++ b/test/063_ladle_vaults.ts
@@ -55,9 +55,14 @@ describe('Ladle - vaults', function () {
   })
 
   it('builds a vault', async () => {
-    await expect(ladle.build(otherVaultId, seriesId, ilkId))
-      .to.emit(cauldron, 'VaultBuilt')
-      .withArgs(otherVaultId, owner, seriesId, ilkId)
+    await expect(ladle.build(seriesId, ilkId)).to.emit(cauldron, 'VaultBuilt')
+
+    const logs = await cauldron.queryFilter(cauldron.filters.VaultBuilt(null, null, null, null))
+    const event = logs[logs.length - 1]
+    const otherVaultId = event.args.vaultId
+    expect(event.args.owner).to.equal(owner)
+    expect(event.args.seriesId).to.equal(seriesId)
+    expect(event.args.ilkId).to.equal(ilkId)
 
     const vault = await cauldron.vaults(otherVaultId)
     expect(vault.owner).to.equal(owner)

--- a/test/064_ladle_stir.ts
+++ b/test/064_ladle_stir.ts
@@ -13,6 +13,7 @@ const { loadFixture } = waffle
 
 import { YieldEnvironment } from './shared/fixtures'
 import { LadleWrapper } from '../src/ladleWrapper'
+import { getLastVaultId } from '../src/helpers'
 
 describe('Ladle - stir', function () {
   this.timeout(0)
@@ -44,8 +45,8 @@ describe('Ladle - stir', function () {
   const baseId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const ilkId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const seriesId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
-  const vaultToId = ethers.utils.hexlify(ethers.utils.randomBytes(12))
   const otherIlkId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
+  let vaultToId: string
 
   let vaultFromId: string
 
@@ -60,7 +61,8 @@ describe('Ladle - stir', function () {
     vaultFromId = (env.vaults.get(seriesId) as Map<string, string>).get(ilkId) as string
 
     // ==== Set testing environment ====
-    await ladle.build(vaultToId, seriesId, ilkId)
+    await ladle.build(seriesId, ilkId)
+    vaultToId = await getLastVaultId(cauldron)
   })
 
   it('does not allow moving collateral other than to the origin vault owner', async () => {

--- a/test/066_remove_and_repay.ts
+++ b/test/066_remove_and_repay.ts
@@ -1,6 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
-import { constants } from '@yield-protocol/utils-v2'
+import { constants, id } from '@yield-protocol/utils-v2'
 const { WAD, MAX128 } = constants
 const MAX = MAX128
 
@@ -63,6 +63,8 @@ describe('Ladle - remove and repay', function () {
     pool = env.pools.get(seriesId) as PoolMock
 
     vaultId = (env.vaults.get(seriesId) as Map<string, string>).get(ilkId) as string
+
+    await baseJoin.grantRoles([id('join(address,uint128)'), id('exit(address,uint128)')], owner)
 
     // Borrow and add liquidity
     await ladle.serve(vaultId, pool.address, WAD, WAD, MAX)

--- a/test/068_ladle_eth.ts
+++ b/test/068_ladle_eth.ts
@@ -76,6 +76,12 @@ describe('Ladle - eth', function () {
     await ladle.batch([ladle.joinEtherAction(ethId), ladle.pourAction(ethVaultId, owner, WAD, 0)], { value: WAD })
   })
 
+  it('ladle will only receive from WETH', async () => {
+    await expect(ownerAcc.sendTransaction({ to: ladle.address, value: WAD })).to.be.revertedWith(
+      'Only receive from WETH'
+    )
+  })
+
   describe('with ETH posted', async () => {
     beforeEach(async () => {
       expect(await ladle.joinEther(ethId, { value: WAD }))

--- a/test/069_ladle_permit.ts
+++ b/test/069_ladle_permit.ts
@@ -118,7 +118,7 @@ describe('Ladle - permit', function () {
 
     expect(
       await ladle.batch([
-        ladle.buildAction(vaultId, seriesId, ilkId),
+        ladle.buildAction(seriesId, ilkId),
         ladle.forwardPermitAction(seriesId, false, ladle.address, amount, deadline, v, r, s),
       ])
     )
@@ -165,7 +165,7 @@ describe('Ladle - permit', function () {
 
     expect(
       await ladle.batch([
-        ladle.buildAction(vaultId, seriesId, ilkId),
+        ladle.buildAction(seriesId, ilkId),
         ladle.forwardDaiPermitAction(DAI, true, ladle.address, nonce, deadline, true, v, r, s),
       ])
     )

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -1,6 +1,12 @@
+import { id, constants } from '@yield-protocol/utils-v2'
+
+import { sendStatic } from './helpers'
+
+import { Contract } from '@ethersproject/contracts'
+import { Event } from '@ethersproject/contracts/lib/index'
+import { Result } from '@ethersproject/abi'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 
-import { id, constants } from '@yield-protocol/utils-v2'
 const { WAD, THREE_MONTHS, ETH, DAI, USDC } = constants
 import { CHI, RATE } from '../../src/constants'
 
@@ -304,7 +310,8 @@ export class YieldEnvironment {
     for (let assetId of assetIds) {
       const asset = assets.get(assetId) as ERC20Mock
       await wand.addAsset(assetId, asset.address)
-      const join = await ethers.getContractAt('Join', await joinFactory.calculateJoinAddress(asset.address), owner) as Join
+      const joinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(asset.address, null)))[0].args[1]
+      const join = await ethers.getContractAt('Join', joinAddress, owner) as Join
 
       await this.initAsset(owner, ladle, assetId, asset)
       joins.set(assetId, join)
@@ -312,7 +319,8 @@ export class YieldEnvironment {
 
     // Add WETH9
     await wand.addAsset(ETH, weth.address)
-    const wethJoin = await ethers.getContractAt('Join', await joinFactory.calculateJoinAddress(weth.address), owner) as Join
+    const wethJoinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(weth.address, null)))[0].args[1]
+    const wethJoin = await ethers.getContractAt('Join', wethJoinAddress, owner) as Join
 
     await this.initAsset(owner, ladle, ETH, weth)
     assets.set(ETH, weth as unknown as ERC20Mock)
@@ -321,7 +329,8 @@ export class YieldEnvironment {
 
     // Add Dai
     await wand.addAsset(DAI, dai.address)
-    const daiJoin = await ethers.getContractAt('Join', await joinFactory.calculateJoinAddress(dai.address), owner) as Join
+    const daiJoinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(dai.address, null)))[0].args[1]
+    const daiJoin = await ethers.getContractAt('Join', daiJoinAddress, owner) as Join
     
     await this.initAsset(owner, ladle, DAI, dai)
     assets.set(DAI, dai as unknown as ERC20Mock)
@@ -330,7 +339,8 @@ export class YieldEnvironment {
 
     // Add USDC
     await wand.addAsset(USDC, usdc.address)
-    const usdcJoin = await ethers.getContractAt('Join', await joinFactory.calculateJoinAddress(usdc.address), owner) as Join
+    const usdcJoinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(usdc.address, null)))[0].args[1]
+    const usdcJoin = await ethers.getContractAt('Join', usdcJoinAddress, owner) as Join
 
     await this.initAsset(owner, ladle, USDC, usdc)
     assets.set(USDC, usdc as unknown as ERC20Mock)

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -48,6 +48,7 @@ import { DAIMock } from '../../typechain/DAIMock'
 import { USDCMock } from '../../typechain/USDCMock'
 
 import { LadleWrapper } from '../../src/ladleWrapper'
+import { getLastVaultId } from '../../src/helpers'
 
 import { ethers, waffle } from 'hardhat'
 const { deployContract } = waffle
@@ -388,10 +389,8 @@ export class YieldEnvironment {
     for (let seriesId of seriesIds) {
       const seriesVaults: Map<string, string> = new Map()
       for (let ilkId of ilkIds) {
-        await cauldron.build(ownerAdd, ethers.utils.hexlify(ethers.utils.randomBytes(12)), seriesId, ilkId)
-        const vaultEvents = (await cauldron.queryFilter(cauldron.filters.VaultBuilt(null, null, null, null)))
-        const vaultId = vaultEvents[vaultEvents.length - 1].args.vaultId
-        seriesVaults.set(ilkId, vaultId)
+        await ladle.build(seriesId, ilkId)
+        seriesVaults.set(ilkId, await getLastVaultId(cauldron))
       }
       vaults.set(seriesId, seriesVaults)
     }

--- a/test/shared/helpers.ts
+++ b/test/shared/helpers.ts
@@ -1,0 +1,20 @@
+import { Contract } from '@ethersproject/contracts'
+import { Signer } from '@ethersproject/abstract-signer/src.ts/index'
+
+export const sendStatic = async (
+    contractInstance: Contract,
+    contractMethod: string,
+    contractCaller: Signer,
+    contractParams: Array<any>,
+    callValue = '0'
+): Promise<any> => {
+    const returnValue = await contractInstance.connect(contractCaller).callStatic[contractMethod](
+        ...contractParams,
+        { value: callValue }
+    );
+    await contractInstance.connect(contractCaller)[contractMethod](
+        ...contractParams,
+        { value: callValue }
+    );
+    return returnValue;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,10 +2297,10 @@
     ethereumjs-util "^7.0.8"
     ethers "^5.0.7"
 
-"@yield-protocol/vault-interfaces@^2.0.33":
-  version "2.0.33"
-  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.0.33.tgz#9d76aec8698b6377713c7e0cf1add0c06ed986b5"
-  integrity sha512-GUhA5UpnVrZjaoBt1jy7yubz5pAkDkegZXSRdSpznVwmSJBMMm7hs/tF/Yfkma7Ru+30kxIVvuhYOT1Y/q8P5g==
+"@yield-protocol/vault-interfaces@^2.0.35":
+  version "2.0.35"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.0.35.tgz#1a6d5d8ca60039cfa5375186563f38c5456eb84b"
+  integrity sha512-xIY23pFerspk6wckyukhlDkyUzEiu+AyC8W2PpqvC4mqT1iYic51MMNn4CInIyCh34YgaVJbDhzHQ32ZccjpIQ==
 
 "@yield-protocol/yieldspace-interfaces@^2.0.14":
   version "2.0.14"


### PR DESCRIPTION
Fixes from the Code Arena review.

 - Check seriesId, ilkId, and vaultId can't be zero
 - Random vault ids
 - Block stir to the same address
 - Replace public auth with external auth
 - Make JoinFactory use CREATE and wand.addAsset deploys the Join
 - Only receive Ether from WETH
 - PoolRouter.batch returns the return values of the batch actions
 - Check for function signature collisions in CI