### PR TITLE
Tests: extra debugging, minor fix

### DIFF
--- a/test/017_oracles_accumulator.ts
+++ b/test/017_oracles_accumulator.ts
@@ -15,8 +15,11 @@ function bytes6ToBytes32(x: string): string {
 
 // fast forward X seconds
 async function ff(seconds: number) {
+  const block = await ethers.provider.getBlock('latest')
+  console.log(`FFing ${seconds} seconds from ${block.timestamp} (expecting: ${block.timestamp + seconds})`)
   await network.provider.send('evm_increaseTime', [seconds])
   await network.provider.send('evm_mine')
+  console.log(`FFeded to: ${(await ethers.provider.getBlock('latest')).timestamp}`)
 }
 
 // make the next block's timestamp fast forward X seconds

--- a/test/017_oracles_yearnvault.ts
+++ b/test/017_oracles_yearnvault.ts
@@ -79,9 +79,9 @@ describe('Oracles - Yearn Vault', function () {
 
   it('setSource() sets a pair and the inverse pair', async () => {
     //Set yvUSDC/USDC yearn vault oracle
-    expect(await yearnVaultMultiOracle.setSource(YVUSDC, USDC, yvUSDCMock.address))
+    await expect(yearnVaultMultiOracle.setSource(YVUSDC, USDC, yvUSDCMock.address))
       .to.emit(yearnVaultMultiOracle, 'SourceSet')
-      .withArgs(USDC, YVUSDC, yvUSDCMock.address, 6, true)
+      .withArgs(USDC, YVUSDC, yvUSDCMock.address, 6)
 
     await expect(yearnVaultMultiOracle.get(bytes6ToBytes32(USDC), bytes6ToBytes32(YVUSDC), '2' + '000000')).not.to.be
       .reverted


### PR DESCRIPTION
 + `ff`: log block timestamp pre/post fast forwarding
 * 017_oracles_yearnvault: fix expect()...to.emit() syntaxis, expected event args