### PR TITLE
Fix/reverse spot

### DIFF
--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -484,7 +484,7 @@ contract Cauldron is AccessControl() {
     {
         DataTypes.SpotOracle memory spotOracle_ = spotOracles[series_.baseId][vault_.ilkId];
         uint256 ratio = uint256(spotOracle_.ratio) * 1e12;   // Normalized to 18 decimals
-        (uint256 inkValue,) = spotOracle_.oracle.get(series_.baseId, vault_.ilkId, balances_.ink);    // ink * spot
+        (uint256 inkValue,) = spotOracle_.oracle.get(vault_.ilkId, series_.baseId, balances_.ink);    // ink * spot
 
         if (uint32(block.timestamp) >= series_.maturity) {
             uint256 accrual_ = _accrual(vault_.seriesId, series_);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.10.0-rc2",
+  "version": "0.10.0-rc3",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [

--- a/test/053_cauldron_level.ts
+++ b/test/053_cauldron_level.ts
@@ -68,7 +68,7 @@ describe('Cauldron - level', function () {
     fyToken = env.series.get(seriesId) as FYToken
     vaultId = (env.vaults.get(seriesId) as Map<string, string>).get(ilkId) as string
 
-    await spotSource.set(WAD.mul(2))
+    await spotSource.set(WAD.div(2))
     await cauldron.pour(vaultId, WAD, WAD)
   })
 
@@ -79,9 +79,15 @@ describe('Cauldron - level', function () {
       await spotSource.set(WAD.mul(spot))
       for (let ratio of [50, 100, 200]) {
         await cauldron.setSpotOracle(baseId, ilkId, spotOracle.address, ratio * 10000)
-        const expectedLevel = ink.mul(spot).sub(art.mul(ratio).div(100))
+        const reverseSpot = WAD.div(spot)
+        // When setting the oracles, we set them as underlying/collateral, but then for `level` we want
+        // the collateral/underlying spot price (this one ETH collateral, how much DAI is worth?)
+        // So we set the DAI/ETH spot to 2.0 (WAD*2), for example, but the `spot` that `level` uses is the
+        // reverse of that, 1 / 2.0 = 0.5 (WAD/2). ink * spot is fixed point with WAD decimals, so we finally
+        // divide by WAD to find the value of the collateral in base terms.
+        const expectedLevel = ink.mul(reverseSpot).div(WAD).sub(art.mul(ratio).div(100))
+        // console.log(`${ink} * ${WAD.mul(spot)} - ${art} * ${ratio} = ${await cauldron.callStatic.level(vaultId)} | ${expectedLevel} `)
         expect(await cauldron.callStatic.level(vaultId)).to.equal(expectedLevel)
-        // console.log(`${ink} * ${WAD.mul(spot)} - ${art} * ${ratio} = ${await cauldron.level(vaultId)} | ${expectedLevel} `)
       }
     }
   })
@@ -128,7 +134,7 @@ describe('Cauldron - level', function () {
           // accrual = rate / 100
           for (let ratio of [50, 100, 200]) {
             await cauldron.setSpotOracle(baseId, ilkId, spotOracle.address, ratio * 10000)
-            const expectedLevel = ink.mul(spot).sub(art.mul(rate).mul(ratio).div(10000))
+            const expectedLevel = ink.div(spot).sub(art.mul(rate).mul(ratio).div(10000))
             expect(await cauldron.callStatic.level(vaultId)).to.equal(expectedLevel)
             // console.log(`${ink} * ${RAY.mul(spot)} - ${art} * ${ratio} = ${await cauldron.level(vaultId)} | ${expectedLevel} `)
           }

--- a/test/053_cauldron_level.ts
+++ b/test/053_cauldron_level.ts
@@ -80,11 +80,11 @@ describe('Cauldron - level', function () {
       for (let ratio of [50, 100, 200]) {
         await cauldron.setSpotOracle(baseId, ilkId, spotOracle.address, ratio * 10000)
         const reverseSpot = WAD.div(spot)
-        // When setting the oracles, we set them as underlying/collateral, but then for `level` we want
-        // the collateral/underlying spot price (this one ETH collateral, how much DAI is worth?)
-        // So we set the DAI/ETH spot to 2.0 (WAD*2), for example, but the `spot` that `level` uses is the
-        // reverse of that, 1 / 2.0 = 0.5 (WAD/2). ink * spot is fixed point with WAD decimals, so we finally
-        // divide by WAD to find the value of the collateral in base terms.
+        // When setting the oracles, we set them as underlying/collateral matching Chainlink, for which ETH is always the quote.
+        // Then for `level` we want the collateral/underlying spot price (this one ETH collateral, how much DAI is worth?)
+        // So we set the DAI/ETH spot to 2.0 (WAD*2), for example, but the `spot` that `level` uses is the reverse of that,
+        // 1 / 2.0 = 0.5 (WAD/2). ink * spot is fixed point with WAD decimals, so we finally divide by WAD to find the value
+        // of the collateral in base terms.
         const expectedLevel = ink.mul(reverseSpot).div(WAD).sub(art.mul(ratio).div(100))
         // console.log(`${ink} * ${WAD.mul(spot)} - ${art} * ${ratio} = ${await cauldron.callStatic.level(vaultId)} | ${expectedLevel} `)
         expect(await cauldron.callStatic.level(vaultId)).to.equal(expectedLevel)

--- a/test/081_witch.ts
+++ b/test/081_witch.ts
@@ -108,7 +108,7 @@ describe('Witch', function () {
   })
 
   it('auctions undercollateralized vaults', async () => {
-    await spotSource.set(WAD.div(2))
+    await spotSource.set(WAD.mul(2))
     await witch.auction(vaultId)
     const event = (await witch.queryFilter(witch.filters.Auctioned(null, null)))[0]
     expect((await cauldron.vaults(vaultId)).owner).to.equal(witch.address)
@@ -119,7 +119,7 @@ describe('Witch', function () {
 
   describe('once a vault has been auctioned', async () => {
     beforeEach(async () => {
-      await spotSource.set(WAD.div(2))
+      await spotSource.set(WAD.mul(2))
       await witch.auction(vaultId)
     })
 

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -239,20 +239,20 @@ export class YieldEnvironment {
 
     for (let ilkId of ilkIds) {
       const aggregator = (await deployContract(owner, ChainlinkAggregatorV3MockArtifact, [8])) as ISourceMock
-      await aggregator.set(WAD.mul(2))
+      await aggregator.set(WAD.div(2))
       sources.set(ilkId, aggregator)
     }
 
     const ethAggregator = (await deployContract(owner, ChainlinkAggregatorV3MockArtifact, [8])) as ISourceMock
-    await ethAggregator.set(WAD.mul(2))
+    await ethAggregator.set(WAD.div(2))
     sources.set(ETH, ethAggregator)
 
     const daiAggregator = (await deployContract(owner, ChainlinkAggregatorV3MockArtifact, [8])) as ISourceMock
-    await daiAggregator.set(WAD.mul(2))
+    await daiAggregator.set(WAD.div(2))
     sources.set(DAI, daiAggregator)
 
     const usdcAggregator = (await deployContract(owner, ChainlinkAggregatorV3MockArtifact, [8])) as ISourceMock
-    await usdcAggregator.set(WAD.mul(2))
+    await usdcAggregator.set(WAD.div(2))
     sources.set(USDC, usdcAggregator)
 
     // ==== Libraries ====


### PR DESCRIPTION
`level` should check the value of the collateral in base terms, and not the other way round.

It took me an ungodly amount of time to test, until I realized that for Chainlink ETH is always a quote, and that we set our own oracles mocking Chainlink and also setting ETH as a quote. Then we ask for the ETH/DAI price out of the DAI/ETH oracle, so `spot` is reversed by ChainlinkMultiOracle.