### PR TITLE
fix: make factories auth to avoid griefing attacks

### DIFF
--- a/contracts/FYTokenFactory.sol
+++ b/contracts/FYTokenFactory.sol
@@ -4,11 +4,12 @@ pragma solidity 0.8.1;
 import "@yield-protocol/vault-interfaces/IOracle.sol";
 import "@yield-protocol/vault-interfaces/IJoin.sol";
 import "@yield-protocol/vault-interfaces/IFYTokenFactory.sol";
+import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "./FYToken.sol";
 
 
 /// @dev The FYTokenFactory creates new FYToken instances.
-contract FYTokenFactory is IFYTokenFactory {
+contract FYTokenFactory is IFYTokenFactory, AccessControl {
 
   /// @dev Deploys a new fyToken.
   /// @return fyToken The fyToken address.
@@ -20,7 +21,9 @@ contract FYTokenFactory is IFYTokenFactory {
     string memory name,
     string memory symbol
   )
-    external override returns (address)
+    external override
+    auth
+    returns (address)
   {
     FYToken fyToken = new FYToken(
       baseId,

--- a/contracts/JoinFactory.sol
+++ b/contracts/JoinFactory.sol
@@ -2,16 +2,21 @@
 pragma solidity 0.8.1;
 
 import "@yield-protocol/vault-interfaces/IJoinFactory.sol";
+import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "./Join.sol";
 
 
 /// @dev The JoinFactory creates new join instances.
-contract JoinFactory is IJoinFactory {
+contract JoinFactory is IJoinFactory, AccessControl {
 
   /// @dev Deploys a new join.
   /// @param asset Address of the asset token.
   /// @return join The join address.
-  function createJoin(address asset) external override returns (address) {
+  function createJoin(address asset)
+    external override
+    auth
+    returns (address)
+  {
     Join join = new Join(asset);
 
     join.grantRole(join.ROOT(), msg.sender);

--- a/test/021_join.ts
+++ b/test/021_join.ts
@@ -45,13 +45,18 @@ describe('Join', function () {
   beforeEach(async () => {
     token = (await deployContract(ownerAcc, ERC20MockArtifact, ['MTK', 'Mock Token'])) as ERC20Mock
     otherToken = (await deployContract(ownerAcc, ERC20MockArtifact, ['OTH', 'Other Token'])) as ERC20Mock
+    
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
+    await joinFactory.grantRoles(
+      [id('createJoin(address)')],
+      owner
+    )
+    
     join = (await ethers.getContractAt(
       'Join',
       await sendStatic(joinFactory as Contract, 'createJoin', ownerAcc, [token.address]),
       ownerAcc
     )) as Join
-
     await join.grantRoles(
       [id('join(address,uint128)'), id('exit(address,uint128)'), id('retrieve(address,address)')],
       owner

--- a/test/021_join.ts
+++ b/test/021_join.ts
@@ -45,13 +45,10 @@ describe('Join', function () {
   beforeEach(async () => {
     token = (await deployContract(ownerAcc, ERC20MockArtifact, ['MTK', 'Mock Token'])) as ERC20Mock
     otherToken = (await deployContract(ownerAcc, ERC20MockArtifact, ['OTH', 'Other Token'])) as ERC20Mock
-    
+
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
-    await joinFactory.grantRoles(
-      [id('createJoin(address)')],
-      owner
-    )
-    
+    await joinFactory.grantRoles([id('createJoin(address)')], owner)
+
     join = (await ethers.getContractAt(
       'Join',
       await sendStatic(joinFactory as Contract, 'createJoin', ownerAcc, [token.address]),

--- a/test/022_join_flash.ts
+++ b/test/022_join_flash.ts
@@ -53,12 +53,16 @@ describe('Join - flash', function () {
   beforeEach(async () => {
     token = (await deployContract(ownerAcc, ERC20MockArtifact, ['MTK', 'Mock Token'])) as ERC20Mock
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
+    await joinFactory.grantRoles(
+      [id('createJoin(address)')],
+      owner
+    )
+
     join = (await ethers.getContractAt(
       'Join',
       await sendStatic(joinFactory as Contract, 'createJoin', ownerAcc, [token.address]),
       ownerAcc
     )) as Join
-
     await join.grantRoles(
       [id('join(address,uint128)'), id('exit(address,uint128)'), id('setFlashFeeFactor(uint256)')],
       owner

--- a/test/022_join_flash.ts
+++ b/test/022_join_flash.ts
@@ -53,10 +53,7 @@ describe('Join - flash', function () {
   beforeEach(async () => {
     token = (await deployContract(ownerAcc, ERC20MockArtifact, ['MTK', 'Mock Token'])) as ERC20Mock
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
-    await joinFactory.grantRoles(
-      [id('createJoin(address)')],
-      owner
-    )
+    await joinFactory.grantRoles([id('createJoin(address)')], owner)
 
     join = (await ethers.getContractAt(
       'Join',

--- a/test/051_cauldron_admin.ts
+++ b/test/051_cauldron_admin.ts
@@ -60,10 +60,7 @@ describe('Cauldron - admin', function () {
     ilk1 = (await deployContract(ownerAcc, ERC20MockArtifact, [ilkId1, 'Mock Ilk'])) as ERC20Mock
     ilk2 = (await deployContract(ownerAcc, ERC20MockArtifact, [ilkId2, 'Mock Ilk'])) as ERC20Mock
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
-    await joinFactory.grantRoles(
-      [id('createJoin(address)')],
-      owner
-    )
+    await joinFactory.grantRoles([id('createJoin(address)')], owner)
 
     join = (await ethers.getContractAt(
       'Join',

--- a/test/051_cauldron_admin.ts
+++ b/test/051_cauldron_admin.ts
@@ -60,6 +60,11 @@ describe('Cauldron - admin', function () {
     ilk1 = (await deployContract(ownerAcc, ERC20MockArtifact, [ilkId1, 'Mock Ilk'])) as ERC20Mock
     ilk2 = (await deployContract(ownerAcc, ERC20MockArtifact, [ilkId2, 'Mock Ilk'])) as ERC20Mock
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
+    await joinFactory.grantRoles(
+      [id('createJoin(address)')],
+      owner
+    )
+
     join = (await ethers.getContractAt(
       'Join',
       await sendStatic(joinFactory as Contract, 'createJoin', ownerAcc, [base.address]),

--- a/test/060_ladle_admin.ts
+++ b/test/060_ladle_admin.ts
@@ -100,10 +100,7 @@ describe('Ladle - admin', function () {
 
     // Deploy a join
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
-    await joinFactory.grantRoles(
-      [id('createJoin(address)')],
-      owner
-    )
+    await joinFactory.grantRoles([id('createJoin(address)')], owner)
 
     ilkJoin = (await ethers.getContractAt(
       'Join',

--- a/test/060_ladle_admin.ts
+++ b/test/060_ladle_admin.ts
@@ -100,6 +100,11 @@ describe('Ladle - admin', function () {
 
     // Deploy a join
     joinFactory = (await deployContract(ownerAcc, JoinFactoryArtifact, [])) as JoinFactory
+    await joinFactory.grantRoles(
+      [id('createJoin(address)')],
+      owner
+    )
+
     ilkJoin = (await ethers.getContractAt(
       'Join',
       await sendStatic(joinFactory as Contract, 'createJoin', ownerAcc, [ilk.address]),

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -162,6 +162,14 @@ export class YieldEnvironment {
     await witch.grantRoles([id('setIlk(bytes6,uint32,uint64,uint128)')], receiver)
   }
 
+  public static async joinFactoryAuth(joinFactory: JoinFactory, receiver: string) {
+    await joinFactory.grantRoles([id('createJoin(address)')], receiver)
+  }
+
+  public static async fyTokenFactoryAuth(fyTokenFactory: FYTokenFactory, receiver: string) {
+    await fyTokenFactory.grantRoles([id('createFYToken(bytes6,address,address,uint32,string,string)')], receiver)
+  }
+
   // Initialize an asset for testing purposes. Gives the owner powers over it, and approves the join to take the asset from the owner.
   public static async initAsset(
     owner: SignerWithAddress,
@@ -290,13 +298,16 @@ export class YieldEnvironment {
     await this.cauldronGovAuth(cauldron, wand.address)
     await this.ladleGovAuth(ladle, wand.address)
     await this.witchGovAuth(witch, wand.address)
+    await this.joinFactoryAuth(joinFactory, wand.address)
+    await this.fyTokenFactoryAuth(fyTokenFactory, wand.address)
     await chiRateOracle.grantRole(id('setSource(bytes6,bytes6,address)'), wand.address)
     await spotOracle.grantRole(id('setSource(bytes6,bytes6,address)'), wand.address)
 
     // ==== Owner access (only test environment) ====
     await this.cauldronLadleAuth(cauldron, ownerAdd)
     await this.wandAuth(wand, ownerAdd)
-
+    await this.joinFactoryAuth(joinFactory, ownerAdd)
+    await this.fyTokenFactoryAuth(fyTokenFactory, ownerAdd)
     await this.cauldronGovAuth(cauldron, ownerAdd)
     await this.ladleGovAuth(ladle, ownerAdd)
     await this.witchGovAuth(witch, ownerAdd)


### PR DESCRIPTION
If anyone can use our factories to create Joins and FYTokens, they could front-run us for a denial-of-service attack. It would only stop us from adding assets, but it would be annoying. Better to fix it now.