### PR TITLE
fix: return assets in ladle if no debt was repaid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.11.0-rc7",
+  "version": "0.11.0-rc8",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [

--- a/test/066_ladle_repay_from.ts
+++ b/test/066_ladle_repay_from.ts
@@ -101,33 +101,26 @@ describe('Ladle - remove and repay', function () {
   })
 
   it('if there is no debt, returns fyToken', async () => {
-    const artBefore = (await cauldron.balances(vaultId)).art
-    const ilkBefore = (await cauldron.balances(vaultId)).ink
-
-    await fyToken.mint(ladle.address, artBefore)
+    // Make a vault with no debt
+    await fyToken.mint(ladle.address, (await cauldron.balances(vaultId)).art)
     await ladle.repayFromLadle(vaultId, owner)
     expect((await cauldron.balances(vaultId)).art).to.equal(0)
 
-    const baseBalanceBefore = await base.balanceOf(owner)
     const fyTokenBalanceBefore = await fyToken.balanceOf(owner)
-    await fyToken.mint(ladle.address, artBefore)
+    await fyToken.mint(ladle.address, WAD)
     await ladle.repayFromLadle(vaultId, owner)
-    expect((await base.balanceOf(owner)).sub(baseBalanceBefore)).to.equal(ilkBefore)
-    expect((await fyToken.balanceOf(owner)).sub(fyTokenBalanceBefore)).to.equal(artBefore)
+    expect(await fyToken.balanceOf(owner)).to.equal(fyTokenBalanceBefore.add(WAD))
   })
 
   it('if there is no debt, returns base', async () => {
-    const baseBalanceBefore = await base.balanceOf(owner)
-    const debtBefore = await cauldron.callStatic.debtToBase(seriesId, (await cauldron.balances(vaultId)).art)
-    const artBefore = (await cauldron.balances(vaultId)).art
-    const ilkBefore = (await cauldron.balances(vaultId)).ink
-
-    await fyToken.mint(ladle.address, artBefore)
+    // Make a vault with no debt
+    await fyToken.mint(ladle.address, (await cauldron.balances(vaultId)).art)
     await ladle.repayFromLadle(vaultId, owner)
     expect((await cauldron.balances(vaultId)).art).to.equal(0)
 
-    await base.mint(ladle.address, debtBefore)
+    const baseBalanceBefore = await base.balanceOf(owner)
+    await base.mint(ladle.address, WAD)
     await ladle.closeFromLadle(vaultId, owner) // close with base
-    expect((await base.balanceOf(owner)).sub(baseBalanceBefore)).to.equal(debtBefore.add(ilkBefore))
+    expect(await base.balanceOf(owner)).to.equal(baseBalanceBefore.add(WAD))
   })
 })


### PR DESCRIPTION
Otherwise `repayFromLadle` and `closeFromLadle` will keep assets in Ladle when called due to slippage making it too close to call whether debt will be repaid or not.