### PR TITLE
fix: ladle.build infinite loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.9.0-rc0",
+  "version": "0.9.0-rc1",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [

--- a/test/063_ladle_vaults.ts
+++ b/test/063_ladle_vaults.ts
@@ -70,6 +70,12 @@ describe('Ladle - vaults', function () {
     expect(vault.ilkId).to.equal(ilkId)
   })
 
+  it('doesn\'t fall into an infinite vaultId generating loop', async () => {
+    await expect(ladle.build(seriesId, emptyAssetId)).to.be.revertedWith(
+      'Ilk id is zero'
+    )
+  })
+
   it('does not allow destroying vaults if not the vault owner', async () => {
     await expect(ladleFromOther.destroy(vaultId)).to.be.revertedWith('Only vault owner')
   })

--- a/test/063_ladle_vaults.ts
+++ b/test/063_ladle_vaults.ts
@@ -70,10 +70,8 @@ describe('Ladle - vaults', function () {
     expect(vault.ilkId).to.equal(ilkId)
   })
 
-  it('doesn\'t fall into an infinite vaultId generating loop', async () => {
-    await expect(ladle.build(seriesId, emptyAssetId)).to.be.revertedWith(
-      'Ilk id is zero'
-    )
+  it("doesn't fall into an infinite vaultId generating loop", async () => {
+    await expect(ladle.build(seriesId, emptyAssetId)).to.be.revertedWith('Ilk id is zero')
   })
 
   it('does not allow destroying vaults if not the vault owner', async () => {


### PR DESCRIPTION
When building a vault through the Ladle, if the Cauldron reverts for any reason other than the vaultId already being used, the Ladle will fall into an infinite vaultId generating and vault building loop. Fun, but expensive.