### PR TITLE
Feat/v1 burn

### DIFF
--- a/contracts/mocks/v1/DelegableMock.sol
+++ b/contracts/mocks/v1/DelegableMock.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+
+
+/// @dev Delegable enables users to delegate their account management to other users.
+contract DelegableMock {
+    mapping(address => mapping(address => bool)) public delegated;
+
+    /// @dev Require that msg.sender is the account holder or a delegate
+    modifier onlyHolderOrDelegate(address holder, string memory errorMessage) {
+        require(
+            msg.sender == holder || delegated[holder][msg.sender],
+            errorMessage
+        );
+        _;
+    }
+}

--- a/contracts/mocks/v1/V1FYDaiMock.sol
+++ b/contracts/mocks/v1/V1FYDaiMock.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.6;
+import "@yield-protocol/utils-v2/contracts/token/ERC20Permit.sol";
+import "../DAIMock.sol";
+import "./DelegableMock.sol";
+
+
+contract V1FYDaiMock is ERC20Permit, DelegableMock  {
+
+    DAIMock public immutable dai;
+    uint256 public immutable maturity;
+
+    constructor(
+        DAIMock dai_,
+        uint256 maturity_
+    ) ERC20Permit("FYDai", "FYDai", 18) {
+        dai = dai_;
+        maturity = maturity_;
+    }
+
+    /// @dev Give tokens to whoever asks for them.
+    function mint(address to, uint256 amount) public virtual {
+        _mint(to, amount);
+    }
+
+    function redeem(address from, address to, uint256 amount)
+        public
+        onlyHolderOrDelegate(from, "FYDai: Only Holder Or Delegate")
+        returns(uint256)
+    {
+        _burn(from, amount);
+        dai.mint(to, amount);
+        return amount;
+    }
+}

--- a/contracts/mocks/v1/V1PoolMock.sol
+++ b/contracts/mocks/v1/V1PoolMock.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.6;
+import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
+import "../../modules/IV1FYDai.sol";
+import "../../modules/IV1Pool.sol";
+import "../ERC20Mock.sol";
+import "./DelegableMock.sol";
+
+
+contract V1PoolMock is ERC20, DelegableMock, IV1Pool {
+
+    IERC20 public immutable override dai;
+    IV1FYDai public immutable override fyDai;
+    uint128 constant public rate = 105e25; // 5%
+
+    constructor(IERC20 dai_, IV1FYDai fyDai_) ERC20("Pool", "Pool", 18) {
+        dai = dai_;
+        fyDai = fyDai_;
+    }
+
+    /// @dev Mint liquidity tokens in exchange for adding dai and fyDai
+    /// The liquidity provider needs to have called `dai.approve` and `fyDai.approve`.
+    /// @param from Wallet providing the dai and fyDai. Must have approved the operator with `pool.addDelegate(operator)`.
+    /// @param to Wallet receiving the minted liquidity tokens.
+    /// @param daiOffered Amount of `dai` being invested, an appropriate amount of `fyDai` to be invested alongside will be calculated and taken by this function from the caller.
+    function mint(address from, address to, uint256 daiOffered)
+        external
+        onlyHolderOrDelegate(from, "Pool: Only Holder Or Delegate")
+        returns (uint256 tokensMinted)
+    {
+        uint256 fyDaiRequired;
+
+        if (_totalSupply == 0) {
+            tokensMinted = daiOffered;
+        } else {
+            tokensMinted = daiOffered * _totalSupply / dai.balanceOf(address(this));
+            fyDaiRequired = tokensMinted * fyDai.balanceOf(address(this)) / _totalSupply;
+            ERC20Mock(address(fyDai)).mint(address(this), fyDaiRequired);
+        }
+        ERC20Mock(address(dai)).mint(address(this), daiOffered);
+        
+        _mint(to, tokensMinted);
+    }
+
+    /// @dev Burn liquidity tokens in exchange for dai and fyDai.
+    /// The liquidity provider needs to have called `pool.approve`.
+    /// @param from Wallet providing the liquidity tokens. Must have approved the operator with `pool.addDelegate(operator)`.
+    /// @param to Wallet receiving the dai and fyDai.
+    /// @param tokensBurned Amount of liquidity tokens being burned.
+    function burn(address from, address to, uint256 tokensBurned)
+        external override
+        onlyHolderOrDelegate(from, "Pool: Only Holder Or Delegate")
+        returns (uint256 daiReturned, uint256 fyDaiReturned)
+    {
+        daiReturned = tokensBurned * dai.balanceOf(address(this)) / _totalSupply;
+        fyDaiReturned = tokensBurned * fyDai.balanceOf(address(this)) / _totalSupply;
+
+        _burn(from, tokensBurned);
+        dai.transfer(to, daiReturned);
+        fyDai.transfer(to, fyDaiReturned);
+    }
+
+    /// @dev Sell fyDai for Dai
+    /// The trader needs to have called `fyDai.approve`
+    /// @param from Wallet providing the fyDai being sold. Must have approved the operator with `pool.addDelegate(operator)`.
+    /// @param to Wallet receiving the dai being bought
+    /// @param fyDaiIn Amount of fyDai being sold that will be taken from the user's wallet
+    function sellFYDai(address from, address to, uint128 fyDaiIn)
+        external override
+        onlyHolderOrDelegate(from, "Pool: Only Holder Or Delegate")
+        returns(uint128 daiOut)
+    {
+        daiOut = fyDaiIn * 1e18 / rate;
+
+        fyDai.transferFrom(from, address(this), fyDaiIn);
+        dai.transfer(to, daiOut);
+    }
+}

--- a/contracts/mocks/v1/V1PoolMock.sol
+++ b/contracts/mocks/v1/V1PoolMock.sol
@@ -12,7 +12,7 @@ contract V1PoolMock is ERC20, DelegableMock, IV1Pool {
 
     IERC20 public immutable override dai;
     IV1FYDai public immutable override fyDai;
-    uint128 constant public rate = 105e25; // 5%
+    uint128 constant public rate = 105e16; // 5%
 
     constructor(IERC20 dai_, IV1FYDai fyDai_) ERC20("Pool", "Pool", 18) {
         dai = dai_;

--- a/contracts/modules/BurnV1LiquidityModule.sol
+++ b/contracts/modules/BurnV1LiquidityModule.sol
@@ -21,7 +21,7 @@ contract BurnV1LiquidityModule {
     /// @dev Burns v1 tokens. If before maturity sells any fyDai for Dai, otherwise redeems fyDai for Dai
     /// @param pool Pool to burn LP tokens from.
     /// @param poolTokens amount of pool tokens to burn. 
-    /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
+    /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai. Only used before maturity.
     function burnForDai(IV1Pool pool, address to, uint256 poolTokens, uint256 minimumFYDaiPrice) public {
         require(pool == sepPool || pool == decPool, "Unknown pool");
 

--- a/contracts/modules/BurnV1LiquidityModule.sol
+++ b/contracts/modules/BurnV1LiquidityModule.sol
@@ -12,6 +12,12 @@ contract BurnV1LiquidityModule {
     /// @param poolTokens amount of pool tokens to burn. 
     /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
     function migrateLiquidity(IV1Pool pool, address to, uint256 poolTokens, uint256 minimumFYDaiPrice) public {
+        require(
+            address(pool) == 0x8EcC94a91b5CF03927f5eb8c60ABbDf48F82b0b3 || 
+            address(pool) == 0x5591f644B377eD784e558D4BE1bbA78f5a26bdCd,
+            "Unknown pool"
+        );
+
         IV1FYDai fyDai = pool.fyDai();
 
         (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(address(this), address(this), poolTokens);

--- a/contracts/modules/BurnV1LiquidityModule.sol
+++ b/contracts/modules/BurnV1LiquidityModule.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.6;
+
+import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+import "./IV1FYDai.sol";
+import "./IV1Pool.sol";
+
+
+contract BurnV1LiquidityModule {
+    /// @dev Burns v1 tokens. If before maturity sells any fyDai for Dai, otherwise redeems fyDai for Dai
+    /// @param pool Pool to burn LP tokens from.
+    /// @param poolTokens amount of pool tokens to burn. 
+    /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
+    function migrateLiquidity(IV1Pool pool, address to, uint256 poolTokens, uint256 minimumFYDaiPrice) public {
+        IV1FYDai fyDai = pool.fyDai();
+
+        (uint256 daiObtained, uint256 fyDaiObtained) = pool.burn(address(this), address(this), poolTokens);
+        uint256 daiFromFYDai;
+
+        if (fyDai.maturity() > block.timestamp) {
+            fyDai.approve(address(pool), fyDaiObtained);
+            daiFromFYDai = pool.sellFYDai(address(this), address(this), uint128(fyDaiObtained));
+            require(
+                daiFromFYDai >= fyDaiObtained * minimumFYDaiPrice / 1e18,
+                "Minimum FYDai price not reached"
+            );
+        } else {
+            daiFromFYDai = fyDai.redeem(address(this), address(this), fyDaiObtained);
+        }
+
+        require(pool.dai().transfer(to, daiObtained + daiFromFYDai), "Dai Transfer Failed");
+    }
+}

--- a/contracts/modules/BurnV1LiquidityModule.sol
+++ b/contracts/modules/BurnV1LiquidityModule.sol
@@ -4,19 +4,26 @@ pragma solidity 0.8.6;
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "./IV1FYDai.sol";
 import "./IV1Pool.sol";
+import "../LadleStorage.sol";
 
 
 contract BurnV1LiquidityModule {
+
+    IV1Pool public immutable sepPool;
+    IV1Pool public immutable decPool;
+
+    constructor (IV1Pool sepPool_, IV1Pool decPool_) 
+    {
+        sepPool = sepPool_;
+        decPool = decPool_;
+    }
+
     /// @dev Burns v1 tokens. If before maturity sells any fyDai for Dai, otherwise redeems fyDai for Dai
     /// @param pool Pool to burn LP tokens from.
     /// @param poolTokens amount of pool tokens to burn. 
     /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
     function migrateLiquidity(IV1Pool pool, address to, uint256 poolTokens, uint256 minimumFYDaiPrice) public {
-        require(
-            address(pool) == 0x8EcC94a91b5CF03927f5eb8c60ABbDf48F82b0b3 || 
-            address(pool) == 0x5591f644B377eD784e558D4BE1bbA78f5a26bdCd,
-            "Unknown pool"
-        );
+        require(pool == sepPool || pool == decPool, "Unknown pool");
 
         IV1FYDai fyDai = pool.fyDai();
 

--- a/contracts/modules/BurnV1LiquidityModule.sol
+++ b/contracts/modules/BurnV1LiquidityModule.sol
@@ -22,7 +22,7 @@ contract BurnV1LiquidityModule {
     /// @param pool Pool to burn LP tokens from.
     /// @param poolTokens amount of pool tokens to burn. 
     /// @param minimumFYDaiPrice minimum Dai/fyDai price to be accepted when internally selling fyDai.
-    function migrateLiquidity(IV1Pool pool, address to, uint256 poolTokens, uint256 minimumFYDaiPrice) public {
+    function burnForDai(IV1Pool pool, address to, uint256 poolTokens, uint256 minimumFYDaiPrice) public {
         require(pool == sepPool || pool == decPool, "Unknown pool");
 
         IV1FYDai fyDai = pool.fyDai();

--- a/contracts/modules/IV1FYDai.sol
+++ b/contracts/modules/IV1FYDai.sol
@@ -4,6 +4,6 @@ pragma solidity 0.8.6;
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 
 interface IV1FYDai is IERC20 {
-    function maturity() external view returns(uint);
+    function maturity() external view returns(uint256);
     function redeem(address, address, uint256) external returns (uint256);
 }

--- a/contracts/modules/IV1FYDai.sol
+++ b/contracts/modules/IV1FYDai.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.6;
+
+import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+
+interface IV1FYDai is IERC20 {
+    function maturity() external view returns(uint);
+    function redeem(address, address, uint256) external returns (uint256);
+}

--- a/contracts/modules/IV1Pool.sol
+++ b/contracts/modules/IV1Pool.sol
@@ -7,14 +7,6 @@ import "./IV1FYDai.sol";
 interface IV1Pool is IERC20 {
     function dai() external view returns(IERC20);
     function fyDai() external view returns(IV1FYDai);
-    function sellDai(address from, address to, uint128 daiIn) external returns(uint128);
-    function buyDai(address from, address to, uint128 daiOut) external returns(uint128);
     function sellFYDai(address from, address to, uint128 fyDaiIn) external returns(uint128);
-    function buyFYDai(address from, address to, uint128 fyDaiOut) external returns(uint128);
-    function sellDaiPreview(uint128 daiIn) external view returns(uint128);
-    function buyDaiPreview(uint128 daiOut) external view returns(uint128);
-    function sellFYDaiPreview(uint128 fyDaiIn) external view returns(uint128);
-    function buyFYDaiPreview(uint128 fyDaiOut) external view returns(uint128);
-    function mint(address from, address to, uint256 daiOffered) external returns (uint256);
     function burn(address from, address to, uint256 tokensBurned) external returns (uint256, uint256);
 }

--- a/contracts/modules/IV1Pool.sol
+++ b/contracts/modules/IV1Pool.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.6;
+
+import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+import "./IV1FYDai.sol";
+
+interface IV1Pool is IERC20 {
+    function dai() external view returns(IERC20);
+    function fyDai() external view returns(IV1FYDai);
+    function sellDai(address from, address to, uint128 daiIn) external returns(uint128);
+    function buyDai(address from, address to, uint128 daiOut) external returns(uint128);
+    function sellFYDai(address from, address to, uint128 fyDaiIn) external returns(uint128);
+    function buyFYDai(address from, address to, uint128 fyDaiOut) external returns(uint128);
+    function sellDaiPreview(uint128 daiIn) external view returns(uint128);
+    function buyDaiPreview(uint128 daiOut) external view returns(uint128);
+    function sellFYDaiPreview(uint128 fyDaiIn) external view returns(uint128);
+    function buyFYDaiPreview(uint128 fyDaiOut) external view returns(uint128);
+    function mint(address from, address to, uint256 daiOffered) external returns (uint256);
+    function burn(address from, address to, uint256 tokensBurned) external returns (uint256, uint256);
+}

--- a/src/ladleWrapper.ts
+++ b/src/ladleWrapper.ts
@@ -226,12 +226,20 @@ export class LadleWrapper {
     return this.ladle.transfer(token, receiver, wad)
   }
 
-  public routeAction(target: string, poolCall: string): string {
-    return this.ladle.interface.encodeFunctionData('route', [target, poolCall])
+  public routeAction(target: string, calldata: string): string {
+    return this.ladle.interface.encodeFunctionData('route', [target, calldata])
   }
 
-  public async route(target: string, poolCall: string): Promise<ContractTransaction> {
-    return this.ladle.route(target, poolCall)
+  public async route(target: string, calldata: string): Promise<ContractTransaction> {
+    return this.ladle.route(target, calldata)
+  }
+
+  public moduleCallAction(target: string, calldata: string): string {
+    return this.ladle.interface.encodeFunctionData('moduleCall', [target, calldata])
+  }
+
+  public async moduleCall(target: string, calldata: string): Promise<ContractTransaction> {
+    return this.ladle.moduleCall(target, calldata)
   }
 
   public redeemAction(seriesId: string, to: string, wad: BigNumberish): string {

--- a/test/031_fyToken.ts
+++ b/test/031_fyToken.ts
@@ -64,7 +64,7 @@ describe('FYToken', function () {
     fyToken = env.series.get(seriesId) as FYToken
     chiOracle = (env.oracles.get(CHI) as unknown) as CompoundMultiOracle
     chiSource = (await ethers.getContractAt('CTokenChiMock', await chiOracle.sources(baseId, CHI))) as CTokenChiMock
-    
+
     await baseJoin.grantRoles(
       [id(baseJoin.interface, 'join(address,uint128)'), id(baseJoin.interface, 'exit(address,uint128)')],
       fyToken.address

--- a/test/072_module_v1_migrate.ts
+++ b/test/072_module_v1_migrate.ts
@@ -119,11 +119,8 @@ describe('Ladle - module', function () {
   it('reverts if the minimum fyDai price is not reached', async () => {
     const poolTokensToBurn = (await v1PoolDec.balanceOf(owner)).div(2)
     await v1PoolDec.transfer(module.address, poolTokensToBurn)
-    await expect(module.burnForDai(
-      v1PoolDec.address,
-      owner,
-      poolTokensToBurn,
-      WAD.mul(2)
-    )).to.be.revertedWith('Minimum FYDai price not reached')
+    await expect(module.burnForDai(v1PoolDec.address, owner, poolTokensToBurn, WAD.mul(2))).to.be.revertedWith(
+      'Minimum FYDai price not reached'
+    )
   })
 })

--- a/test/072_module_v1_migrate.ts
+++ b/test/072_module_v1_migrate.ts
@@ -102,7 +102,7 @@ describe('Ladle - module', function () {
 
   it('redeems mature v1 fyDai', async () => {
     const poolTokensToBurn = (await v1PoolSep.balanceOf(owner)).div(2)
-    const calldata = module.interface.encodeFunctionData('migrateLiquidity', [
+    const calldata = module.interface.encodeFunctionData('burnForDai', [
       v1PoolSep.address,
       owner,
       poolTokensToBurn,
@@ -115,7 +115,7 @@ describe('Ladle - module', function () {
 
   it('sells v1 fyDai', async () => {
     const poolTokensToBurn = (await v1PoolDec.balanceOf(owner)).div(2)
-    const calldata = module.interface.encodeFunctionData('migrateLiquidity', [
+    const calldata = module.interface.encodeFunctionData('burnForDai', [
       v1PoolDec.address,
       owner,
       poolTokensToBurn,

--- a/test/072_module_v1_migrate.ts
+++ b/test/072_module_v1_migrate.ts
@@ -1,0 +1,134 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { id, constants } from '@yield-protocol/utils-v2'
+const { WAD, MAX256 } = constants
+import { ETH, DAI } from '../src/constants'
+
+import V1FYDaiMockArtifact from '../artifacts/contracts/mocks/v1/V1FYDaiMock.sol/V1FYDaiMock.json'
+import V1PoolMockArtifact from '../artifacts/contracts/mocks/v1/V1PoolMock.sol/V1PoolMock.json'
+import BurnModuleArtifact from '../artifacts/contracts/modules/BurnV1LiquidityModule.sol/BurnV1LiquidityModule.json'
+
+import { Cauldron } from '../typechain/Cauldron'
+import { BurnV1LiquidityModule } from '../typechain/BurnV1LiquidityModule'
+
+import { ERC20Mock } from '../typechain/ERC20Mock'
+import { DAIMock } from '../typechain/DAIMock'
+import { V1FYDaiMock } from '../typechain/V1FYDaiMock'
+import { V1PoolMock } from '../typechain/V1PoolMock'
+
+import { ethers, waffle } from 'hardhat'
+import { expect } from 'chai'
+const { deployContract, loadFixture } = waffle
+
+import { YieldEnvironment } from './shared/fixtures'
+import { LadleWrapper } from '../src/ladleWrapper'
+
+describe('Ladle - module', function () {
+  this.timeout(0)
+
+  let env: YieldEnvironment
+  let ownerAcc: SignerWithAddress
+  let owner: string
+  let cauldron: Cauldron
+  let ladle: LadleWrapper
+  let base: ERC20Mock
+  let fyDaiSep: V1FYDaiMock
+  let fyDaiDec: V1FYDaiMock
+  let v1PoolSep: V1PoolMock
+  let v1PoolDec: V1PoolMock
+  let module: BurnV1LiquidityModule
+  const EODEC = 1640995199
+  const EOSEP = 1633046399
+
+  async function fixture() {
+    return await YieldEnvironment.setup(ownerAcc, [baseId, ilkId], [seriesId])
+  }
+
+  before(async () => {
+    const signers = await ethers.getSigners()
+    ownerAcc = signers[0]
+    owner = await ownerAcc.getAddress()
+  })
+
+  const baseId = DAI
+  const ilkId = ETH
+  const seriesId = ethers.utils.hexlify(ethers.utils.randomBytes(6))
+
+  beforeEach(async () => {
+    env = await loadFixture(fixture)
+    cauldron = env.cauldron
+    ladle = env.ladle
+    base = env.assets.get(baseId) as ERC20Mock
+
+    // ==== Set v1 Mocks ====
+    fyDaiSep = (await deployContract(ownerAcc, V1FYDaiMockArtifact, [
+      base.address,
+      EOSEP,
+    ])) as V1FYDaiMock
+
+    v1PoolSep = (await deployContract(ownerAcc, V1PoolMockArtifact, [
+      base.address,
+      fyDaiSep.address,
+    ])) as V1PoolMock
+
+    fyDaiDec = (await deployContract(ownerAcc, V1FYDaiMockArtifact, [
+      base.address,
+      EODEC,
+    ])) as V1FYDaiMock
+    
+    v1PoolDec = (await deployContract(ownerAcc, V1PoolMockArtifact, [
+      base.address,
+      fyDaiDec.address,
+    ])) as V1PoolMock
+
+    // ==== Module ====
+
+    module = (await deployContract(ownerAcc, BurnModuleArtifact, [
+      v1PoolSep.address,
+      v1PoolDec.address,
+    ])) as BurnV1LiquidityModule
+    
+    await ladle.grantRoles([id(ladle.ladle.interface, 'addToken(address,bool)')], owner)
+    await ladle.grantRoles([id(ladle.ladle.interface, 'addModule(address,bool)')], owner)
+
+    await ladle.ladle.addToken(v1PoolSep.address, true)
+    await ladle.ladle.addToken(v1PoolDec.address, true)
+    await ladle.addModule(module.address, true)
+
+    // ==== Initialize v1 pools ====
+
+    await v1PoolSep.mint(owner, owner, WAD.mul(10))
+    await fyDaiSep.approve(v1PoolSep.address, MAX256)
+    await fyDaiSep.mint(owner, WAD)
+    await v1PoolSep.sellFYDai(owner, owner, WAD)
+
+    await v1PoolDec.mint(owner, owner, WAD.mul(10))
+    await fyDaiDec.approve(v1PoolDec.address, MAX256)
+    await fyDaiDec.mint(owner, WAD)
+    await v1PoolDec.sellFYDai(owner, owner, WAD)
+
+    // ==== Ladle approvals ====
+    // I don't feel like messing with permits
+    await v1PoolSep.approve(ladle.address, MAX256)
+    await v1PoolDec.approve(ladle.address, MAX256)
+  })
+
+  it('redeems mature v1 fyDai', async () => {
+    const poolTokensToBurn = (await v1PoolSep.balanceOf(owner)).div(2)
+    const calldata = module.interface.encodeFunctionData('migrateLiquidity', [
+      v1PoolSep.address, owner, poolTokensToBurn, 0
+    ])
+    await v1PoolSep.transfer(ladle.address, poolTokensToBurn)
+    await ladle.moduleCall(module.address, calldata)
+    expect(await base.balanceOf(owner)).to.not.equal(0)
+  })
+
+  it('sells v1 fyDai', async () => {
+    const poolTokensToBurn = (await v1PoolDec.balanceOf(owner)).div(2)
+    const calldata = module.interface.encodeFunctionData('migrateLiquidity', [
+      v1PoolDec.address, owner, poolTokensToBurn, 0
+    ])
+    await v1PoolDec.transfer(ladle.address, poolTokensToBurn)
+    await ladle.moduleCall(module.address, calldata)
+    expect(await base.balanceOf(owner)).to.not.equal(0)
+  })
+})

--- a/test/072_module_v1_migrate.ts
+++ b/test/072_module_v1_migrate.ts
@@ -102,12 +102,7 @@ describe('Ladle - module', function () {
 
   it('redeems mature v1 fyDai', async () => {
     const poolTokensToBurn = (await v1PoolSep.balanceOf(owner)).div(2)
-    const calldata = module.interface.encodeFunctionData('burnForDai', [
-      v1PoolSep.address,
-      owner,
-      poolTokensToBurn,
-      0,
-    ])
+    const calldata = module.interface.encodeFunctionData('burnForDai', [v1PoolSep.address, owner, poolTokensToBurn, 0])
     await v1PoolSep.transfer(ladle.address, poolTokensToBurn)
     await ladle.moduleCall(module.address, calldata)
     expect(await base.balanceOf(owner)).to.not.equal(0)
@@ -115,14 +110,17 @@ describe('Ladle - module', function () {
 
   it('sells v1 fyDai', async () => {
     const poolTokensToBurn = (await v1PoolDec.balanceOf(owner)).div(2)
-    const calldata = module.interface.encodeFunctionData('burnForDai', [
-      v1PoolDec.address,
-      owner,
-      poolTokensToBurn,
-      0,
-    ])
+    const calldata = module.interface.encodeFunctionData('burnForDai', [v1PoolDec.address, owner, poolTokensToBurn, 0])
     await v1PoolDec.transfer(ladle.address, poolTokensToBurn)
     await ladle.moduleCall(module.address, calldata)
     expect(await base.balanceOf(owner)).to.not.equal(0)
+  })
+
+  it('reverts if the minimum fyDai price is not reached', async () => {
+    const poolTokensToBurn = (await v1PoolDec.balanceOf(owner)).div(2)
+    await v1PoolDec.transfer(module.address, poolTokensToBurn)
+    await expect(module.burnForDai(v1PoolDec.address, owner, poolTokensToBurn, WAD.mul(2))).to.be.revertedWith(
+      'Minimum FYDai price not reached'
+    )
   })
 })

--- a/test/072_module_v1_migrate.ts
+++ b/test/072_module_v1_migrate.ts
@@ -60,25 +60,13 @@ describe('Ladle - module', function () {
     base = env.assets.get(baseId) as ERC20Mock
 
     // ==== Set v1 Mocks ====
-    fyDaiSep = (await deployContract(ownerAcc, V1FYDaiMockArtifact, [
-      base.address,
-      EOSEP,
-    ])) as V1FYDaiMock
+    fyDaiSep = (await deployContract(ownerAcc, V1FYDaiMockArtifact, [base.address, EOSEP])) as V1FYDaiMock
 
-    v1PoolSep = (await deployContract(ownerAcc, V1PoolMockArtifact, [
-      base.address,
-      fyDaiSep.address,
-    ])) as V1PoolMock
+    v1PoolSep = (await deployContract(ownerAcc, V1PoolMockArtifact, [base.address, fyDaiSep.address])) as V1PoolMock
 
-    fyDaiDec = (await deployContract(ownerAcc, V1FYDaiMockArtifact, [
-      base.address,
-      EODEC,
-    ])) as V1FYDaiMock
-    
-    v1PoolDec = (await deployContract(ownerAcc, V1PoolMockArtifact, [
-      base.address,
-      fyDaiDec.address,
-    ])) as V1PoolMock
+    fyDaiDec = (await deployContract(ownerAcc, V1FYDaiMockArtifact, [base.address, EODEC])) as V1FYDaiMock
+
+    v1PoolDec = (await deployContract(ownerAcc, V1PoolMockArtifact, [base.address, fyDaiDec.address])) as V1PoolMock
 
     // ==== Module ====
 
@@ -86,7 +74,7 @@ describe('Ladle - module', function () {
       v1PoolSep.address,
       v1PoolDec.address,
     ])) as BurnV1LiquidityModule
-    
+
     await ladle.grantRoles([id(ladle.ladle.interface, 'addToken(address,bool)')], owner)
     await ladle.grantRoles([id(ladle.ladle.interface, 'addModule(address,bool)')], owner)
 
@@ -115,7 +103,10 @@ describe('Ladle - module', function () {
   it('redeems mature v1 fyDai', async () => {
     const poolTokensToBurn = (await v1PoolSep.balanceOf(owner)).div(2)
     const calldata = module.interface.encodeFunctionData('migrateLiquidity', [
-      v1PoolSep.address, owner, poolTokensToBurn, 0
+      v1PoolSep.address,
+      owner,
+      poolTokensToBurn,
+      0,
     ])
     await v1PoolSep.transfer(ladle.address, poolTokensToBurn)
     await ladle.moduleCall(module.address, calldata)
@@ -125,7 +116,10 @@ describe('Ladle - module', function () {
   it('sells v1 fyDai', async () => {
     const poolTokensToBurn = (await v1PoolDec.balanceOf(owner)).div(2)
     const calldata = module.interface.encodeFunctionData('migrateLiquidity', [
-      v1PoolDec.address, owner, poolTokensToBurn, 0
+      v1PoolDec.address,
+      owner,
+      poolTokensToBurn,
+      0,
     ])
     await v1PoolDec.transfer(ladle.address, poolTokensToBurn)
     await ladle.moduleCall(module.address, calldata)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2280,10 +2280,10 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
-"@yield-protocol/utils-v2@^2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@yield-protocol/utils-v2/-/utils-v2-2.4.1.tgz#063fbd0c12cff15c70215a202b28fb1459b5ed51"
-  integrity sha512-PyLNLNjZfwbLD3CvDngnebUpRJtb+aWUdIKVgzxRGrYxahahhJfRQQL+dzIUyQ0pGu56CgvL/A5PFQ3VH52bpw==
+"@yield-protocol/utils-v2@^2.4.2":
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/utils-v2/-/utils-v2-2.4.5.tgz#f567d7d4669be91137813850179d18a79947adb8"
+  integrity sha512-aMT3hXon3VYiKsj5L13U+2s4BXUphrWS5380grSPSja2trrsxOwsgluk/jaUPtIZ9oQ2OkGB8ONsy14RKJoayQ==
   dependencies:
     ethereumjs-util "^7.0.8"
     ethers "^5.0.7"


### PR DESCRIPTION
1. Add `BurnV1LiquidityModule` as a module to Ladle
2. Add the V1 pools as tokens to Ladle
3. Recipe:
```
permit(v1pool, ladle)
ladle.transfer(v1pool, ladle, poolTokens)
ladle.moduleCall(burnV1Module, migrateLiquidity(v1pool, v2DaiPool, poolTokens, minimumFYDaiPrice))
... the v2 pool now has the Dai from burning the v1 tokens, and you can mint v2 LP and add to a strategy.
```
