### PR TITLE
feat: repay/close from ladle

### DIFF
--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -6,6 +6,7 @@ import "@yield-protocol/vault-interfaces/DataTypes.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
 import "@yield-protocol/utils-v2/contracts/math/WDiv.sol";
+import "@yield-protocol/utils-v2/contracts/math/WDivUp.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastU128I128.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastI128U128.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastU256U128.sol";
@@ -24,6 +25,7 @@ contract Cauldron is AccessControl() {
     using CauldronMath for uint128;
     using WMul for uint256;
     using WDiv for uint256;
+    using WDivUp for uint256;
     using CastU128I128 for uint128;
     using CastI128U128 for int128;
     using CastU256U128 for uint256;
@@ -257,14 +259,14 @@ contract Cauldron is AccessControl() {
     }
 
     /// @dev Convert a debt amount for a series from base to fyToken terms.
-    /// @notice Think about rounding if using, since we are dividing.
+    /// @notice Think about rounding up if using, since we are dividing.
     function debtFromBase(bytes6 seriesId, uint128 base)
         external
         returns (uint128 art)
     {
         if (uint32(block.timestamp) >= series[seriesId].maturity) {
             DataTypes.Series memory series_ = series[seriesId];
-            art = uint256(base).wdiv(_accrual(seriesId, series_)).u128();
+            art = uint256(base).wdivup(_accrual(seriesId, series_)).u128();
         } else {
             art = base;
         }

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -483,8 +483,8 @@ contract Ladle is LadleStorage, AccessControl() {
 
     // ---- Ladle as a token holder ----
 
-    /// @dev Use fyToken in the Ladle to repay debt.
-    function repayLadle(bytes12 vaultId_)
+    /// @dev Use fyToken in the Ladle to repay debt. Return unused fyToken to `to`.
+    function repayFromLadle(bytes12 vaultId_, address to)
         external payable
         returns (uint256 repaid)
     {
@@ -493,11 +493,45 @@ contract Ladle is LadleStorage, AccessControl() {
         DataTypes.Balances memory balances = cauldron.balances(vaultId);
         
         uint256 amount = series.fyToken.balanceOf(address(this));
+        if (amount == 0 || balances.art == 0) return 0;
+
         repaid = amount <= balances.art ? amount : balances.art;
 
         // Update accounting
         cauldron.pour(vaultId, 0, -(repaid.i128()));
         series.fyToken.burn(address(this), repaid);
+
+        // Return remainder
+        if (repaid < amount) IERC20(address(series.fyToken)).safeTransfer(to, repaid - amount);
+    }
+
+    /// @dev Use base in the Ladle to repay debt. Return unused base to `to`.
+    function closeFromLadle(bytes12 vaultId_, address to)
+        external payable
+        returns (uint256 repaid)
+    {
+        (bytes12 vaultId, DataTypes.Vault memory vault) = getVault(vaultId_);
+        DataTypes.Series memory series = getSeries(vault.seriesId);
+        DataTypes.Balances memory balances = cauldron.balances(vaultId);
+        
+        IERC20 base = IERC20(cauldron.assets(series.baseId));
+        uint256 amount = base.balanceOf(address(this));
+        if (amount == 0 || balances.art == 0) return 0;
+
+        uint256 debtInBase = cauldron.debtToBase(vault.seriesId, balances.art);
+        uint128 repaidInBase = ((amount <= debtInBase) ? amount : debtInBase).u128();
+        repaid = (repaidInBase == debtInBase) ? balances.art : cauldron.debtFromBase(vault.seriesId, repaidInBase);
+
+        // Update accounting
+        cauldron.pour(vaultId, 0, -(repaid.i128()));
+
+        // Manage underlying
+        IJoin baseJoin = getJoin(series.baseId);
+        base.safeTransfer(address(baseJoin), repaidInBase);
+        baseJoin.join(address(this), repaidInBase);
+
+        // Return remainder
+        if (repaidInBase < amount) base.safeTransfer(to, repaidInBase - amount);
     }
 
     /// @dev Allow users to redeem fyToken, to be used with batch.

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -87,7 +87,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 5000,
+        runs: 2500,
       }
     }
   },

--- a/src/ladleWrapper.ts
+++ b/src/ladleWrapper.ts
@@ -150,12 +150,20 @@ export class LadleWrapper {
     return this.ladle.repayVault(vaultId, to, ink, max)
   }
 
-  public repayLadleAction(vaultId: string): string {
-    return this.ladle.interface.encodeFunctionData('repayLadle', [vaultId])
+  public repayFromLadleAction(vaultId: string, to: string): string {
+    return this.ladle.interface.encodeFunctionData('repayFromLadle', [vaultId, to])
   }
 
-  public async repayLadle(vaultId: string): Promise<ContractTransaction> {
-    return this.ladle.repayLadle(vaultId)
+  public async repayFromLadle(vaultId: string, to: string): Promise<ContractTransaction> {
+    return this.ladle.repayFromLadle(vaultId, to)
+  }
+
+  public closeFromLadleAction(vaultId: string, to: string): string {
+    return this.ladle.interface.encodeFunctionData('closeFromLadle', [vaultId, to])
+  }
+
+  public async closeFromLadle(vaultId: string, to: string): Promise<ContractTransaction> {
+    return this.ladle.closeFromLadle(vaultId, to)
   }
 
   public retrieveAction(token: string, to: string): string {

--- a/test/066_remove_and_repay.ts
+++ b/test/066_remove_and_repay.ts
@@ -89,13 +89,11 @@ describe('Ladle - remove and repay', function () {
 
     await pool.transfer(pool.address, WAD.mul(2))
 
-    const burnCall = pool.interface.encodeFunctionData('burn', [ladle.address, ladle.address, 0, 0])
+    const burnCall = pool.interface.encodeFunctionData('burn', [owner, ladle.address, 0, 0])
 
     await ladle.batch([
       ladle.routeAction(pool.address, burnCall), // burn to ladle
-      ladle.repayLadleAction(vaultId), // ladle repay
-      ladle.retrieveAction(fyToken.address, owner), // retrieve fyToken
-      ladle.retrieveAction(base.address, owner), // retrieve base
+      ladle.repayFromLadleAction(vaultId, owner), // repay with fyToken
     ])
 
     const baseOut = baseReservesBefore.sub(await base.balanceOf(pool.address))
@@ -105,6 +103,34 @@ describe('Ladle - remove and repay', function () {
     const fyTokenObtained = (await fyToken.balanceOf(owner)).sub(fyTokenBalanceBefore)
     expect(fyTokenOut).to.equal(debtRepaid.add(fyTokenObtained))
     expect(baseObtained).to.equal(baseOut)
+  })
+
+  it('repays debt with base, returns base and surplus fyToken', async () => {
+    const baseReservesBefore = await base.balanceOf(pool.address)
+    const fyTokenReservesBefore = await fyToken.balanceOf(pool.address)
+    const baseBalanceBefore = await base.balanceOf(owner)
+    const fyTokenBalanceBefore = await fyToken.balanceOf(owner)
+    const debtBefore = (await cauldron.balances(vaultId)).art
+
+    await pool.transfer(pool.address, WAD.mul(2))
+
+    const burnCall = pool.interface.encodeFunctionData('burn', [ladle.address, owner, 0, 0])
+
+    await ladle.batch([
+      ladle.routeAction(pool.address, burnCall), // burn to ladle
+      ladle.closeFromLadleAction(vaultId, owner), // close with base
+    ])
+
+    const baseOut = baseReservesBefore.sub(await base.balanceOf(pool.address))
+    const fyTokenOut = fyTokenReservesBefore.sub(await fyToken.balanceOf(pool.address))
+    const debtRepaid = await cauldron.callStatic.debtToBase(
+      seriesId,
+      debtBefore.sub((await cauldron.balances(vaultId)).art)
+    )
+    const baseObtained = (await base.balanceOf(owner)).sub(baseBalanceBefore)
+    const fyTokenObtained = (await fyToken.balanceOf(owner)).sub(fyTokenBalanceBefore)
+    expect(baseOut).to.equal(debtRepaid.add(baseObtained))
+    expect(fyTokenObtained).to.equal(fyTokenOut)
   })
 
   describe('after maturity', async () => {
@@ -120,12 +146,11 @@ describe('Ladle - remove and repay', function () {
       const baseBalanceBefore = await base.balanceOf(owner)
 
       await pool.transfer(pool.address, WAD.mul(2))
-      const burnCall = pool.interface.encodeFunctionData('burn', [ladle.address, ladle.address, 0, 0])
+      const burnCall = pool.interface.encodeFunctionData('burn', [owner, ladle.address, 0, 0])
 
       await ladle.batch([
         ladle.routeAction(pool.address, burnCall), // burn to ladle
         ladle.redeemAction(seriesId, owner, 0), // ladle redeem
-        ladle.retrieveAction(base.address, owner), // retrieve base
       ])
 
       const baseOut = baseReservesBefore.sub(await base.balanceOf(pool.address))


### PR DESCRIPTION
Implemented a `closeFromLadle` function that takes any base existing in the Ladle and uses it to repay debt, sending the remained to the selected address.

Along with `repayFromLadle`, this will be used to remove liquidity from a pool, repay as much debt as possible, and get the rest.