### PR TITLE
fix: only buy from vaults under auction, don't touch ownership

### DIFF
--- a/contracts/Cauldron.sol
+++ b/contracts/Cauldron.sol
@@ -367,17 +367,6 @@ contract Cauldron is AccessControl(), Constants {
         return balances_;
     }
 
-    /// @dev Give an uncollateralized vault to another user.
-    /// To be used for liquidation engines.
-    function grab(bytes12 vaultId, address receiver)
-        external
-        auth
-    {
-        (DataTypes.Vault memory vault_, DataTypes.Series memory series_, DataTypes.Balances memory balances_) = vaultData(vaultId, true);
-        require(_level(vault_, balances_, series_) < 0, "Not undercollateralized");
-        _give(vaultId, receiver);
-    }
-
     /// @dev Reduce debt and collateral from a vault, ignoring collateralization checks.
     /// To be used by liquidation engines.
     function slurp(bytes12 vaultId, uint128 ink, uint128 art)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.11.0-rc3",
+  "version": "0.11.0-rc4",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [
@@ -34,7 +34,7 @@
     "@truffle/hdwallet-provider": "^1.0.40",
     "@types/mocha": "^8.0.0",
     "@yield-protocol/utils-v2": "^2.4.2",
-    "@yield-protocol/vault-interfaces": "^2.3.0-rc5",
+    "@yield-protocol/vault-interfaces": "^2.3.0-rc6",
     "@yield-protocol/yieldspace-interfaces": "^2.3.0-rc2",
     "chai": "4.2.0",
     "dss-interfaces": "0.1.1",

--- a/test/081_witch.ts
+++ b/test/081_witch.ts
@@ -161,7 +161,7 @@ describe('Witch', function () {
     it('it can buy no collateral (coverage)', async () => {
       expect(await witch.buy(vaultId, 0, 0))
         .to.emit(witch, 'Bought')
-        .withArgs(owner, vaultId, 0, 0)
+        .withArgs(vaultId, owner, 0, 0)
     })
 
     it('allows to buy 1/2 of the collateral for the whole debt at the beginning', async () => {

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -129,8 +129,6 @@ export class YieldEnvironment {
   public static async cauldronWitchAuth(cauldron: Cauldron, receiver: string) {
     await cauldron.grantRoles(
       [
-        id(cauldron.interface, 'give(bytes12,address)'),
-        id(cauldron.interface, 'grab(bytes12,address)'),
         id(cauldron.interface, 'slurp(bytes12,uint128,uint128)'),
       ],
       receiver

--- a/yarn.lock
+++ b/yarn.lock
@@ -2288,10 +2288,10 @@
     ethereumjs-util "^7.0.8"
     ethers "^5.0.7"
 
-"@yield-protocol/vault-interfaces@^2.3.0-rc5":
-  version "2.3.0-rc5"
-  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.3.0-rc5.tgz#5184b3674d9b741f769cb57eb90d4eb0860dd2f5"
-  integrity sha512-KYnq2corKqg9jsOvXF5jvibg/M6mXb7PEdPVoJByc18cQDEhdwcAMAGc3B04FT5BARm7NVyACOZKbdSFGIvAsQ==
+"@yield-protocol/vault-interfaces@^2.3.0-rc6":
+  version "2.3.0-rc6"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.3.0-rc6.tgz#dbfad673507913e13a39b2f36ef5fa44cde4217d"
+  integrity sha512-MlLFJVjE6Z6esHZffjGULwBsCe/+XSLqWLcDsxxo/mXL79BdYIhwRBT50ikaqo2o6IDqib/S40hPN3uS36LT7g==
 
 "@yield-protocol/yieldspace-interfaces@^2.3.0-rc2":
   version "2.3.0-rc2"


### PR DESCRIPTION
Adding a require so that it is only possible to `buy` or `payAll` vaults under auction (doh!).

Also, removed the whole `grab` logic, since it was not used anymore. When the Witch started using `slurp` on Cauldron, the refactor didn't include the Witch checking it was using `slurp` only on vaults it owned. While that check could be added, it's much simpler, and possibly safer, just not to change vault ownership.