### PR TITLE
Redeem from fyToken contract

### DIFF
--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -131,17 +131,19 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit,
         accrual_ = accrual_ >= 1e18 ? accrual_ : 1e18;     // The accrual can't be below 1 (with 18 decimals)
     }
 
-    /// @dev Burn the fyToken after maturity for an amount that increases according to `chi`
+    /// @dev Burn fyToken after maturity for an amount that increases according to `chi`
+    /// If `amount` is 0, the contract will redeem instead the fyToken balance of this contract. Useful for batches.
     function redeem(address to, uint256 amount)
         external override
         afterMaturity
         returns (uint256 redeemed)
     {
-        _burn(msg.sender, amount);
-        redeemed = amount.wmul(_accrual());
+        uint256 amount_ = (amount == 0) ? _balanceOf[address(this)] : amount;
+        _burn(msg.sender, amount_);
+        redeemed = amount_.wmul(_accrual());
         join.exit(to, redeemed.u128());
         
-        emit Redeemed(msg.sender, to, amount, redeemed);
+        emit Redeemed(msg.sender, to, amount_, redeemed);
     }
 
     /// @dev Mint fyTokens.

--- a/test/031_fyToken.ts
+++ b/test/031_fyToken.ts
@@ -110,7 +110,7 @@ describe('FYToken', function () {
     it('matures by recording the chi value', async () => {
       expect(await fyToken.mature())
         .to.emit(fyToken, 'SeriesMatured')
-        .withArgs(WAD)
+        .withArgs(await chiSource.exchangeRateStored())
     })
 
     it('matures if needed on first redemption after maturity', async () => {
@@ -153,7 +153,7 @@ describe('FYToken', function () {
         const baseJoinBefore = await base.balanceOf(baseJoin.address)
         await fyToken.transfer(fyToken.address, WAD)
         expect(await fyToken.balanceOf(owner)).to.equal(0)
-        await expect(fyToken.redeem(owner, WAD))
+        await expect(fyToken.redeem(owner, 0))
           .to.emit(fyToken, 'Transfer')
           .withArgs(fyToken.address, '0x0000000000000000000000000000000000000000', WAD)
           .to.emit(fyToken, 'Redeemed')


### PR DESCRIPTION
If the `amount` to redeem is 0, the fyToken contract redeems its own balance, as with uniswap v2.