### PR TITLE
feat: ladle.batch collates the results of the actions

### DIFF
--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -131,10 +131,12 @@ contract Ladle is LadleStorage, AccessControl() {
     function batch(
         Operation[] calldata operations,
         bytes[] calldata data
-    ) external payable {
+    ) external payable returns(bytes[] memory results) {
         require(operations.length == data.length, "Mismatched operation data");
         bytes12 cachedId;
         DataTypes.Vault memory vault;
+
+        results = new bytes[](operations.length);
 
         // Execute all operations in the batch. Conditionals ordered by expected frequency.
         for (uint256 i = 0; i < operations.length; i += 1) {
@@ -144,99 +146,110 @@ contract Ladle is LadleStorage, AccessControl() {
             if (operation == Operation.BUILD) {
                 (bytes6 seriesId, bytes6 ilkId) = abi.decode(data[i], (bytes6, bytes6));
                 (cachedId, vault) = _build(seriesId, ilkId, 0);   // Cache the vault that was just built
+                results[i] = abi.encode(cachedId);  // We only return the data that changed
             
             } else if (operation == Operation.FORWARD_PERMIT) {
                 (bytes6 id, bool isAsset, address spender, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) =
                     abi.decode(data[i], (bytes6, bool, address, uint256, uint256, uint8, bytes32, bytes32));
                 _forwardPermit(id, isAsset, spender, amount, deadline, v, r, s);
+                results[i] = abi.encode(true);
             
             } else if (operation == Operation.JOIN_ETHER) {
                 (bytes6 etherId) = abi.decode(data[i], (bytes6));
-                _joinEther(etherId);
+                results[i] = abi.encode(_joinEther(etherId));
             
             } else if (operation == Operation.POUR) {
                 (bytes12 vaultId, address to, int128 ink, int128 art) = abi.decode(data[i], (bytes12, address, int128, int128));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
                 _pour(vaultId, vault, to, ink, art);
+                results[i] = abi.encode(true);
             
             } else if (operation == Operation.SERVE) {
                 (bytes12 vaultId, address to, uint128 ink, uint128 base, uint128 max) = abi.decode(data[i], (bytes12, address, uint128, uint128, uint128));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                _serve(vaultId, vault, to, ink, base, max);
+                results[i] = abi.encode(_serve(vaultId, vault, to, ink, base, max));
 
             } else if (operation == Operation.ROLL) {
                 (bytes12 vaultId, bytes6 newSeriesId, uint8 loan, uint128 max) = abi.decode(data[i], (bytes12, bytes6, uint8, uint128));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                (vault,) = _roll(vaultId, vault, newSeriesId, loan, max);
+                uint256 newDebt;
+                (vault, newDebt) = _roll(vaultId, vault, newSeriesId, loan, max);
+                results[i] = abi.encode(newDebt);
             
             } else if (operation == Operation.FORWARD_DAI_PERMIT) {
                 (bytes6 id, bool isAsset, address spender, uint256 nonce, uint256 deadline, bool allowed, uint8 v, bytes32 r, bytes32 s) =
                     abi.decode(data[i], (bytes6, bool, address, uint256, uint256, bool, uint8, bytes32, bytes32));
                 _forwardDaiPermit(id, isAsset, spender, nonce, deadline, allowed, v, r, s);
+                results[i] = abi.encode(true);
             
             } else if (operation == Operation.TRANSFER_TO_POOL) {
                 (bytes6 seriesId, bool base, uint128 wad) =
                     abi.decode(data[i], (bytes6, bool, uint128));
                 IPool pool = getPool(seriesId);
                 _transferToPool(pool, base, wad);
+                results[i] = abi.encode(true);
             
             } else if (operation == Operation.ROUTE) {
                 (bytes6 seriesId, bytes memory poolCall) =
                     abi.decode(data[i], (bytes6, bytes));
                 IPool pool = getPool(seriesId);
-                _route(pool, poolCall);
+                results[i] = _route(pool, poolCall);
             
             } else if (operation == Operation.EXIT_ETHER) {
                 (address to) = abi.decode(data[i], (address));
-                _exitEther(payable(to));
+                results[i] = abi.encode(_exitEther(payable(to)));
             
             } else if (operation == Operation.CLOSE) {
                 (bytes12 vaultId, address to, int128 ink, int128 art) = abi.decode(data[i], (bytes12, address, int128, int128));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                _close(vaultId, vault, to, ink, art);
+                results[i] = abi.encode(_close(vaultId, vault, to, ink, art));
             
             } else if (operation == Operation.REPAY) {
                 (bytes12 vaultId, address to, int128 ink, uint128 min) = abi.decode(data[i], (bytes12, address, int128, uint128));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                _repay(vaultId, vault, to, ink, min);
+                results[i] = abi.encode(_repay(vaultId, vault, to, ink, min));
             
             } else if (operation == Operation.REPAY_VAULT) {
                 (bytes12 vaultId, address to, int128 ink, uint128 max) = abi.decode(data[i], (bytes12, address, int128, uint128));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                _repayVault(vaultId, vault, to, ink, max);
+                results[i] = abi.encode(_repayVault(vaultId, vault, to, ink, max));
 
             } else if (operation == Operation.REPAY_LADLE) {
                 (bytes12 vaultId) = abi.decode(data[i], (bytes12));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                _repayLadle(vaultId, vault);
+                results[i] = abi.encode(_repayLadle(vaultId, vault));
 
             } else if (operation == Operation.RETRIEVE) {
                 (bytes6 assetId, bool isAsset, address to) = abi.decode(data[i], (bytes6, bool, address));
-                _retrieve(assetId, isAsset, to);
+                results[i] = abi.encode(_retrieve(assetId, isAsset, to));
 
             } else if (operation == Operation.TRANSFER_TO_FYTOKEN) {
                 (bytes6 seriesId, uint256 amount) = abi.decode(data[i], (bytes6, uint256));
                 IFYToken fyToken = getSeries(seriesId).fyToken;
                 _transferToFYToken(fyToken, amount);
+                results[i] = abi.encode(true);
             
             } else if (operation == Operation.REDEEM) {
                 (bytes6 seriesId, address to, uint256 amount) = abi.decode(data[i], (bytes6, address, uint256));
                 IFYToken fyToken = getSeries(seriesId).fyToken;
-                _redeem(fyToken, to, amount);
+                results[i] = abi.encode(_redeem(fyToken, to, amount));
             
             } else if (operation == Operation.STIR) {
                 (bytes12 from, bytes12 to, uint128 ink, uint128 art) = abi.decode(data[i], (bytes12, bytes12, uint128, uint128));
                 _stir(from, to, ink, art);  // Too complicated to use caching here
+                results[i] = abi.encode(true);
             
             } else if (operation == Operation.TWEAK) {
                 (bytes12 vaultId, bytes6 seriesId, bytes6 ilkId) = abi.decode(data[i], (bytes12, bytes6, bytes6));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
                 vault = _tweak(vaultId, seriesId, ilkId);
+                results[i] = abi.encode(true);
 
             } else if (operation == Operation.GIVE) {
                 (bytes12 vaultId, address to) = abi.decode(data[i], (bytes12, address));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
                 _give(vaultId, to);
+                results[i] = abi.encode(true);
                 delete vault;   // Clear the cache, since the vault doesn't necessarily belong to msg.sender anymore
                 cachedId = bytes12(0);
 
@@ -244,12 +257,13 @@ contract Ladle is LadleStorage, AccessControl() {
                 (bytes12 vaultId) = abi.decode(data[i], (bytes12));
                 (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
                 _destroy(vaultId);
+                results[i] = abi.encode(true);
                 delete vault;   // Clear the cache
                 cachedId = bytes12(0);
             
             } else if (operation == Operation.MODULE) {
                 (address module, bytes memory moduleCall) = abi.decode(data[i], (address, bytes));
-                _moduleCall(module, moduleCall);
+                results[i] = _moduleCall(module, moduleCall);
             
             }
         }
@@ -304,11 +318,10 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Move collateral and debt between vaults.
     function _stir(bytes12 from, bytes12 to, uint128 ink, uint128 art)
         private
-        returns (DataTypes.Balances memory, DataTypes.Balances memory)
     {
         if (ink > 0) require (cauldron.vaults(from).owner == msg.sender, "Only origin vault owner");
         if (art > 0) require (cauldron.vaults(to).owner == msg.sender, "Only destination vault owner");
-        return cauldron.stir(from, to, ink, art);
+        cauldron.stir(from, to, ink, art);
     }
 
     /// @dev Add collateral and borrow from vault, pull assets from and push borrowed asset to user
@@ -316,7 +329,6 @@ contract Ladle is LadleStorage, AccessControl() {
     /// Borrow only before maturity.
     function _pour(bytes12 vaultId, DataTypes.Vault memory vault, address to, int128 ink, int128 art)
         private
-        returns (DataTypes.Balances memory balances)
     {
         DataTypes.Series memory series;
         if (art != 0) series = getSeries(vault.seriesId);
@@ -325,7 +337,7 @@ contract Ladle is LadleStorage, AccessControl() {
         if (art > 0) fee = ((series.maturity - block.timestamp) * uint256(int256(art)).wmul(borrowingFee)).u128().i128();
 
         // Update accounting
-        balances = cauldron.pour(vaultId, ink, art + fee);
+        cauldron.pour(vaultId, ink, art + fee);
 
         // Manage collateral
         if (ink != 0) {
@@ -346,12 +358,12 @@ contract Ladle is LadleStorage, AccessControl() {
     /// Only before maturity.
     function _serve(bytes12 vaultId, DataTypes.Vault memory vault, address to, uint128 ink, uint128 base, uint128 max)
         private
-        returns (DataTypes.Balances memory balances, uint128 art)
+        returns (uint128 art)
     {
         IPool pool = getPool(vault.seriesId);
         
         art = pool.buyBasePreview(base);
-        balances = _pour(vaultId, vault, address(pool), ink.i128(), art.i128());
+        _pour(vaultId, vault, address(pool), ink.i128(), art.i128());
         pool.buyBase(to, base, max);
     }
 
@@ -362,16 +374,16 @@ contract Ladle is LadleStorage, AccessControl() {
     /// Debt cannot be acquired with this function.
     function _close(bytes12 vaultId, DataTypes.Vault memory vault, address to, int128 ink, int128 art)
         private
-        returns (DataTypes.Balances memory balances)
+        returns (uint128 base)
     {
         require (art < 0, "Only repay debt");                                          // When repaying debt in `frob`, art is a negative value. Here is the same for consistency.
 
         // Calculate debt in fyToken terms
         DataTypes.Series memory series = getSeries(vault.seriesId);
-        uint128 base = cauldron.debtToBase(vault.seriesId, uint128(-art));
+        base = cauldron.debtToBase(vault.seriesId, uint128(-art));
 
         // Update accounting
-        balances = cauldron.pour(vaultId, ink, art);
+        cauldron.pour(vaultId, ink, art);
 
         // Manage collateral
         if (ink != 0) {
@@ -390,13 +402,13 @@ contract Ladle is LadleStorage, AccessControl() {
     /// Only before maturity. After maturity use close.
     function _repay(bytes12 vaultId, DataTypes.Vault memory vault, address to, int128 ink, uint128 min)
         private
-        returns (DataTypes.Balances memory balances, uint128 art)
+        returns (uint128 art)
     {
         DataTypes.Series memory series = getSeries(vault.seriesId);
         IPool pool = getPool(vault.seriesId);
 
         art = pool.sellBase(address(series.fyToken), min);
-        balances = _pour(vaultId, vault, to, ink, -(art.i128()));
+        _pour(vaultId, vault, to, ink, -(art.i128()));
     }
 
     /// @dev Repay all debt in a vault by buying fyToken from a pool with base.
@@ -404,27 +416,26 @@ contract Ladle is LadleStorage, AccessControl() {
     /// Only before maturity. After maturity use close.
     function _repayVault(bytes12 vaultId, DataTypes.Vault memory vault, address to, int128 ink, uint128 max)
         private
-        returns (DataTypes.Balances memory balances, uint128 base)
+        returns (uint128 base)
     {
         DataTypes.Series memory series = getSeries(vault.seriesId);
         IPool pool = getPool(vault.seriesId);
 
-        balances = cauldron.balances(vaultId);
+        DataTypes.Balances memory balances = cauldron.balances(vaultId);
         base = pool.buyFYToken(address(series.fyToken), balances.art, max);
-        balances = _pour(vaultId, vault, to, ink, -(balances.art.i128()));
+        _pour(vaultId, vault, to, ink, -(balances.art.i128()));
         pool.retrieveBase(msg.sender);
     }
 
     /// @dev Change series and debt of a vault.
     function _roll(bytes12 vaultId, DataTypes.Vault memory vault, bytes6 newSeriesId, uint8 loan, uint128 max)
         private
-        returns (DataTypes.Vault memory, DataTypes.Balances memory)
+        returns (DataTypes.Vault memory vault_, uint128 newDebt)
     {
         DataTypes.Series memory series = getSeries(vault.seriesId);
         DataTypes.Series memory newSeries = getSeries(newSeriesId);
         DataTypes.Balances memory balances = cauldron.balances(vaultId);
         
-        uint128 newDebt;
         {
             IPool pool = getPool(newSeriesId);
             IFYToken fyToken = IFYToken(newSeries.fyToken);
@@ -446,7 +457,9 @@ contract Ladle is LadleStorage, AccessControl() {
 
         newDebt += ((newSeries.maturity - block.timestamp) * uint256(newDebt).wmul(borrowingFee)).u128();  // Add borrowing fee, also stops users form rolling to a mature series
 
-        return cauldron.roll(vaultId, newSeriesId, newDebt.i128() - balances.art.i128()); // Change the series and debt for the vault
+        (vault_,) = cauldron.roll(vaultId, newSeriesId, newDebt.i128() - balances.art.i128()); // Change the series and debt for the vault
+        
+        return (vault_, newDebt);
     }
 
     // ---- Ladle as a token holder ----
@@ -454,17 +467,17 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Use fyToken in the Ladle to repay debt.
     function _repayLadle(bytes12 vaultId, DataTypes.Vault memory vault)
         private
-        returns (DataTypes.Balances memory balances)
+        returns (uint256 repaid)
     {
         DataTypes.Series memory series = getSeries(vault.seriesId);
-        balances = cauldron.balances(vaultId);
+        DataTypes.Balances memory balances = cauldron.balances(vaultId);
         
         uint256 amount = series.fyToken.balanceOf(address(this));
-        amount = amount <= balances.art ? amount : balances.art;
+        repaid = amount <= balances.art ? amount : balances.art;
 
         // Update accounting
-        balances = cauldron.pour(vaultId, 0, -(amount.u128().i128()));
-        series.fyToken.burn(address(this), amount);
+        cauldron.pour(vaultId, 0, -(repaid.u128().i128()));
+        series.fyToken.burn(address(this), repaid);
     }
 
     /// @dev Retrieve any asset or fyToken in the Ladle
@@ -567,8 +580,9 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Allow users to route calls to a pool, to be used with batch
     function _route(IPool pool, bytes memory data)
         private
-        returns (bool success, bytes memory result)
+        returns (bytes memory result)
     {
+        bool success;
         (success, result) = address(pool).call(data);
         if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
     }
@@ -598,9 +612,10 @@ contract Ladle is LadleStorage, AccessControl() {
     /// it would be disastrous in combination with batch vault caching 
     function _moduleCall(address module, bytes memory moduleCall)
         private
-        returns (bool success, bytes memory result)
+        returns (bytes memory result)
     {
         require (modules[module], "Unregistered module");
+        bool success;
         (success, result) = module.delegatecall(moduleCall);
         if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
     }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -87,7 +87,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 2500,
+        runs: 1000,
       }
     }
   },


### PR DESCRIPTION
Follows the pattern used in PoolRouter.sol.

To fit the extra code the optimization runs had to be decreased again, to 1000 runs. The complexity of `batch` and the size it imposes in `Ladle` is starting to make a strong case for using the regular `multicall` approach.