### PR TITLE
tweak: don't manage oracle sources in Wand

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.10.0-rc1",
+  "version": "0.10.0-rc2",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [


### PR DESCRIPTION
Managing oracle sources in Wand doesn't let it be used with Composite Oracles