### PR TITLE
Witch refactor

### DIFF
--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -19,7 +19,6 @@ library CauldronMath {
     }
 }
 
-
 contract Cauldron is AccessControl() {
     using CauldronMath for uint128;
     using WMul for uint256;
@@ -29,7 +28,6 @@ contract Cauldron is AccessControl() {
     using CastU256I256 for uint256;
     using CastI128U128 for int128;
 
-    event AuctionIntervalSet(uint32 indexed auctionInterval);
     event AssetAdded(bytes6 indexed assetId, address indexed asset);
     event SeriesAdded(bytes6 indexed seriesId, bytes6 indexed baseId, address indexed fyToken);
     event IlkAdded(bytes6 indexed seriesId, bytes6 indexed ilkId);
@@ -45,7 +43,6 @@ contract Cauldron is AccessControl() {
     event VaultPoured(bytes12 indexed vaultId, bytes6 indexed seriesId, bytes6 indexed ilkId, int128 ink, int128 art);
     event VaultStirred(bytes12 indexed from, bytes12 indexed to, uint128 ink, uint128 art);
     event VaultRolled(bytes12 indexed vaultId, bytes6 indexed seriesId, uint128 art);
-    event VaultLocked(bytes12 indexed vaultId, uint256 indexed timestamp);
 
     event SeriesMatured(bytes6 indexed seriesId, uint256 rateAtMaturity);
 
@@ -60,12 +57,10 @@ contract Cauldron is AccessControl() {
     // ==== Protocol data ====
     mapping (bytes6 => mapping(bytes6 => DataTypes.Debt))       public debt;            // [baseId][ilkId] Max and sum of debt per underlying and collateral.
     mapping (bytes6 => uint256)                                 public ratesAtMaturity; // Borrowing rate at maturity for a mature series
-    uint32                                                      public auctionInterval;// Time that vaults in liquidation are protected from being grabbed by a different engine.
 
     // ==== User data ====
     mapping (bytes12 => DataTypes.Vault)                        public vaults;          // An user can own one or more Vaults, each one with a bytes12 identifier
     mapping (bytes12 => DataTypes.Balances)                     public balances;        // Both debt and assets
-    mapping (bytes12 => uint32)                                 public auctions;        // If grater than zero, time that a vault was timestamped. Used for liquidation.
 
     // ==== Administration ====
 
@@ -103,15 +98,6 @@ contract Cauldron is AccessControl() {
         require (assets[baseId] != address(0), "Base not found");
         rateOracles[baseId] = oracle;
         emit RateOracleAdded(baseId, address(oracle));
-    }
-
-    /// @dev Set the interval for which vaults being auctioned can't be grabbed by another liquidation engine
-    function setAuctionInterval(uint32 auctionInterval_)
-        external
-        auth
-    {
-        auctionInterval = auctionInterval_;
-        emit AuctionIntervalSet(auctionInterval_);
     }
 
     /// @dev Set a spot oracle and its collateralization ratio. Can be reset.
@@ -198,7 +184,6 @@ contract Cauldron is AccessControl() {
     {
         DataTypes.Balances memory balances_ = balances[vaultId];
         require (balances_.art == 0 && balances_.ink == 0, "Only empty vaults");
-        delete auctions[vaultId];
         delete vaults[vaultId];
         emit VaultDestroyed(vaultId);
     }
@@ -350,22 +335,15 @@ contract Cauldron is AccessControl() {
         return balances_;
     }
 
-    /// @dev Give a non-timestamped vault to another user, and timestamp it.
+    /// @dev Give an uncollateralized vault to another user.
     /// To be used for liquidation engines.
     function grab(bytes12 vaultId, address receiver)
         external
         auth
     {
-        uint32 now_ = uint32(block.timestamp);
-        require (auctions[vaultId] + auctionInterval <= now_, "Vault under auction");        // Grabbing a vault protects it for a day from being grabbed by another liquidator. All grabbed vaults will be suddenly released on the 7th of February 2106, at 06:28:16 GMT. I can live with that.
-
         (DataTypes.Vault memory vault_, DataTypes.Series memory series_, DataTypes.Balances memory balances_) = vaultData(vaultId, true);
         require(_level(vault_, balances_, series_) < 0, "Not undercollateralized");
-
-        auctions[vaultId] = now_;
         _give(vaultId, receiver);
-
-        emit VaultLocked(vaultId, now_);
     }
 
     /// @dev Reduce debt and collateral from a vault, ignoring collateralization checks.

--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -263,7 +263,8 @@ contract Cauldron is AccessControl() {
         returns (uint128 art)
     {
         if (uint32(block.timestamp) >= series[seriesId].maturity) {
-            art = uint256(base).wdiv(accrual(seriesId)).u128();
+            DataTypes.Series memory series_ = series[seriesId];
+            art = uint256(base).wdiv(_accrual(seriesId, series_)).u128();
         } else {
             art = base;
         }
@@ -275,7 +276,8 @@ contract Cauldron is AccessControl() {
         returns (uint128 base)
     {
         if (uint32(block.timestamp) >= series[seriesId].maturity) {
-            base = uint256(art).wmul(accrual(seriesId)).u128();
+            DataTypes.Series memory series_ = series[seriesId];
+            base = uint256(art).wmul(_accrual(seriesId, series_)).u128();
         } else {
             base = art;
         }
@@ -427,9 +429,8 @@ contract Cauldron is AccessControl() {
     function mature(bytes6 seriesId)
         external
     {
-        DataTypes.Series memory series_ = series[seriesId];
-        require (uint32(block.timestamp) >= series_.maturity, "Only after maturity");
         require (ratesAtMaturity[seriesId] == 0, "Already matured");
+        DataTypes.Series memory series_ = series[seriesId];
         _mature(seriesId, series_);
     }
 
@@ -437,6 +438,7 @@ contract Cauldron is AccessControl() {
     function _mature(bytes6 seriesId, DataTypes.Series memory series_)
         internal
     {
+        require (uint32(block.timestamp) >= series_.maturity, "Only after maturity");
         IOracle rateOracle = rateOracles[series_.baseId];
         (uint256 rateAtMaturity,) = rateOracle.get(series_.baseId, bytes32("rate"), 1e18);
         ratesAtMaturity[seriesId] = rateAtMaturity;
@@ -449,7 +451,6 @@ contract Cauldron is AccessControl() {
         returns (uint256)
     {
         DataTypes.Series memory series_ = series[seriesId];
-        require (uint32(block.timestamp) >= series_.maturity, "Only after maturity");
         return _accrual(seriesId, series_);
     }
 

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -487,8 +487,6 @@ contract Ladle is LadleStorage, AccessControl() {
         DataTypes.Vault memory vault = getOwnedVault(vaultId);
         DataTypes.Series memory series = getSeries(vault.seriesId);
 
-        cauldron.slurp(vaultId, ink, art);                                                  // Remove debt and collateral from the vault
-
         if (ink != 0) {                                                                     // Give collateral to the user
             IJoin ilkJoin = getJoin(vault.ilkId);
             ilkJoin.exit(user, ink);

--- a/contracts/Witch.sol
+++ b/contracts/Witch.sol
@@ -71,7 +71,8 @@ contract Witch is AccessControl() {
         DataTypes.Balances memory balances_ = cauldron.balances(vaultId);
 
         require (balances_.art > 0, "Nothing to buy");                                      // Cheapest way of failing gracefully if given a non existing vault
-        uint256 elapsed = uint32(block.timestamp) - auctions[vaultId].start;                      // Auctions will malfunction on the 7th of February 2106, at 06:28:16 GMT, we should replace this contract before then.
+        Auction memory auction_ = auctions[vaultId];
+        uint256 elapsed = uint32(block.timestamp) - auction_.start;                      // Auctions will malfunction on the 7th of February 2106, at 06:28:16 GMT, we should replace this contract before then.
         uint256 price;
         {
             // Price of a collateral unit, in underlying, at the present moment, for a given vault
@@ -91,7 +92,7 @@ contract Witch is AccessControl() {
 
         ladle.settle(vaultId, msg.sender, ink.u128(), art);                                        // Move the assets
         if (balances_.art - art == 0) {                                                             // If there is no debt left, return the vault with the collateral to the owner
-            cauldron.give(vaultId, auctions[vaultId].owner);
+            cauldron.give(vaultId, auction_.owner);
             delete auctions[vaultId];
         }
 

--- a/contracts/Witch.sol
+++ b/contracts/Witch.sol
@@ -109,7 +109,7 @@ contract Witch is AccessControl() {
 
     /// @dev Pay all debt from a vault in liquidation, getting at least `min` collateral.
     function payAll(bytes12 vaultId, uint128 min)
-        public
+        external
         returns (uint256 ink)
     {
         DataTypes.Balances memory balances_ = cauldron.balances(vaultId);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@truffle/hdwallet-provider": "^1.0.40",
     "@types/mocha": "^8.0.0",
     "@yield-protocol/utils-v2": "^2.2.5",
-    "@yield-protocol/vault-interfaces": "^2.0.35",
+    "@yield-protocol/vault-interfaces": "^2.0.36",
     "@yield-protocol/yieldspace-interfaces": "^2.0.14",
     "chai": "4.2.0",
     "dss-interfaces": "0.1.1",

--- a/test/051_cauldron_admin.ts
+++ b/test/051_cauldron_admin.ts
@@ -79,7 +79,6 @@ describe('Cauldron - admin', function () {
 
     await cauldron.grantRoles(
       [
-        id('setAuctionInterval(uint32)'),
         id('addAsset(bytes6,address)'),
         id('setDebtLimits(bytes6,bytes6,uint96,uint24,uint8)'),
         id('setRateOracle(bytes6,address)'),
@@ -89,13 +88,6 @@ describe('Cauldron - admin', function () {
       ],
       owner
     )
-  })
-
-  it('sets the protection period', async () => {
-    expect(await cauldron.setAuctionInterval(1))
-      .to.emit(cauldron, 'AuctionIntervalSet')
-      .withArgs(1)
-    expect(await cauldron.auctionInterval()).to.equal(1)
   })
 
   it('does not allow using zero as an asset identifier', async () => {

--- a/test/081_witch.ts
+++ b/test/081_witch.ts
@@ -80,10 +80,7 @@ describe('Witch', function () {
       (await spotOracle.sources(baseId, ilkId))[0]
     )) as ISourceMock
     rateOracle = (env.oracles.get(RATE) as unknown) as CompoundMultiOracle
-    rateSource = (await ethers.getContractAt(
-      'ISourceMock',
-      await rateOracle.sources(baseId, RATE)
-    )) as ISourceMock
+    rateSource = (await ethers.getContractAt('ISourceMock', await rateOracle.sources(baseId, RATE))) as ISourceMock
 
     witchFromOther = witch.connect(otherAcc)
 
@@ -182,7 +179,7 @@ describe('Witch', function () {
     describe('once the auction time has passed', async () => {
       beforeEach(async () => {
         const { timestamp } = await ethers.provider.getBlock('latest')
-        await ethers.provider.send('evm_mine', [timestamp + await witch.duration()])
+        await ethers.provider.send('evm_mine', [timestamp + (await witch.duration())])
       })
 
       it('allows to buy all of the collateral for the whole debt at the end', async () => {
@@ -205,17 +202,17 @@ describe('Witch', function () {
         })
 
         it('debt to repay grows with rate after maturity', async () => {
-
           const baseBalanceBefore = await base.balanceOf(owner)
           const ilkBalanceBefore = await ilk.balanceOf(owner)
-          await expect(witch.buy(vaultId, WAD, 0)).to.emit(witch, 'Bought')
+          await expect(witch.buy(vaultId, WAD, 0))
+            .to.emit(witch, 'Bought')
             .withArgs(
               vaultId,
               owner,
               WAD.sub((await cauldron.balances(vaultId)).art),
               WAD.sub((await cauldron.balances(vaultId)).ink)
             )
-  
+
           const art = WAD.sub((await cauldron.balances(vaultId)).art)
           const ink = WAD.sub((await cauldron.balances(vaultId)).ink)
           expect(art).to.equal(WAD.mul(100).div(110)) // The rate increased by a 10%, so by paying WAD base we only repay 100/110 of the debt in fyToken terms
@@ -228,7 +225,7 @@ describe('Witch', function () {
           const baseBalanceBefore = await base.balanceOf(owner)
           const ilkBalanceBefore = await ilk.balanceOf(owner)
           await expect(witch.payAll(vaultId, WAD)).to.emit(witch, 'Bought').withArgs(vaultId, owner, WAD, WAD)
-  
+
           expect((await cauldron.balances(vaultId)).art).to.equal(0)
           expect((await cauldron.balances(vaultId)).ink).to.equal(0)
           expect(await base.balanceOf(owner)).to.equal(baseBalanceBefore.sub(WAD.mul(110).div(100)))

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -175,8 +175,9 @@ export class YieldEnvironment {
   public static async witchGovAuth(witch: Witch, receiver: string) {
     await witch.grantRoles(
       [
-        id('setAuctionTime(uint128)'),
-        id('setInitialProportion(uint128)'),
+        id('setDuration(uint32)'),
+        id('setInitialOffer(uint64)'),
+        id('setDust(uint128)'),
       ],
       receiver
     )

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -129,11 +129,7 @@ export class YieldEnvironment {
 
   public static async cauldronWitchAuth(cauldron: Cauldron, receiver: string) {
     await cauldron.grantRoles(
-      [
-        id('give(bytes12,address)'),
-        id('grab(bytes12,address)'),
-        id('slurp(bytes12,uint128,uint128)'),
-      ],
+      [id('give(bytes12,address)'), id('grab(bytes12,address)'), id('slurp(bytes12,uint128,uint128)')],
       receiver
     )
   }
@@ -164,46 +160,33 @@ export class YieldEnvironment {
   }
 
   public static async ladleWitchAuth(ladle: LadleWrapper, receiver: string) {
-    await ladle.grantRoles([
-      id(
-        'settle(bytes12,address,uint128,uint128)'
-      )],
-      receiver
-    )
+    await ladle.grantRoles([id('settle(bytes12,address,uint128,uint128)')], receiver)
   }
 
   public static async witchGovAuth(witch: Witch, receiver: string) {
-    await witch.grantRoles(
-      [
-        id('setDuration(uint32)'),
-        id('setInitialOffer(uint64)'),
-        id('setDust(uint128)'),
-      ],
-      receiver
-    )
+    await witch.grantRoles([id('setDuration(uint32)'), id('setInitialOffer(uint64)'), id('setDust(uint128)')], receiver)
   }
 
   // Initialize an asset for testing purposes. Gives the owner powers over it, and approves the join to take the asset from the owner.
-  public static async initAsset(owner: SignerWithAddress, ladle: LadleWrapper, assetId: string, asset: ERC20Mock | DAIMock | USDCMock | WETH9Mock): Promise<Join> {
-    const join = await ethers.getContractAt('Join', await ladle.joins(assetId), owner) as Join
+  public static async initAsset(
+    owner: SignerWithAddress,
+    ladle: LadleWrapper,
+    assetId: string,
+    asset: ERC20Mock | DAIMock | USDCMock | WETH9Mock
+  ): Promise<Join> {
+    const join = (await ethers.getContractAt('Join', await ladle.joins(assetId), owner)) as Join
     await asset.approve(await ladle.joins(assetId), ethers.constants.MaxUint256) // Owner approves all joins to take from him. Only testing
 
-    await join.grantRoles([
-      id('join(address,uint128)'),
-      id('exit(address,uint128)'),
-      id('retrieve(address,address)')
-    ], await owner.getAddress()) // Only test environment
+    await join.grantRoles(
+      [id('join(address,uint128)'), id('exit(address,uint128)'), id('retrieve(address,address)')],
+      await owner.getAddress()
+    ) // Only test environment
 
     return join
   }
 
   // Initialize a mock pool, with assets printed out of thin air. Also give the owner the right to mint fyToken at will.
-  public static async initPool(
-    owner: SignerWithAddress,
-    pool: PoolMock,
-    base: ERC20Mock,
-    fyToken: FYToken,
-  ) {
+  public static async initPool(owner: SignerWithAddress, pool: PoolMock, base: ERC20Mock, fyToken: FYToken) {
     await base.mint(pool.address, WAD.mul(1000000))
     await pool.mint(await owner.getAddress(), true, 0)
     await fyToken.grantRole(id('mint(address,uint256)'), await owner.getAddress()) // Only test environment
@@ -277,17 +260,22 @@ export class YieldEnvironment {
     const witch = (await deployContract(owner, WitchArtifact, [cauldron.address, ladle.address])) as Witch
     const joinFactory = (await deployContract(owner, JoinFactoryArtifact, [])) as JoinFactory
     const poolFactory = (await deployContract(owner, PoolFactoryMockArtifact, [])) as PoolFactoryMock
-    const wand = (await deployContract(owner, WandArtifact, [cauldron.address, ladle.address, poolFactory.address, joinFactory.address])) as Wand
+    const wand = (await deployContract(owner, WandArtifact, [
+      cauldron.address,
+      ladle.address,
+      poolFactory.address,
+      joinFactory.address,
+    ])) as Wand
     const chiRateOracle = (await deployContract(owner, CompoundMultiOracleArtifact, [])) as CompoundMultiOracle
     const spotOracle = (await deployContract(owner, ChainlinkMultiOracleArtifact, [])) as ChainlinkMultiOracle
-    oracles.set(RATE, chiRateOracle as unknown as OracleMock)
-    oracles.set(CHI, chiRateOracle as unknown as OracleMock)
+    oracles.set(RATE, (chiRateOracle as unknown) as OracleMock)
+    oracles.set(CHI, (chiRateOracle as unknown) as OracleMock)
 
     // ==== Orchestration ====
     await this.cauldronLadleAuth(cauldron, ladle.address)
     await this.cauldronWitchAuth(cauldron, witch.address)
     await this.ladleWitchAuth(ladle, witch.address)
-  
+
     await this.cauldronGovAuth(cauldron, wand.address)
     await this.ladleGovAuth(ladle, wand.address)
     await this.witchGovAuth(witch, wand.address)
@@ -308,8 +296,9 @@ export class YieldEnvironment {
     for (let assetId of assetIds) {
       const asset = assets.get(assetId) as ERC20Mock
       await wand.addAsset(assetId, asset.address)
-      const joinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(asset.address, null)))[0].args[1]
-      const join = await ethers.getContractAt('Join', joinAddress, owner) as Join
+      const joinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(asset.address, null)))[0]
+        .args[1]
+      const join = (await ethers.getContractAt('Join', joinAddress, owner)) as Join
 
       await this.initAsset(owner, ladle, assetId, asset)
       joins.set(assetId, join)
@@ -317,31 +306,34 @@ export class YieldEnvironment {
 
     // Add WETH9
     await wand.addAsset(ETH, weth.address)
-    const wethJoinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(weth.address, null)))[0].args[1]
-    const wethJoin = await ethers.getContractAt('Join', wethJoinAddress, owner) as Join
+    const wethJoinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(weth.address, null)))[0]
+      .args[1]
+    const wethJoin = (await ethers.getContractAt('Join', wethJoinAddress, owner)) as Join
 
     await this.initAsset(owner, ladle, ETH, weth)
-    assets.set(ETH, weth as unknown as ERC20Mock)
+    assets.set(ETH, (weth as unknown) as ERC20Mock)
     joins.set(ETH, wethJoin)
     ilkIds.push(ETH)
 
     // Add Dai
     await wand.addAsset(DAI, dai.address)
-    const daiJoinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(dai.address, null)))[0].args[1]
-    const daiJoin = await ethers.getContractAt('Join', daiJoinAddress, owner) as Join
-    
+    const daiJoinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(dai.address, null)))[0]
+      .args[1]
+    const daiJoin = (await ethers.getContractAt('Join', daiJoinAddress, owner)) as Join
+
     await this.initAsset(owner, ladle, DAI, dai)
-    assets.set(DAI, dai as unknown as ERC20Mock)
+    assets.set(DAI, (dai as unknown) as ERC20Mock)
     joins.set(DAI, daiJoin)
     ilkIds.push(DAI)
 
     // Add USDC
     await wand.addAsset(USDC, usdc.address)
-    const usdcJoinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(usdc.address, null)))[0].args[1]
-    const usdcJoin = await ethers.getContractAt('Join', usdcJoinAddress, owner) as Join
+    const usdcJoinAddress = (await joinFactory.queryFilter(joinFactory.filters.JoinCreated(usdc.address, null)))[0]
+      .args[1]
+    const usdcJoin = (await ethers.getContractAt('Join', usdcJoinAddress, owner)) as Join
 
     await this.initAsset(owner, ladle, USDC, usdc)
-    assets.set(USDC, usdc as unknown as ERC20Mock)
+    assets.set(USDC, (usdc as unknown) as ERC20Mock)
     joins.set(USDC, usdcJoin)
     ilkIds.push(USDC)
 
@@ -356,7 +348,7 @@ export class YieldEnvironment {
     for (let ilkId of ilkIds) {
       const source = sources.get(ilkId) as ISourceMock
       await wand.makeIlk(baseId, ilkId, spotOracle.address, source.address, ratio, max, min, dec)
-      oracles.set(ilkId, spotOracle as unknown as OracleMock)
+      oracles.set(ilkId, (spotOracle as unknown) as OracleMock)
     }
 
     // ==== Add series and pools ====
@@ -368,17 +360,20 @@ export class YieldEnvironment {
     for (let seriesId of seriesIds) {
       const maturity = timestamp + THREE_MONTHS * count++
       await wand.addSeries(seriesId, baseId, maturity, ilkIds, seriesId, seriesId)
-      const fyToken = await ethers.getContractAt('FYToken', (await cauldron.series(seriesId)).fyToken, owner) as FYToken
-      const pool = await ethers.getContractAt('PoolMock', await ladle.pools(seriesId), owner) as PoolMock
+      const fyToken = (await ethers.getContractAt(
+        'FYToken',
+        (await cauldron.series(seriesId)).fyToken,
+        owner
+      )) as FYToken
+      const pool = (await ethers.getContractAt('PoolMock', await ladle.pools(seriesId), owner)) as PoolMock
       await this.initPool(owner, pool, base, fyToken)
       series.set(seriesId, fyToken)
       pools.set(seriesId, pool)
 
-      await fyToken.grantRoles([
-          id('mint(address,uint256)'),
-          id('burn(address,uint256)'),
-          id('setOracle(address)')],
-      ownerAdd) // Only test environment
+      await fyToken.grantRoles(
+        [id('mint(address,uint256)'), id('burn(address,uint256)'), id('setOracle(address)')],
+        ownerAdd
+      ) // Only test environment
     }
 
     // ==== Build some vaults ====
@@ -392,6 +387,20 @@ export class YieldEnvironment {
       vaults.set(seriesId, seriesVaults)
     }
 
-    return new YieldEnvironment(owner, cauldron, ladle, witch, joinFactory, poolFactory, wand, assets, oracles, series, pools, joins, vaults)
+    return new YieldEnvironment(
+      owner,
+      cauldron,
+      ladle,
+      witch,
+      joinFactory,
+      poolFactory,
+      wand,
+      assets,
+      oracles,
+      series,
+      pools,
+      joins,
+      vaults
+    )
   }
 }

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -122,7 +122,6 @@ export class YieldEnvironment {
         id('pour(bytes12,int128,int128)'),
         id('stir(bytes12,bytes12,uint128,uint128)'),
         id('roll(bytes12,bytes6,int128)'),
-        id('slurp(bytes12,uint128,uint128)'),
       ],
       receiver
     )
@@ -133,6 +132,7 @@ export class YieldEnvironment {
       [
         id('give(bytes12,address)'),
         id('grab(bytes12,address)'),
+        id('slurp(bytes12,uint128,uint128)'),
       ],
       receiver
     )

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -101,7 +101,6 @@ export class YieldEnvironment {
   public static async cauldronGovAuth(cauldron: Cauldron, receiver: string) {
     await cauldron.grantRoles(
       [
-        id('setAuctionInterval(uint32)'),
         id('addAsset(bytes6,address)'),
         id('addSeries(bytes6,bytes6,address)'),
         id('addIlks(bytes6,bytes6[])'),
@@ -303,9 +302,6 @@ export class YieldEnvironment {
     await this.cauldronGovAuth(cauldron, ownerAdd)
     await this.ladleGovAuth(ladle, ownerAdd)
     await this.witchGovAuth(witch, ownerAdd)
-
-    // ==== Set protection period for vaults in liquidation ====
-    await cauldron.setAuctionInterval(24 * 60 * 60)
 
     // ==== Add assets and joins ====
     for (let assetId of assetIds) {

--- a/test/shared/helpers.ts
+++ b/test/shared/helpers.ts
@@ -2,19 +2,15 @@ import { Contract } from '@ethersproject/contracts'
 import { Signer } from '@ethersproject/abstract-signer/src.ts/index'
 
 export const sendStatic = async (
-    contractInstance: Contract,
-    contractMethod: string,
-    contractCaller: Signer,
-    contractParams: Array<any>,
-    callValue = '0'
+  contractInstance: Contract,
+  contractMethod: string,
+  contractCaller: Signer,
+  contractParams: Array<any>,
+  callValue = '0'
 ): Promise<any> => {
-    const returnValue = await contractInstance.connect(contractCaller).callStatic[contractMethod](
-        ...contractParams,
-        { value: callValue }
-    );
-    await contractInstance.connect(contractCaller)[contractMethod](
-        ...contractParams,
-        { value: callValue }
-    );
-    return returnValue;
+  const returnValue = await contractInstance
+    .connect(contractCaller)
+    .callStatic[contractMethod](...contractParams, { value: callValue })
+  await contractInstance.connect(contractCaller)[contractMethod](...contractParams, { value: callValue })
+  return returnValue
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,10 +2297,10 @@
     ethereumjs-util "^7.0.8"
     ethers "^5.0.7"
 
-"@yield-protocol/vault-interfaces@^2.0.35":
-  version "2.0.35"
-  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.0.35.tgz#1a6d5d8ca60039cfa5375186563f38c5456eb84b"
-  integrity sha512-xIY23pFerspk6wckyukhlDkyUzEiu+AyC8W2PpqvC4mqT1iYic51MMNn4CInIyCh34YgaVJbDhzHQ32ZccjpIQ==
+"@yield-protocol/vault-interfaces@^2.0.36":
+  version "2.0.36"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.0.36.tgz#6f896257cee9eb5cd93071533059f58e05e32980"
+  integrity sha512-vsKemfPBFE+IaMkcBzgWf1k73s0EccZNI7C7lrZLyKmlg8QxbKbr1TyeY7+Rx0Sbgoh9hgmtlbuSUDid1kGmIg==
 
 "@yield-protocol/yieldspace-interfaces@^2.0.14":
   version "2.0.14"


### PR DESCRIPTION
Fixes #214 with a refactor of Witch, and with it a number of issues in the C4 report ([8](https://github.com/code-423n4/2021-05-yield-findings/issues/8), [44](https://github.com/code-423n4/2021-05-yield-findings/issues/44), [71](https://github.com/code-423n4/2021-05-yield-findings/issues/71))

 - Removed parallel liquidation engines feature, which was complex and a source of exploits.
 - Included a DUST parameter
 - Debt accrual now taken into account for liquidations
 - payAll function to liquidate a whole vault after maturity

There is an issue unrelated to this PR making CI fail. I believe it has something to do with the chain not being reverted to the previous block after advancing time in the 031 test file.