### PR TITLE
Use ENS-style Multicall

### DIFF
--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -79,7 +79,7 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Add a new Join for an Asset, or replace an existing one for a new one.
     /// There can be only one Join per Asset. Until a Join is added, no tokens of that Asset can be posted or withdrawn.
     function addJoin(bytes6 assetId, IJoin join)
-        external payable
+        external
         auth
     {
         address asset = cauldron.assets(assetId);
@@ -92,7 +92,7 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Add a new Pool for a Series, or replace an existing one for a new one.
     /// There can be only one Pool per Series. Until a Pool is added, it is not possible to borrow Base.
     function addPool(bytes6 seriesId, IPool pool)
-        external payable
+        external
         auth
     {
         IFYToken fyToken = getSeries(seriesId).fyToken;
@@ -104,7 +104,7 @@ contract Ladle is LadleStorage, AccessControl() {
 
     /// @dev Add or remove a module.
     function setModule(address module, bool set)
-        external payable
+        external
         auth
     {
         modules[module] = set;

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -113,8 +113,8 @@ contract Ladle is LadleStorage, AccessControl() {
 
     /// @dev Set the fee parameter
     function setFee(uint256 fee)
-        external payable
-        auth    
+        external
+        auth
     {
         borrowingFee = fee;
         emit FeeSet(fee);

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -26,6 +26,13 @@ contract Ladle is LadleStorage, AccessControl() {
     using AllTransferHelper for IERC20;
     using AllTransferHelper for address payable;
 
+    struct CachedVault {
+        bytes12 vaultId;
+        address vaultOwner;
+        DataTypes.Vault vault;
+    }
+
+    CachedVault public cachedVault;
     IWETH9 public immutable weth;
 
     constructor (ICauldron cauldron, IWETH9 weth_) LadleStorage(cauldron) {
@@ -34,13 +41,23 @@ contract Ladle is LadleStorage, AccessControl() {
 
     // ---- Data sourcing ----
     /// @dev Obtains a vault by vaultId from the Cauldron, and verifies that msg.sender is the owner
-    function getOwnedVault(bytes12 vaultId)
-        internal view returns(DataTypes.Vault memory vault)
+    /// If bytes(0) is passed as the vaultId it tries to load a vault from the cache
+    function getVault(bytes12 vaultId_)
+        private
+        returns (bytes12 vaultId, DataTypes.Vault memory vault)
     {
-        vault = cauldron.vaults(vaultId);
-        require (vault.owner == msg.sender, "Only vault owner");
-    }
-
+        if (vaultId_ == bytes12(0)) { // We use the cache
+            CachedVault memory cache = cachedVault;
+            require (cache.vaultId != bytes12(0), "Vault not cached");
+            require (cache.vaultOwner == msg.sender, "Only vault owner");
+            vaultId = cache.vaultId;
+            vault = cache.vault;
+        } else {
+            vault = cauldron.vaults(vaultId_);
+            vaultId = vaultId_;
+            require (vault.owner == msg.sender, "Only vault owner");
+        }
+    } 
     /// @dev Obtains a series by seriesId from the Cauldron, and verifies that it exists
     function getSeries(bytes6 seriesId)
         internal view returns(DataTypes.Series memory series)
@@ -70,7 +87,7 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Add a new Join for an Asset, or replace an existing one for a new one.
     /// There can be only one Join per Asset. Until a Join is added, no tokens of that Asset can be posted or withdrawn.
     function addJoin(bytes6 assetId, IJoin join)
-        external
+        external payable
         auth
     {
         address asset = cauldron.assets(assetId);
@@ -83,7 +100,7 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Add a new Pool for a Series, or replace an existing one for a new one.
     /// There can be only one Pool per Series. Until a Pool is added, it is not possible to borrow Base.
     function addPool(bytes6 seriesId, IPool pool)
-        external
+        external payable
         auth
     {
         IFYToken fyToken = getSeries(seriesId).fyToken;
@@ -95,7 +112,7 @@ contract Ladle is LadleStorage, AccessControl() {
 
     /// @dev Add or remove a module.
     function setModule(address module, bool set)
-        external
+        external payable
         auth
     {
         modules[module] = set;
@@ -104,7 +121,7 @@ contract Ladle is LadleStorage, AccessControl() {
 
     /// @dev Set the fee parameter
     function setFee(uint256 fee)
-        external
+        external payable
         auth    
     {
         borrowingFee = fee;
@@ -113,159 +130,18 @@ contract Ladle is LadleStorage, AccessControl() {
 
     // ---- Batching ----
 
-    /// @dev Return the cached vault if necessary, preceded by the current vaultId (needed if vaultId == bytes(0)) and cachedId (which is the same as the vaultId)
-    /// If refreshing the cache, verifies that msg.sender is the owner of the vault
-    function getCachedVault(bytes12 vaultId, bytes12 cachedId, DataTypes.Vault memory vault)
-        private view
-        returns (bytes12, bytes12, DataTypes.Vault memory)
-    {
-        require(vaultId != bytes12(0) || cachedId != bytes12(0), "Vault not cached");           // Can't use the cache
-        if (vaultId == bytes12(0) || vaultId == cachedId) return (cachedId, cachedId, vault);   // Use the cache
-        else return (vaultId, vaultId, getOwnedVault(vaultId));                                 // Refresh the cache
-    } 
-
-    /// @dev Submit a series of calls for execution.
-    /// Unlike `batch`, this function calls private functions, saving a CALL per function.
-    /// It also caches the vault, which is useful in `build` + `pour` and `build` + `serve` combinations.
-    function batch(
-        Operation[] calldata operations,
-        bytes[] calldata data
-    ) external payable returns(bytes[] memory results) {
-        require(operations.length == data.length, "Mismatched operation data");
-        bytes12 cachedId;
-        DataTypes.Vault memory vault;
-
-        results = new bytes[](operations.length);
-
-        // Execute all operations in the batch. Conditionals ordered by expected frequency.
-        for (uint256 i = 0; i < operations.length; i += 1) {
-
-            Operation operation = operations[i];
-
-            if (operation == Operation.BUILD) {
-                (bytes6 seriesId, bytes6 ilkId) = abi.decode(data[i], (bytes6, bytes6));
-                (cachedId, vault) = _build(seriesId, ilkId, 0);   // Cache the vault that was just built
-                results[i] = abi.encode(cachedId);  // We only return the data that changed
-            
-            } else if (operation == Operation.FORWARD_PERMIT) {
-                (bytes6 id, bool isAsset, address spender, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) =
-                    abi.decode(data[i], (bytes6, bool, address, uint256, uint256, uint8, bytes32, bytes32));
-                _forwardPermit(id, isAsset, spender, amount, deadline, v, r, s);
-                results[i] = abi.encode(true);
-            
-            } else if (operation == Operation.JOIN_ETHER) {
-                (bytes6 etherId) = abi.decode(data[i], (bytes6));
-                results[i] = abi.encode(_joinEther(etherId));
-            
-            } else if (operation == Operation.POUR) {
-                (bytes12 vaultId, address to, int128 ink, int128 art) = abi.decode(data[i], (bytes12, address, int128, int128));
-                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                _pour(vaultId, vault, to, ink, art);
-                results[i] = abi.encode(true);
-            
-            } else if (operation == Operation.SERVE) {
-                (bytes12 vaultId, address to, uint128 ink, uint128 base, uint128 max) = abi.decode(data[i], (bytes12, address, uint128, uint128, uint128));
-                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                results[i] = abi.encode(_serve(vaultId, vault, to, ink, base, max));
-
-            } else if (operation == Operation.ROLL) {
-                (bytes12 vaultId, bytes6 newSeriesId, uint8 loan, uint128 max) = abi.decode(data[i], (bytes12, bytes6, uint8, uint128));
-                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                uint256 newDebt;
-                (vault, newDebt) = _roll(vaultId, vault, newSeriesId, loan, max);
-                results[i] = abi.encode(newDebt);
-            
-            } else if (operation == Operation.FORWARD_DAI_PERMIT) {
-                (bytes6 id, bool isAsset, address spender, uint256 nonce, uint256 deadline, bool allowed, uint8 v, bytes32 r, bytes32 s) =
-                    abi.decode(data[i], (bytes6, bool, address, uint256, uint256, bool, uint8, bytes32, bytes32));
-                _forwardDaiPermit(id, isAsset, spender, nonce, deadline, allowed, v, r, s);
-                results[i] = abi.encode(true);
-            
-            } else if (operation == Operation.TRANSFER_TO_POOL) {
-                (bytes6 seriesId, bool base, uint128 wad) =
-                    abi.decode(data[i], (bytes6, bool, uint128));
-                IPool pool = getPool(seriesId);
-                _transferToPool(pool, base, wad);
-                results[i] = abi.encode(true);
-            
-            } else if (operation == Operation.ROUTE) {
-                (bytes6 seriesId, bytes memory poolCall) =
-                    abi.decode(data[i], (bytes6, bytes));
-                IPool pool = getPool(seriesId);
-                results[i] = _route(pool, poolCall);
-            
-            } else if (operation == Operation.EXIT_ETHER) {
-                (address to) = abi.decode(data[i], (address));
-                results[i] = abi.encode(_exitEther(payable(to)));
-            
-            } else if (operation == Operation.CLOSE) {
-                (bytes12 vaultId, address to, int128 ink, int128 art) = abi.decode(data[i], (bytes12, address, int128, int128));
-                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                results[i] = abi.encode(_close(vaultId, vault, to, ink, art));
-            
-            } else if (operation == Operation.REPAY) {
-                (bytes12 vaultId, address to, int128 ink, uint128 min) = abi.decode(data[i], (bytes12, address, int128, uint128));
-                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                results[i] = abi.encode(_repay(vaultId, vault, to, ink, min));
-            
-            } else if (operation == Operation.REPAY_VAULT) {
-                (bytes12 vaultId, address to, int128 ink, uint128 max) = abi.decode(data[i], (bytes12, address, int128, uint128));
-                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                results[i] = abi.encode(_repayVault(vaultId, vault, to, ink, max));
-
-            } else if (operation == Operation.REPAY_LADLE) {
-                (bytes12 vaultId) = abi.decode(data[i], (bytes12));
-                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);
-                results[i] = abi.encode(_repayLadle(vaultId, vault));
-
-            } else if (operation == Operation.RETRIEVE) {
-                (bytes6 assetId, bool isAsset, address to) = abi.decode(data[i], (bytes6, bool, address));
-                results[i] = abi.encode(_retrieve(assetId, isAsset, to));
-
-            } else if (operation == Operation.TRANSFER_TO_FYTOKEN) {
-                (bytes6 seriesId, uint256 amount) = abi.decode(data[i], (bytes6, uint256));
-                IFYToken fyToken = getSeries(seriesId).fyToken;
-                _transferToFYToken(fyToken, amount);
-                results[i] = abi.encode(true);
-            
-            } else if (operation == Operation.REDEEM) {
-                (bytes6 seriesId, address to, uint256 amount) = abi.decode(data[i], (bytes6, address, uint256));
-                IFYToken fyToken = getSeries(seriesId).fyToken;
-                results[i] = abi.encode(_redeem(fyToken, to, amount));
-            
-            } else if (operation == Operation.STIR) {
-                (bytes12 from, bytes12 to, uint128 ink, uint128 art) = abi.decode(data[i], (bytes12, bytes12, uint128, uint128));
-                _stir(from, to, ink, art);  // Too complicated to use caching here
-                results[i] = abi.encode(true);
-            
-            } else if (operation == Operation.TWEAK) {
-                (bytes12 vaultId, bytes6 seriesId, bytes6 ilkId) = abi.decode(data[i], (bytes12, bytes6, bytes6));
-                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
-                vault = _tweak(vaultId, seriesId, ilkId);
-                results[i] = abi.encode(true);
-
-            } else if (operation == Operation.GIVE) {
-                (bytes12 vaultId, address to) = abi.decode(data[i], (bytes12, address));
-                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
-                _give(vaultId, to);
-                results[i] = abi.encode(true);
-                delete vault;   // Clear the cache, since the vault doesn't necessarily belong to msg.sender anymore
-                cachedId = bytes12(0);
-
-            } else if (operation == Operation.DESTROY) {
-                (bytes12 vaultId) = abi.decode(data[i], (bytes12));
-                (vaultId, cachedId, vault) = getCachedVault(vaultId, cachedId, vault);  // Needed to verify ownership
-                _destroy(vaultId);
-                results[i] = abi.encode(true);
-                delete vault;   // Clear the cache
-                cachedId = bytes12(0);
-            
-            } else if (operation == Operation.MODULE) {
-                (address module, bytes memory moduleCall) = abi.decode(data[i], (address, bytes));
-                results[i] = _moduleCall(module, moduleCall);
-            
-            }
+    /// @dev Allows batched call to self (this contract).
+    /// @param calls An array of inputs for each call.
+    function batch(bytes[] calldata calls) external payable returns(bytes[] memory results) {
+        results = new bytes[](calls.length);
+        for (uint256 i = 0; i < calls.length; i++) {
+            (bool success, bytes memory result) = address(this).delegatecall(calls[i]);
+            if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
+            results[i] = result;
         }
+
+        // build would have populated the cache, this deletes it
+        delete cachedVault;   // TODO: Verify this deletes the cache
     }
 
     // ---- Vault management ----
@@ -276,12 +152,27 @@ contract Ladle is LadleStorage, AccessControl() {
     }
 
     /// @dev Create a new vault, linked to a series (and therefore underlying) and a collateral
+    function build(bytes6 seriesId, bytes6 ilkId, uint8 salt)
+        external payable
+        returns(bytes12, DataTypes.Vault memory)
+    {
+        return _build(seriesId, ilkId, salt);
+    }
+
+    /// @dev Create a new vault, linked to a series (and therefore underlying) and a collateral
+    // TODO: Include a function that doesn't cache the vault
     function _build(bytes6 seriesId, bytes6 ilkId, uint8 salt)
         private
         returns(bytes12, DataTypes.Vault memory)
     {
         bytes12 vaultId = _generateVaultId(salt);
         try cauldron.build(msg.sender, vaultId, seriesId, ilkId) returns (DataTypes.Vault memory vault) {
+            // Store the vault data in the cache
+            cachedVault = CachedVault({
+                vaultId: vaultId,
+                vaultOwner: msg.sender,
+                vault: vault
+            });
             return (vaultId, vault);
         } catch Error (string memory) {
             return _build(seriesId, ilkId, salt + 1);
@@ -289,34 +180,40 @@ contract Ladle is LadleStorage, AccessControl() {
     }
 
     /// @dev Change a vault series or collateral.
-    function _tweak(bytes12 vaultId, bytes6 seriesId, bytes6 ilkId)
-        private
+    function tweak(bytes12 vaultId_, bytes6 seriesId, bytes6 ilkId)
+        external payable
         returns(DataTypes.Vault memory vault)
     {
+        (bytes12 vaultId, ) = getVault(vaultId_); // getVault verifies the ownership as well
         // tweak checks that the series and the collateral both exist and that the collateral is approved for the series
-        return cauldron.tweak(vaultId, seriesId, ilkId);
+        vault = cauldron.tweak(vaultId, seriesId, ilkId);
+        cachedVault.vault = vault;
     }
 
     /// @dev Give a vault to another user.
-    function _give(bytes12 vaultId, address receiver)
-        private
+    function give(bytes12 vaultId_, address receiver)
+        external payable
         returns(DataTypes.Vault memory vault)
     {
-        return cauldron.give(vaultId, receiver);
+        (bytes12 vaultId, ) = getVault(vaultId_);
+        vault = cauldron.give(vaultId, receiver);
+        delete cachedVault;   // TODO: Verify this deletes the cache
     }
 
     /// @dev Destroy an empty vault. Used to recover gas costs.
-    function _destroy(bytes12 vaultId)
-        private
+    function destroy(bytes12 vaultId_)
+        external payable
     {
+        (bytes12 vaultId, ) = getVault(vaultId_);
         cauldron.destroy(vaultId);
+        delete cachedVault;   // TODO: Verify this deletes the cache
     }
 
     // ---- Asset and debt management ----
 
     /// @dev Move collateral and debt between vaults.
-    function _stir(bytes12 from, bytes12 to, uint128 ink, uint128 art)
-        private
+    function stir(bytes12 from, bytes12 to, uint128 ink, uint128 art)
+        external payable
     {
         if (ink > 0) require (cauldron.vaults(from).owner == msg.sender, "Only origin vault owner");
         if (art > 0) require (cauldron.vaults(to).owner == msg.sender, "Only destination vault owner");
@@ -352,13 +249,24 @@ contract Ladle is LadleStorage, AccessControl() {
         }
     }
 
+    /// @dev Add collateral and borrow from vault, pull assets from and push borrowed asset to user
+    /// Or, repay to vault and remove collateral, pull borrowed asset from and push assets to user
+    /// Borrow only before maturity.
+    function pour(bytes12 vaultId_, address to, int128 ink, int128 art)
+        external payable
+    {
+        (bytes12 vaultId, DataTypes.Vault memory vault) = getVault(vaultId_);
+        _pour(vaultId, vault, to, ink, art);
+    }
+
     /// @dev Add collateral and borrow from vault, so that a precise amount of base is obtained by the user.
     /// The base is obtained by borrowing fyToken and buying base with it in a pool.
     /// Only before maturity.
-    function _serve(bytes12 vaultId, DataTypes.Vault memory vault, address to, uint128 ink, uint128 base, uint128 max)
-        private
+    function serve(bytes12 vaultId_, address to, uint128 ink, uint128 base, uint128 max)
+        external payable
         returns (uint128 art)
     {
+        (bytes12 vaultId, DataTypes.Vault memory vault) = getVault(vaultId_);
         IPool pool = getPool(vault.seriesId);
         
         art = pool.buyBasePreview(base);
@@ -371,13 +279,14 @@ contract Ladle is LadleStorage, AccessControl() {
     /// The debt to repay is denominated in fyToken, even if the tokens pulled from the user are underlying.
     /// The debt to repay must be entered as a negative number, as with `pour`.
     /// Debt cannot be acquired with this function.
-    function _close(bytes12 vaultId, DataTypes.Vault memory vault, address to, int128 ink, int128 art)
-        private
+    function close(bytes12 vaultId_, address to, int128 ink, int128 art)
+        external payable
         returns (uint128 base)
     {
         require (art < 0, "Only repay debt");                                          // When repaying debt in `frob`, art is a negative value. Here is the same for consistency.
 
         // Calculate debt in fyToken terms
+        (bytes12 vaultId, DataTypes.Vault memory vault) = getVault(vaultId_);
         DataTypes.Series memory series = getSeries(vault.seriesId);
         base = cauldron.debtToBase(vault.seriesId, uint128(-art));
 
@@ -399,10 +308,11 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Repay debt by selling base in a pool and using the resulting fyToken
     /// The base tokens need to be already in the pool, unaccounted for.
     /// Only before maturity. After maturity use close.
-    function _repay(bytes12 vaultId, DataTypes.Vault memory vault, address to, int128 ink, uint128 min)
-        private
+    function repay(bytes12 vaultId_, address to, int128 ink, uint128 min)
+        external payable
         returns (uint128 art)
     {
+        (bytes12 vaultId, DataTypes.Vault memory vault) = getVault(vaultId_);
         DataTypes.Series memory series = getSeries(vault.seriesId);
         IPool pool = getPool(vault.seriesId);
 
@@ -413,10 +323,11 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Repay all debt in a vault by buying fyToken from a pool with base.
     /// The base tokens need to be already in the pool, unaccounted for. The surplus base will be returned to msg.sender.
     /// Only before maturity. After maturity use close.
-    function _repayVault(bytes12 vaultId, DataTypes.Vault memory vault, address to, int128 ink, uint128 max)
-        private
+    function repayVault(bytes12 vaultId_, address to, int128 ink, uint128 max)
+        external payable
         returns (uint128 base)
     {
+        (bytes12 vaultId, DataTypes.Vault memory vault) = getVault(vaultId_);
         DataTypes.Series memory series = getSeries(vault.seriesId);
         IPool pool = getPool(vault.seriesId);
 
@@ -427,13 +338,16 @@ contract Ladle is LadleStorage, AccessControl() {
     }
 
     /// @dev Change series and debt of a vault.
-    function _roll(bytes12 vaultId, DataTypes.Vault memory vault, bytes6 newSeriesId, uint8 loan, uint128 max)
-        private
-        returns (DataTypes.Vault memory vault_, uint128 newDebt)
+    function roll(bytes12 vaultId_, bytes6 newSeriesId, uint8 loan, uint128 max)
+        external payable
+        returns (DataTypes.Vault memory vault, uint128 newDebt)
     {
+        bytes12 vaultId;
+        (vaultId, vault) = getVault(vaultId_);
+        DataTypes.Balances memory balances = cauldron.balances(vaultId);
         DataTypes.Series memory series = getSeries(vault.seriesId);
         DataTypes.Series memory newSeries = getSeries(newSeriesId);
-        DataTypes.Balances memory balances = cauldron.balances(vaultId);
+        
         
         {
             IPool pool = getPool(newSeriesId);
@@ -456,18 +370,21 @@ contract Ladle is LadleStorage, AccessControl() {
 
         newDebt += ((newSeries.maturity - block.timestamp) * uint256(newDebt).wmul(borrowingFee)).u128();  // Add borrowing fee, also stops users form rolling to a mature series
 
-        (vault_,) = cauldron.roll(vaultId, newSeriesId, newDebt.i128() - balances.art.i128()); // Change the series and debt for the vault
-        
-        return (vault_, newDebt);
+        (vault,) = cauldron.roll(vaultId, newSeriesId, newDebt.i128() - balances.art.i128()); // Change the series and debt for the vault
+
+        cachedVault.vault = vault;
+
+        return (vault, newDebt);
     }
 
     // ---- Ladle as a token holder ----
 
     /// @dev Use fyToken in the Ladle to repay debt.
-    function _repayLadle(bytes12 vaultId, DataTypes.Vault memory vault)
-        private
+    function repayLadle(bytes12 vaultId_)
+        external payable
         returns (uint256 repaid)
     {
+        (bytes12 vaultId, DataTypes.Vault memory vault) = getVault(vaultId_);
         DataTypes.Series memory series = getSeries(vault.seriesId);
         DataTypes.Balances memory balances = cauldron.balances(vaultId);
         
@@ -480,8 +397,8 @@ contract Ladle is LadleStorage, AccessControl() {
     }
 
     /// @dev Retrieve any asset or fyToken in the Ladle
-    function _retrieve(bytes6 id, bool isAsset, address to) 
-        private
+    function retrieve(bytes6 id, bool isAsset, address to) 
+        external payable
         returns (uint256 amount)
     {
         IERC20 token = IERC20(findToken(id, isAsset));
@@ -500,16 +417,16 @@ contract Ladle is LadleStorage, AccessControl() {
     }
 
     /// @dev Execute an ERC2612 permit for the selected asset or fyToken
-    function _forwardPermit(bytes6 id, bool isAsset, address spender, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
-        private
+    function forwardPermit(bytes6 id, bool isAsset, address spender, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        external payable
     {
         IERC2612 token = IERC2612(findToken(id, isAsset));
         token.permit(msg.sender, spender, amount, deadline, v, r, s);
     }
 
     /// @dev Execute a Dai-style permit for the selected asset or fyToken
-    function _forwardDaiPermit(bytes6 id, bool isAsset, address spender, uint256 nonce, uint256 deadline, bool allowed, uint8 v, bytes32 r, bytes32 s)
-        private
+    function forwardDaiPermit(bytes6 id, bool isAsset, address spender, uint256 nonce, uint256 deadline, bool allowed, uint8 v, bytes32 r, bytes32 s)
+        external payable
     {
         DaiAbstract token = DaiAbstract(findToken(id, isAsset));
         token.permit(msg.sender, spender, nonce, deadline, allowed, v, r, s);
@@ -525,8 +442,8 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Accept Ether, wrap it and forward it to the WethJoin
     /// This function should be called first in a batch, and the Join should keep track of stored reserves
     /// Passing the id for a join that doesn't link to a contract implemnting IWETH9 will fail
-    function _joinEther(bytes6 etherId)
-        private
+    function joinEther(bytes6 etherId)
+        external payable
         returns (uint256 ethTransferred)
     {
         ethTransferred = address(this).balance;
@@ -537,8 +454,8 @@ contract Ladle is LadleStorage, AccessControl() {
 
     /// @dev Unwrap Wrapped Ether held by this Ladle, and send the Ether
     /// This function should be called last in a batch, and the Ladle should have no reason to keep an WETH balance
-    function _exitEther(address payable to)
-        private
+    function exitEther(address payable to)
+        external payable
         returns (uint256 ethTransferred)
     {
         ethTransferred = weth.balanceOf(address(this));
@@ -549,38 +466,42 @@ contract Ladle is LadleStorage, AccessControl() {
     // ---- Pool router ----
 
     /// @dev Allow users to trigger a token transfer to a pool through the ladle, to be used with batch
-    function _transferToPool(IPool pool, bool isBase, uint128 wad)
-        private
+    function transferToPool(bytes6 seriesId, bool isBase, uint128 wad)
+        external payable
     {
+        IPool pool = getPool(seriesId);
         IERC20 token = isBase ? pool.base() : pool.fyToken();
         token.safeTransferFrom(msg.sender, address(pool), wad);
     }
 
     /// @dev Allow users to route calls to a pool, to be used with batch
-    function _route(IPool pool, bytes memory data)
-        private
+    function route(bytes6 seriesId, bytes memory data)
+        external payable
         returns (bytes memory result)
     {
+        address pool = address(getPool(seriesId));
         bool success;
-        (success, result) = address(pool).call(data);
+        (success, result) = pool.call(data);
         if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
     }
 
     // ---- FYToken router ----
 
     /// @dev Allow users to trigger a token transfer to a pool through the ladle, to be used with batch
-    function _transferToFYToken(IFYToken fyToken, uint256 wad)
-        private
+    function transferToFYToken(bytes6 seriesId, uint256 wad)
+        external payable
     {
+        address fyToken = address(getSeries(seriesId).fyToken);
         IERC20(fyToken).safeTransferFrom(msg.sender, address(fyToken), wad);
     }
 
     /// @dev Allow users to redeem fyToken, to be used with batch.
     /// If 0 is passed as the amount to redeem, it redeems the fyToken balance of the Ladle instead.
-    function _redeem(IFYToken fyToken, address to, uint256 wad)
-        private
+    function redeem(bytes6 seriesId, address to, uint256 wad)
+        external payable
         returns (uint256)
     {
+        IFYToken fyToken = getSeries(seriesId).fyToken;
         return fyToken.redeem(to, wad != 0 ? wad : fyToken.balanceOf(address(this)));
     }
 
@@ -589,13 +510,13 @@ contract Ladle is LadleStorage, AccessControl() {
     /// @dev Allow users to use functionality coded in a module, to be used with batch
     /// @notice Modules must not do any changes to the vault (owner, seriesId, ilkId),
     /// it would be disastrous in combination with batch vault caching 
-    function _moduleCall(address module, bytes memory moduleCall)
-        private
+    function moduleCall(address module, bytes memory data)
+        external payable
         returns (bytes memory result)
     {
         require (modules[module], "Unregistered module");
         bool success;
-        (success, result) = module.delegatecall(moduleCall);
+        (success, result) = module.delegatecall(data);
         if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
     }
 

--- a/contracts/LadleStorage.sol
+++ b/contracts/LadleStorage.sol
@@ -7,32 +7,6 @@ import "@yield-protocol/yieldspace-interfaces/IPool.sol";
 
 /// @dev Ladle orchestrates contract calls throughout the Yield Protocol v2 into useful and efficient user oriented features.
 contract LadleStorage {
-
-    enum Operation {
-        BUILD,               // 0
-        TWEAK,               // 1
-        GIVE,                // 2
-        DESTROY,             // 3
-        STIR,                // 4
-        POUR,                // 5
-        SERVE,               // 6
-        ROLL,                // 7
-        CLOSE,               // 8
-        REPAY,               // 9
-        REPAY_VAULT,         // 10
-        REPAY_LADLE,         // 11
-        RETRIEVE,            // 12
-        FORWARD_PERMIT,      // 13
-        FORWARD_DAI_PERMIT,  // 14
-        JOIN_ETHER,          // 15
-        EXIT_ETHER,          // 16
-        TRANSFER_TO_POOL,    // 17
-        ROUTE,               // 18
-        TRANSFER_TO_FYTOKEN, // 19
-        REDEEM,              // 20
-        MODULE               // 21
-    }
-
     ICauldron public immutable cauldron;
     uint256 public borrowingFee;
 

--- a/contracts/mocks/WETH9Mock.sol
+++ b/contracts/mocks/WETH9Mock.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
-
 pragma solidity 0.8.1;
 
 

--- a/contracts/oracles/composite/CompositeMultiOracle.sol
+++ b/contracts/oracles/composite/CompositeMultiOracle.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.1;
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/vault-interfaces/IOracle.sol";
 import "../../math/CastBytes32Bytes6.sol";
-import "hardhat/console.sol";
 
 
 /**

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -87,7 +87,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 10000,
+        runs: 20000,
       }
     }
   },

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -87,7 +87,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 2500,
+        runs: 10000,
       }
     }
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,29 +1,4 @@
 import { ethers } from 'ethers'
 
-export const OPS = {
-    BUILD:                0,
-    TWEAK:                1,
-    GIVE:                 2,
-    DESTROY:              3,
-    STIR:                 4,
-    POUR:                 5,
-    SERVE:                6,
-    ROLL:                 7,
-    CLOSE:                8,
-    REPAY:                9,
-    REPAY_VAULT:          10,
-    REPAY_LADLE:          11,
-    RETRIEVE:             12,
-    FORWARD_PERMIT:       13,
-    FORWARD_DAI_PERMIT:   14,
-    JOIN_ETHER:           15,
-    EXIT_ETHER:           16,
-    TRANSFER_TO_POOL:     17,
-    ROUTE:                18,
-    TRANSFER_TO_FYTOKEN:  19,
-    REDEEM:               20,
-    MODULE:               21,
-  }
-
 export const CHI = ethers.utils.formatBytes32String('chi').slice(0, 14)
 export const RATE = ethers.utils.formatBytes32String('rate').slice(0, 14)

--- a/src/ladleWrapper.ts
+++ b/src/ladleWrapper.ts
@@ -1,17 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
 import { ethers, BigNumberish, ContractTransaction, BytesLike, PayableOverrides } from 'ethers'
 import { Ladle } from '../typechain/Ladle'
-import { OPS } from './constants'
-
-export class BatchAction {
-  op: BigNumberish
-  data: string
-
-  constructor(op: BigNumberish, data: string) {
-    this.op = op
-    this.data = data
-  }
-}
 
 export class LadleWrapper {
   ladle: Ladle
@@ -76,272 +65,259 @@ export class LadleWrapper {
     return this.ladle.pools(seriesId)
   }
 
-  public async batch(actions: Array<BatchAction>, overrides?: PayableOverrides): Promise<ContractTransaction> {
-    const ops = new Array<BigNumberish>()
-    const data = new Array<BytesLike>()
-    actions.forEach(action => {
-      ops.push(action.op)
-      data.push(action.data)
-    });
-    if (overrides === undefined) return this.ladle.batch(ops, data)
-    else return this.ladle.batch(ops, data, overrides)
+  public async batch(actions: Array<string>, overrides?: PayableOverrides): Promise<ContractTransaction> {
+    if (overrides === undefined) return this.ladle.batch(actions)
+    else return this.ladle.batch(actions, overrides)
   }
 
-  public buildAction(seriesId: string, ilkId: string): BatchAction {
-    return new BatchAction(OPS.BUILD, ethers.utils.defaultAbiCoder.encode(['bytes6', 'bytes6'], [seriesId, ilkId]))
+  public buildAction(seriesId: string, ilkId: string): string {
+    return this.ladle.interface.encodeFunctionData('build', [seriesId, ilkId, 0])
   }
 
   public async build(seriesId: string, ilkId: string): Promise<ContractTransaction> {
-    return this.batch([this.buildAction(seriesId, ilkId)])
+    return this.ladle.build(seriesId, ilkId, 0)
   }
 
-  public tweakAction(vaultId: string, seriesId: string, ilkId: string): BatchAction {
-    return new BatchAction(OPS.TWEAK, ethers.utils.defaultAbiCoder.encode(['bytes12', 'bytes6', 'bytes6'], [vaultId, seriesId, ilkId]))
+  public tweakAction(vaultId: string, seriesId: string, ilkId: string): string {
+    return this.ladle.interface.encodeFunctionData('tweak', [vaultId, seriesId, ilkId])
   }
 
   public async tweak(vaultId: string, seriesId: string, ilkId: string): Promise<ContractTransaction> {
-    return this.batch([this.tweakAction(vaultId, seriesId, ilkId)])
+    return this.ladle.tweak(vaultId, seriesId, ilkId)
   }
 
-  public giveAction(vaultId: string, to: string): BatchAction {
-    return new BatchAction(OPS.GIVE, ethers.utils.defaultAbiCoder.encode(['bytes12', 'address'], [vaultId, to]))
+  public giveAction(vaultId: string, to: string): string {
+    return this.ladle.interface.encodeFunctionData('give', [vaultId, to])
   }
 
   public async give(vaultId: string, to: string): Promise<ContractTransaction> {
-    return this.batch([this.giveAction(vaultId, to)])
+    return this.ladle.give(vaultId, to)
   }
 
-  public destroyAction(vaultId: string): BatchAction {
-    return new BatchAction(OPS.DESTROY, ethers.utils.defaultAbiCoder.encode(['bytes12'], [vaultId]))
+  public destroyAction(vaultId: string): string {
+    return this.ladle.interface.encodeFunctionData('destroy', [vaultId])
   }
 
   public async destroy(vaultId: string): Promise<ContractTransaction> {
-    return this.batch([this.destroyAction(vaultId)])
+    return this.ladle.destroy(vaultId)
   }
 
-  public stirAction(from: string, to: string, ink: BigNumberish, art: BigNumberish): BatchAction {
-    return new BatchAction(OPS.STIR, ethers.utils.defaultAbiCoder.encode(['bytes12', 'bytes12', 'uint128', 'uint128'], [from, to, ink, art]))
+  public stirAction(from: string, to: string, ink: BigNumberish, art: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('stir', [from, to, ink, art])
   }
 
   public async stir(from: string, to: string, ink: BigNumberish, art: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.stirAction(from, to, ink, art)])
+    return this.ladle.stir(from, to, ink, art)
   }
 
-  public pourAction(vaultId: string, to: string, ink: BigNumberish, art: BigNumberish): BatchAction {
-    return new BatchAction(OPS.POUR, ethers.utils.defaultAbiCoder.encode(['bytes12', 'address', 'int128', 'int128'], [vaultId, to, ink, art]))
+  public pourAction(vaultId: string, to: string, ink: BigNumberish, art: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('pour', [vaultId, to, ink, art])
   }
 
   public async pour(vaultId: string, to: string, ink: BigNumberish, art: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.pourAction(vaultId, to, ink, art)])
+    return this.ladle.pour(vaultId, to, ink, art)
   }
 
-  public closeAction(vaultId: string, to: string, ink: BigNumberish, art: BigNumberish): BatchAction {
-    return new BatchAction(OPS.CLOSE, ethers.utils.defaultAbiCoder.encode(['bytes12', 'address', 'int128', 'int128'], [vaultId, to, ink, art]))
+  public closeAction(vaultId: string, to: string, ink: BigNumberish, art: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('close', [vaultId, to, ink, art])
   }
 
   public async close(vaultId: string, to: string, ink: BigNumberish, art: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.closeAction(vaultId, to, ink, art)])
+    return this.ladle.close(vaultId, to, ink, art)
   }
 
-  public serveAction(vaultId: string, to: string, ink: BigNumberish, base: BigNumberish, max: BigNumberish): BatchAction {
-    return new BatchAction(OPS.SERVE, ethers.utils.defaultAbiCoder.encode(['bytes12', 'address', 'uint128', 'uint128', 'uint128'], [vaultId, to, ink, base, max]))
+  public serveAction(vaultId: string, to: string, ink: BigNumberish, base: BigNumberish, max: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('serve', [vaultId, to, ink, base, max])
   }
 
   public async serve(vaultId: string, to: string, ink: BigNumberish, base: BigNumberish, max: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.serveAction(vaultId, to, ink, base, max)])
+    return this.ladle.serve(vaultId, to, ink, base, max)
   }
 
-  public repayAction(vaultId: string, to: string, ink: BigNumberish, min: BigNumberish): BatchAction {
-    return new BatchAction(OPS.REPAY, ethers.utils.defaultAbiCoder.encode(['bytes12', 'address', 'int128', 'uint128'], [vaultId, to, ink, min]))
+  public repayAction(vaultId: string, to: string, ink: BigNumberish, min: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('repay', [vaultId, to, ink, min])
   }
 
   public async repay(vaultId: string, to: string, ink: BigNumberish, min: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.repayAction(vaultId, to, ink, min)])
+    return this.ladle.repay(vaultId, to, ink, min)
   }
 
-  public repayVaultAction(vaultId: string, to: string, ink: BigNumberish, max: BigNumberish): BatchAction {
-    return new BatchAction(OPS.REPAY_VAULT, ethers.utils.defaultAbiCoder.encode(['bytes12', 'address', 'int128', 'uint128'], [vaultId, to, ink, max]))
+  public repayVaultAction(vaultId: string, to: string, ink: BigNumberish, max: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('repayVault', [vaultId, to, ink, max])
   }
 
   public async repayVault(vaultId: string, to: string, ink: BigNumberish, max: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.repayVaultAction(vaultId, to, ink, max)])
+    return this.ladle.repayVault(vaultId, to, ink, max)
   }
 
-  public repayLadleAction(vaultId: string): BatchAction {
-    return new BatchAction(OPS.REPAY_LADLE, ethers.utils.defaultAbiCoder.encode(['bytes12'], [vaultId]))
+  public repayLadleAction(vaultId: string): string {
+    return this.ladle.interface.encodeFunctionData('repayLadle', [vaultId])
   }
 
   public async repayLadle(vaultId: string): Promise<ContractTransaction> {
-    return this.batch([this.repayLadleAction(vaultId)])
+    return this.ladle.repayLadle(vaultId)
   }
 
-  public retrieveAction(assetId: string, isAsset: boolean, to: string): BatchAction {
-    return new BatchAction(OPS.RETRIEVE, ethers.utils.defaultAbiCoder.encode(['bytes6', 'bool', 'address'], [assetId, isAsset, to]))
+  public retrieveAction(assetId: string, isAsset: boolean, to: string): string {
+    return this.ladle.interface.encodeFunctionData('retrieve', [assetId, isAsset, to])
   }
 
   public async retrieve(assetId: string, isAsset: boolean, to: string): Promise<ContractTransaction> {
-    return this.batch([this.retrieveAction(assetId, isAsset, to)])
+    return this.ladle.retrieve(assetId, isAsset, to)
   }
 
-  public rollAction(vaultId: string, newSeriesId: string, loan: BigNumberish, max: BigNumberish): BatchAction {
-    return new BatchAction(OPS.ROLL, ethers.utils.defaultAbiCoder.encode(['bytes12', 'bytes6', 'uint8', 'uint128'], [vaultId, newSeriesId, loan, max]))
+  public rollAction(vaultId: string, newSeriesId: string, loan: BigNumberish, max: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('roll', [vaultId, newSeriesId, loan, max])
   }
 
   public async roll(vaultId: string, newSeriesId: string, loan: BigNumberish, max: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.rollAction(vaultId, newSeriesId, loan, max)])
+    return this.ladle.roll(vaultId, newSeriesId, loan, max)
   }
 
-  public forwardPermitAction(id: string, isAsset: boolean, spender: string, amount: BigNumberish, deadline: BigNumberish, v: BigNumberish, r: Buffer, s: Buffer): BatchAction {
-    return new BatchAction(OPS.FORWARD_PERMIT, ethers.utils.defaultAbiCoder.encode(
-      ['bytes6', 'bool', 'address', 'uint256', 'uint256', 'uint8', 'bytes32', 'bytes32'],
+  public forwardPermitAction(id: string, isAsset: boolean, spender: string, amount: BigNumberish, deadline: BigNumberish, v: BigNumberish, r: Buffer, s: Buffer): string {
+    return this.ladle.interface.encodeFunctionData('forwardPermit',
       [id, isAsset, spender, amount, deadline, v, r, s]
-    ))
+    )
   }
 
   public async forwardPermit(id: string, isAsset: boolean, spender: string, amount: BigNumberish, deadline: BigNumberish, v: BigNumberish, r: Buffer, s: Buffer): Promise<ContractTransaction> {
-    return this.batch([this.forwardPermitAction(id, isAsset, spender, amount, deadline, v, r, s)])
+    return this.ladle.forwardPermit(id, isAsset, spender, amount, deadline, v, r, s)
   }
 
-  public forwardDaiPermitAction(id: string, isAsset: boolean, spender: string, nonce: BigNumberish, deadline: BigNumberish, approved: boolean, v: BigNumberish, r: Buffer, s: Buffer): BatchAction {
-    return new BatchAction(OPS.FORWARD_DAI_PERMIT, ethers.utils.defaultAbiCoder.encode(
-      ['bytes6', 'bool', 'address', 'uint256', 'uint256', 'bool', 'uint8', 'bytes32', 'bytes32'],
+  public forwardDaiPermitAction(id: string, isAsset: boolean, spender: string, nonce: BigNumberish, deadline: BigNumberish, approved: boolean, v: BigNumberish, r: Buffer, s: Buffer): string {
+    return this.ladle.interface.encodeFunctionData('forwardDaiPermit',
       [id, isAsset, spender, nonce, deadline, approved, v, r, s]
-    ))
+    )
   }
 
   public async forwardDaiPermit(id: string, isAsset: boolean, spender: string, nonce: BigNumberish, deadline: BigNumberish, approved: boolean, v: BigNumberish, r: Buffer, s: Buffer): Promise<ContractTransaction> {
-    return this.batch([this.forwardDaiPermitAction(id, isAsset, spender, nonce, deadline, approved, v, r, s)])
+    return this.ladle.forwardDaiPermit(id, isAsset, spender, nonce, deadline, approved, v, r, s)
   }
 
-  public joinEtherAction(etherId: string): BatchAction {
-    return new BatchAction(OPS.JOIN_ETHER, ethers.utils.defaultAbiCoder.encode(['bytes6'], [etherId]))
+  public joinEtherAction(etherId: string): string {
+    return this.ladle.interface.encodeFunctionData('joinEther', [etherId])
   }
 
   public async joinEther(etherId: string, overrides?: any): Promise<ContractTransaction> {
-    return this.batch([this.joinEtherAction(etherId)], overrides)
+    return this.ladle.joinEther(etherId, overrides)
   }
 
-  public exitEtherAction(to: string): BatchAction {
-    return new BatchAction(OPS.EXIT_ETHER, ethers.utils.defaultAbiCoder.encode(['address'], [to]))
+  public exitEtherAction(to: string): string {
+    return this.ladle.interface.encodeFunctionData('exitEther', [to])
   }
 
   public async exitEther(to: string): Promise<ContractTransaction> {
-    return this.batch([this.exitEtherAction(to)])
+    return this.ladle.exitEther(to)
   }
 
-  public transferToPoolAction(seriesId: string, base: boolean, wad: BigNumberish): BatchAction {
-    return new BatchAction(OPS.TRANSFER_TO_POOL, ethers.utils.defaultAbiCoder.encode(['bytes6', 'bool', 'uint128'], [seriesId, base, wad]))
+  public transferToPoolAction(seriesId: string, base: boolean, wad: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('transferToPool', [seriesId, base, wad])
   }
 
   public async transferToPool(seriesId: string, base: boolean, wad: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.transferToPoolAction(seriesId, base, wad)])
+    return this.ladle.transferToPool(seriesId, base, wad)
   }
 
-  public routeAction(seriesId: string, poolCall: string): BatchAction {
-    return new BatchAction(OPS.ROUTE, ethers.utils.defaultAbiCoder.encode(['bytes6', 'bytes'], [seriesId, poolCall]))
+  public routeAction(seriesId: string, poolCall: string): string {
+    return this.ladle.interface.encodeFunctionData('route', [seriesId, poolCall])
   }
 
   public async route(seriesId: string, poolCall: string): Promise<ContractTransaction> {
-    return this.batch([this.routeAction(seriesId, poolCall)])
+    return this.ladle.route(seriesId, poolCall)
   }
 
-  public transferToFYTokenAction(seriesId: string, wad: BigNumberish): BatchAction {
-    return new BatchAction(OPS.TRANSFER_TO_FYTOKEN, ethers.utils.defaultAbiCoder.encode(['bytes6', 'uint256'], [seriesId, wad]))
+  public transferToFYTokenAction(seriesId: string, wad: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('transferToFYToken', [seriesId, wad])
   }
 
   public async transferToFYToken(seriesId: string, wad: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.transferToFYTokenAction(seriesId, wad)])
+    return this.ladle.transferToFYToken(seriesId, wad)
   }
 
-  public redeemAction(seriesId: string, to: string, wad: BigNumberish): BatchAction {
-    return new BatchAction(OPS.REDEEM, ethers.utils.defaultAbiCoder.encode(['bytes6', 'address', 'uint256'], [seriesId, to, wad]))
+  public redeemAction(seriesId: string, to: string, wad: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('redeem', [seriesId, to, wad])
   }
 
   public async redeem(seriesId: string, to: string, wad: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.redeemAction(seriesId, to, wad)])
+    return this.ladle.redeem(seriesId, to, wad)
   }
 
 
-  public sellBaseAction(seriesId: string, receiver: string, min: BigNumberish): BatchAction {
-    return new BatchAction(OPS.ROUTE, ethers.utils.defaultAbiCoder.encode(
-      ['bytes6', 'bytes'],
+  public sellBaseAction(seriesId: string, receiver: string, min: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('route',
       [
         seriesId,
         this.pool.encodeFunctionData('sellBase', [receiver, min])
       ]
-    ))
+    )
   }
 
   public async sellBase(seriesId: string, receiver: string, min: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.sellBaseAction(seriesId, receiver, min)])
+    return this.ladle.route(seriesId, this.pool.encodeFunctionData('sellBase', [receiver, min]))
   }
 
-  public sellFYTokenAction(seriesId: string, receiver: string, min: BigNumberish): BatchAction {
-    return new BatchAction(OPS.ROUTE, ethers.utils.defaultAbiCoder.encode(
-      ['bytes6', 'bytes'],
+  public sellFYTokenAction(seriesId: string, receiver: string, min: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('route',
       [
         seriesId,
         this.pool.encodeFunctionData('sellFYToken', [receiver, min])
       ]
-    ))
+    )
   }
 
   public async sellFYToken(seriesId: string, receiver: string, min: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.sellFYTokenAction(seriesId, receiver, min)])
+    return this.ladle.route(seriesId, this.pool.encodeFunctionData('sellFYToken', [receiver, min]))
   }
 
-  public mintWithBaseAction(seriesId: string, receiver: string, fyTokenToBuy: BigNumberish, minTokensMinted: BigNumberish): BatchAction {
-    return new BatchAction(OPS.ROUTE, ethers.utils.defaultAbiCoder.encode(
-      ['bytes6', 'bytes'],
+  public mintWithBaseAction(seriesId: string, receiver: string, fyTokenToBuy: BigNumberish, minTokensMinted: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('route',
       [
         seriesId,
         this.pool.encodeFunctionData('mintWithBase', [receiver, fyTokenToBuy, minTokensMinted])
       ]
-    ))
+    )
   }
 
   public async mintWithBase(seriesId: string, receiver: string, fyTokenToBuy: BigNumberish, minTokensMinted: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.mintWithBaseAction(seriesId, receiver, fyTokenToBuy, minTokensMinted)])
+    return this.ladle.route(seriesId, this.pool.encodeFunctionData('mintWithBase', [receiver, fyTokenToBuy, minTokensMinted]))
   }
 
-  public burnForBaseAction(seriesId: string, receiver: string, minBaseOut: BigNumberish): BatchAction {
-    return new BatchAction(OPS.ROUTE, ethers.utils.defaultAbiCoder.encode(
-      ['bytes6', 'bytes'],
+  public burnForBaseAction(seriesId: string, receiver: string, minBaseOut: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('route',
       [
         seriesId,
         this.pool.encodeFunctionData('burnForBase', [receiver, minBaseOut])
       ]
-    ))
+    )
   }
 
   public async burnForBase(seriesId: string, receiver: string, minBaseOut: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.burnForBaseAction(seriesId, receiver, minBaseOut)])
+    return this.ladle.route(seriesId, this.pool.encodeFunctionData('burnForBase', [receiver, minBaseOut]))
   }
 
-  public tlmApproveAction(tlmModuleAddress: string, seriesId: string): BatchAction {
+  public tlmApproveAction(tlmModuleAddress: string, seriesId: string): string {
     const tlmApproveCall = this.tlmModule.encodeFunctionData('approve', [seriesId])
 
-    return new BatchAction(OPS.MODULE, ethers.utils.defaultAbiCoder.encode(
-      ['address', 'bytes'],
+    return this.ladle.interface.encodeFunctionData('moduleCall',
       [tlmModuleAddress, tlmApproveCall]
-    ))
+    )
   }
 
   public async tlmApprove(tlmModuleAddress: string, seriesId: string): Promise<ContractTransaction> {
-    return this.batch([this.tlmApproveAction(tlmModuleAddress, seriesId)])
+    const tlmApproveCall = this.tlmModule.encodeFunctionData('approve', [seriesId])
+    return this.ladle.moduleCall(tlmModuleAddress, tlmApproveCall)
   }
 
-  public tlmSellAction(tlmModuleAddress: string, seriesId: string, receiver: string, amount: BigNumberish): BatchAction {
+  public tlmSellAction(tlmModuleAddress: string, seriesId: string, receiver: string, amount: BigNumberish): string {
     const tlmSellCall = this.tlmModule.encodeFunctionData('sell', [seriesId, receiver, amount])
-
-    return new BatchAction(OPS.MODULE, ethers.utils.defaultAbiCoder.encode(
-      ['address', 'bytes'],
+    return this.ladle.interface.encodeFunctionData('moduleCall',
       [tlmModuleAddress, tlmSellCall]
-    ))
+    )
   }
 
   public async tlmSell(tlmModuleAddress: string, seriesId: string, receiver: string, amount: BigNumberish): Promise<ContractTransaction> {
-    return this.batch([this.tlmSellAction(tlmModuleAddress, seriesId, receiver, amount)])
+    const tlmSellCall = this.tlmModule.encodeFunctionData('sell', [seriesId, receiver, amount])
+    return this.ladle.tlmSell(tlmModuleAddress, tlmSellCall)
   }
 }
   

--- a/test/070_ladle_batch.ts
+++ b/test/070_ladle_batch.ts
@@ -74,10 +74,6 @@ describe('Ladle - batch', function () {
     ethVaultId = (env.vaults.get(seriesId) as Map<string, string>).get(ethId) as string
   })
 
-  it('operations and their data must match in length', async () => {
-    await expect(ladle.ladle.batch([0], [])).to.be.revertedWith('Mismatched operation data')
-  })
-
   it('builds a vault, tweaks it and gives it', async () => {
     await ladle.batch([
       ladle.buildAction(seriesId, ilkId),

--- a/test/070_ladle_batch.ts
+++ b/test/070_ladle_batch.ts
@@ -102,7 +102,7 @@ describe('Ladle - batch', function () {
         ladle.giveAction(cachedVaultId, other),
         ladle.tweakAction(cachedVaultId, seriesId, otherIlkId),
       ])
-    ).to.be.revertedWith('Vault not cached')
+    ).to.be.revertedWith('Only vault owner')
   })
 
   it('builds a vault, permit and pour', async () => {


### PR DESCRIPTION
The main changes are:
1. All functions are now `external payable`. They can be executed in a batch or on their own. To make the generalized use of `payable` safe the contract never uses `msg.value`.
2. The vault cache is now done in an storage variable, which costs no gas if used in a batch because it returns to zero at the end of the batch. To avoid scenarios where a vault is intentionally left in the cache after the transaction to carry out an attack, only the vaultId is cached, and the vault is retrieved and matched against msg.sender for each action. This is cheap after the Berlin fork.
3. Optimization runs have been raised from 2500 to 20000