### PR TITLE
feat: transferToModule

### DIFF
--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -470,7 +470,7 @@ contract Ladle is LadleStorage, AccessControl() {
 
     // ---- FYToken router ----
 
-    /// @dev Allow users to trigger a token transfer to a pool through the ladle, to be used with batch
+    /// @dev Allow users to trigger a token transfer to a fyToken through the ladle, to be used with batch
     function transferToFYToken(bytes6 seriesId, uint256 wad)
         external payable
     {
@@ -503,4 +503,14 @@ contract Ladle is LadleStorage, AccessControl() {
         if (!success) revert(RevertMsgExtractor.getRevertMsg(result));
     }
 
+    /// @dev Allow users to trigger an asset transfer to a module through the ladle, to be used with batch
+    function transferToModule(bytes6 assetId, address module, uint256 wad)
+        external payable
+    {
+        require (modules[module], "Unregistered module");
+        IERC20 token = IERC20(cauldron.assets(assetId));
+        require (token != IERC20(address(0)), "Unknown asset");
+
+        token.safeTransferFrom(msg.sender, module, wad);
+    }
 }

--- a/src/ladleWrapper.ts
+++ b/src/ladleWrapper.ts
@@ -242,7 +242,6 @@ export class LadleWrapper {
     return this.ladle.redeem(seriesId, to, wad)
   }
 
-
   public sellBaseAction(seriesId: string, receiver: string, min: BigNumberish): string {
     return this.ladle.interface.encodeFunctionData('route',
       [
@@ -318,6 +317,14 @@ export class LadleWrapper {
   public async tlmSell(tlmModuleAddress: string, seriesId: string, receiver: string, amount: BigNumberish): Promise<ContractTransaction> {
     const tlmSellCall = this.tlmModule.encodeFunctionData('sell', [seriesId, receiver, amount])
     return this.ladle.tlmSell(tlmModuleAddress, tlmSellCall)
+  }
+
+  public transferToModuleAction(assetId: string, module_: string, wad: BigNumberish): string {
+    return this.ladle.interface.encodeFunctionData('transferToModule', [assetId, module_, wad])
+  }
+
+  public async transferToModule(assetId: string, module_: string, wad: BigNumberish): Promise<ContractTransaction> {
+    return this.ladle.transferToModule(assetId, module_, wad)
   }
 }
   

--- a/test/072_module_transfer.ts
+++ b/test/072_module_transfer.ts
@@ -82,9 +82,7 @@ describe('Ladle - module transfer', function () {
 
   it('transfers to a module', async () => {
     await base.approve(ladle.address, WAD)
-    await expect(ladle.transferToModule(baseId, user1, WAD))
-      .to.emit(base, 'Transfer')
-      .withArgs(owner, user1, WAD)
+    await expect(ladle.transferToModule(baseId, user1, WAD)).to.emit(base, 'Transfer').withArgs(owner, user1, WAD)
     expect(await base.balanceOf(user1)).to.equal(WAD)
   })
 })


### PR DESCRIPTION
Allow the Ladle to transfer known assets to known modules, so that the modules can be the first action in a batch