### PR TITLE
tweak: removed setSecondsAgo function in UniswapV3 Oracle

### DIFF
--- a/contracts/oracles/uniswap/UniswapV3Oracle.sol
+++ b/contracts/oracles/uniswap/UniswapV3Oracle.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.6;
 
-import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
-import "@yield-protocol/vault-interfaces/IOracle.sol";
-import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
-import "./IUniswapV3PoolImmutables.sol";
+import '@yield-protocol/utils-v2/contracts/access/AccessControl.sol';
+import '@yield-protocol/vault-interfaces/IOracle.sol';
+import '@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol';
+import './IUniswapV3PoolImmutables.sol';
 // This for the real deal
 // import "@uniswap/v3-periphery/contracts/libraries/OracleLibrary.sol";
-import "../../mocks/oracles/uniswap/UniswapV3OracleLibraryMock.sol";
+import '../../mocks/oracles/uniswap/UniswapV3OracleLibraryMock.sol';
 
 /**
  * @title UniswapV3Oracle
@@ -15,7 +15,6 @@ import "../../mocks/oracles/uniswap/UniswapV3OracleLibraryMock.sol";
 contract UniswapV3Oracle is IOracle, AccessControl {
     using CastBytes32Bytes6 for bytes32;
 
-    event SecondsAgoSet(uint32 indexed secondsAgo);
     event SourceSet(bytes6 indexed base, bytes6 indexed quote, address indexed source);
 
     struct Source {
@@ -28,72 +27,92 @@ contract UniswapV3Oracle is IOracle, AccessControl {
         address baseToken;
         address quoteToken;
         uint24 fee;
+        uint32 secondsAgo;
     }
 
-    uint32 public secondsAgo;
     mapping(bytes6 => mapping(bytes6 => Source)) public sources;
     mapping(address => SourceData) public sourcesData;
 
     /**
-     * @notice Set or reset the number of seconds Uniswap will use for its Time Weighted Average Price computation
+     * @notice Set or reset an oracle source & its inverse and secondsAgo
      */
-    function setSecondsAgo(uint32 secondsAgo_) external auth {
-        require(secondsAgo_ != 0, "Uniswap must look into the past.");
-        secondsAgo = secondsAgo_;
-        emit SecondsAgoSet(secondsAgo_);
-    }
-
-    /**
-     * @notice Set or reset an oracle source and its inverse
-     */
-    function setSource(bytes6 base, bytes6 quote, address source) external auth {
-        _setSource(base, quote, source);
+    function setSource(
+        bytes6 base,
+        bytes6 quote,
+        address source,
+        uint32 secondsAgo
+    ) external auth {
+        require(secondsAgo != 0, 'Uniswap must look into the past.');
+        _setSource(base, quote, source, secondsAgo);
     }
 
     /**
      * @notice Retrieve the value of the amount at the latest oracle price.
      */
-    function peek(bytes32 base, bytes32 quote, uint256 amount)
-        external view virtual override
-        returns (uint256 value, uint256 updateTime)
-    {
+    function peek(
+        bytes32 base,
+        bytes32 quote,
+        uint256 amount
+    ) external view virtual override returns (uint256 value, uint256 updateTime) {
         return _peek(base.b6(), quote.b6(), amount);
     }
 
     /**
      * @notice Retrieve the value of the amount at the latest oracle price. Same as `peek` for this oracle.
      */
-    function get(bytes32 base, bytes32 quote, uint256 amount)
-        external virtual override
-        returns (uint256 value, uint256 updateTime)
-    {
+    function get(
+        bytes32 base,
+        bytes32 quote,
+        uint256 amount
+    ) external virtual override returns (uint256 value, uint256 updateTime) {
         return _peek(base.b6(), quote.b6(), amount);
     }
 
-    function _peek(bytes6 base, bytes6 quote, uint256 amount)
-        private view
-        returns (uint256 value, uint256 updateTime)
-    {
+    function _peek(
+        bytes6 base,
+        bytes6 quote,
+        uint256 amount
+    ) private view returns (uint256 value, uint256 updateTime) {
         Source memory source = sources[base][quote];
         SourceData memory sourceData;
-        require(source.source != address(0), "Source not found");
+        require(source.source != address(0), 'Source not found');
         sourceData = sourcesData[source.source];
         if (source.inverse) {
-            value = UniswapV3OracleLibraryMock.consult(sourceData.factory, sourceData.quoteToken, sourceData.baseToken, sourceData.fee, amount, secondsAgo);
+            value = UniswapV3OracleLibraryMock.consult(
+                sourceData.factory,
+                sourceData.quoteToken,
+                sourceData.baseToken,
+                sourceData.fee,
+                amount,
+                sourceData.secondsAgo
+            );
         } else {
-            value = UniswapV3OracleLibraryMock.consult(sourceData.factory, sourceData.baseToken, sourceData.quoteToken, sourceData.fee, amount, secondsAgo);
+            value = UniswapV3OracleLibraryMock.consult(
+                sourceData.factory,
+                sourceData.baseToken,
+                sourceData.quoteToken,
+                sourceData.fee,
+                amount,
+                sourceData.secondsAgo
+            );
         }
-        updateTime = block.timestamp - secondsAgo;
+        updateTime = block.timestamp - sourceData.secondsAgo;
     }
 
-    function _setSource(bytes6 base, bytes6 quote, address source) internal {
+    function _setSource(
+        bytes6 base,
+        bytes6 quote,
+        address source,
+        uint32 secondsAgo
+    ) internal {
         sources[base][quote] = Source(source, false);
         sources[quote][base] = Source(source, true);
         sourcesData[source] = SourceData(
             IUniswapV3PoolImmutables(source).factory(),
             IUniswapV3PoolImmutables(source).token0(),
             IUniswapV3PoolImmutables(source).token1(),
-            IUniswapV3PoolImmutables(source).fee()
+            IUniswapV3PoolImmutables(source).fee(),
+            secondsAgo
         );
         emit SourceSet(base, quote, source);
         emit SourceSet(quote, base, source);

--- a/contracts/oracles/uniswap/UniswapV3Oracle.sol
+++ b/contracts/oracles/uniswap/UniswapV3Oracle.sol
@@ -74,7 +74,7 @@ contract UniswapV3Oracle is IOracle, AccessControl {
         } else {
             value = UniswapV3OracleLibraryMock.consult(sourceData.factory, sourceData.baseToken, sourceData.quoteToken, sourceData.fee, amount, sourceData.secondsAgo);
         }
-        updateTime = block.timestamp - secondsAgo;
+        updateTime = block.timestamp - sourceData.secondsAgo;
     }
 
     function _setSource(bytes6 base, bytes6 quote, address source,uint32 secondsAgo) internal {

--- a/contracts/oracles/uniswap/UniswapV3Oracle.sol
+++ b/contracts/oracles/uniswap/UniswapV3Oracle.sol
@@ -15,7 +15,7 @@ import "../../mocks/oracles/uniswap/UniswapV3OracleLibraryMock.sol";
 contract UniswapV3Oracle is IOracle, AccessControl {
     using CastBytes32Bytes6 for bytes32;
 
-    event SourceSet(bytes6 indexed base, bytes6 indexed quote, address indexed source);
+    event SourceSet(bytes6 indexed base, bytes6 indexed quote, address indexed source, uint32 secondsAgo);
 
     struct Source {
         address source;
@@ -87,7 +87,7 @@ contract UniswapV3Oracle is IOracle, AccessControl {
             IUniswapV3PoolImmutables(source).fee(),
             secondsAgo
         );
-        emit SourceSet(base, quote, source);
-        emit SourceSet(quote, base, source);
+        emit SourceSet(base, quote, source, secondsAgo);
+        emit SourceSet(quote, base, source, secondsAgo);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.12.0",
+  "version": "0.12.2",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [

--- a/test/015_oracles_uniswap.ts
+++ b/test/015_oracles_uniswap.ts
@@ -47,8 +47,8 @@ describe('Oracles - Uniswap', function () {
     uniswapV3PoolAddress = await sendStatic(uniswapV3Factory as Contract, 'createPool', ownerAcc, [token0, token1, 0])
     uniswapV3Pool = (await ethers.getContractAt('UniswapV3PoolMock', uniswapV3PoolAddress)) as UniswapV3PoolMock
     uniswapV3Oracle = (await deployContract(ownerAcc, UniswapV3OracleArtifact, [])) as UniswapV3Oracle
-    await uniswapV3Oracle.grantRole(id(uniswapV3Oracle.interface, 'setSource(bytes6,bytes6,address)'), owner)
-    await uniswapV3Oracle.setSource(baseId, ethQuoteId, uniswapV3PoolAddress)
+    await uniswapV3Oracle.grantRole(id(uniswapV3Oracle.interface, 'setSource(bytes6,bytes6,address,uint32)'), owner)
+    await uniswapV3Oracle.setSource(baseId, ethQuoteId, uniswapV3PoolAddress, 1)
   })
 
   it('retrieves the value at spot price from a uniswap v3 oracle', async () => {


### PR DESCRIPTION
# Goal
Remove the setSecondsAgo as a separate function

# Details
1. Removed the function to setSecondsAgo and moved setting it to the setSource function.
2. Source data will store the secondsAgo value for each source
3. Modified test to reflect the changes in the setSource function 

# Test
Run [015_oracles_uniswap](https://github.com/yieldprotocol/vault-v2/blob/tweak/uniswapv3-oracle/test/015_oracles_uniswap.ts)