### PR TITLE
Disable fyToken flash loans by default

### DIFF
--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -253,7 +253,7 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit,
         require(token == address(this), "Unsupported currency");
         _mint(address(receiver), amount);
         uint128 fee = _flashFee(amount).u128();
-        require(receiver.onFlashLoan(msg.sender, token, amount, 0, data) == FLASH_LOAN_RETURN, "Non-compliant borrower");
+        require(receiver.onFlashLoan(msg.sender, token, amount, fee, data) == FLASH_LOAN_RETURN, "Non-compliant borrower");
         _burn(address(receiver), amount + fee);
         return true;
     }

--- a/contracts/FYToken.sol
+++ b/contracts/FYToken.sol
@@ -32,7 +32,7 @@ contract FYToken is IFYToken, IERC3156FlashLender, AccessControl(), ERC20Permit,
     uint256 constant internal MAX_TIME_TO_MATURITY = 126144000; // seconds in four years
     bytes32 constant internal FLASH_LOAN_RETURN = keccak256("ERC3156FlashBorrower.onFlashLoan");
     uint256 constant FLASH_LOANS_DISABLED = type(uint256).max;
-    uint256 public flashFeeFactor = FLASH_LOANS_DISABLED;       // Fee on flash loans, as a percentage in fixed point with 18 decimals. Flash loans disabled by default.
+    uint256 public flashFeeFactor = FLASH_LOANS_DISABLED;       // Fee on flash loans, as a percentage in fixed point with 18 decimals. Flash loans disabled by default by overflow from `flashFee`.
 
     IOracle public oracle;                                      // Oracle for the savings rate.
     IJoin public join;                                          // Source of redemption funds.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.15.0-rc3",
+  "version": "0.15.0-fyToken-rc0",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.15.0-rc1",
+  "version": "0.15.0-rc3",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.15.0-fyToken-rc0",
+  "version": "0.15.0-fyToken-rc1",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [

--- a/test/032_fyToken_flash.ts
+++ b/test/032_fyToken_flash.ts
@@ -54,54 +54,87 @@ describe('FYToken - flash', function () {
     borrower = (await deployContract(ownerAcc, FlashBorrowerArtifact, [fyToken.address])) as FlashBorrower
   })
 
-  it('should do a simple flash loan', async () => {
-    await borrower.flashBorrow(fyToken.address, WAD, actions.normal)
-
-    expect(await fyToken.balanceOf(owner)).to.equal(0)
-    expect(await borrower.flashBalance()).to.equal(WAD)
-    expect(await borrower.flashToken()).to.equal(fyToken.address)
-    expect(await borrower.flashAmount()).to.equal(WAD)
-    expect(await borrower.flashInitiator()).to.equal(borrower.address)
+  it('flash loans are disabled by default', async () => {
+    await expect(fyToken.flashLoan(borrower.address, fyToken.address, 1, actions.normal)).to.be.reverted
   })
 
-  it('can repay the flash loan by transfer', async () => {
-    await expect(borrower.flashBorrow(fyToken.address, WAD, actions.transfer))
-      .to.emit(fyToken, 'Transfer')
-      .withArgs(fyToken.address, '0x0000000000000000000000000000000000000000', WAD)
-
-    expect(await fyToken.balanceOf(owner)).to.equal(0)
-    expect(await borrower.flashBalance()).to.equal(WAD)
-    expect(await borrower.flashToken()).to.equal(fyToken.address)
-    expect(await borrower.flashAmount()).to.equal(WAD)
-    expect(await borrower.flashInitiator()).to.equal(borrower.address)
-  })
-
-  it('the receiver needs to approve the repayment if not the initiator', async () => {
-    await expect(fyToken.flashLoan(borrower.address, fyToken.address, WAD, actions.normal)).to.be.revertedWith(
-      'ERC20: Insufficient approval'
-    )
-  })
-
-  it('needs to have enough funds to repay a flash loan', async () => {
-    await expect(borrower.flashBorrow(fyToken.address, WAD, actions.steal)).to.be.revertedWith(
-      'ERC20: Insufficient balance'
-    )
-  })
-
-  it('should do two nested flash loans', async () => {
-    await borrower.flashBorrow(fyToken.address, WAD, actions.reenter) // It will borrow WAD, and then reenter and borrow WAD * 2
-    expect(await borrower.flashBalance()).to.equal(WAD.mul(3))
-  })
-
-  describe('after maturity', async () => {
+  describe('with a zero fee', async () => {
     beforeEach(async () => {
-      await ethers.provider.send('evm_mine', [(await fyToken.maturity()).toNumber()])
+      const feeFactor = 0
+      await fyToken.setFlashFeeFactor(feeFactor)
     })
 
-    it('does not allow to flash mint after maturity', async () => {
-      await expect(borrower.flashBorrow(fyToken.address, WAD, actions.normal)).to.be.revertedWith(
-        'Only before maturity'
+    it('should do a simple flash loan', async () => {
+      await borrower.flashBorrow(fyToken.address, WAD, actions.normal)
+
+      expect(await fyToken.balanceOf(owner)).to.equal(0)
+      expect(await borrower.flashBalance()).to.equal(WAD)
+      expect(await borrower.flashToken()).to.equal(fyToken.address)
+      expect(await borrower.flashAmount()).to.equal(WAD)
+      expect(await borrower.flashInitiator()).to.equal(borrower.address)
+    })
+
+    it('can repay the flash loan by transfer', async () => {
+      await expect(borrower.flashBorrow(fyToken.address, WAD, actions.transfer))
+        .to.emit(fyToken, 'Transfer')
+        .withArgs(fyToken.address, '0x0000000000000000000000000000000000000000', WAD)
+
+      expect(await fyToken.balanceOf(owner)).to.equal(0)
+      expect(await borrower.flashBalance()).to.equal(WAD)
+      expect(await borrower.flashToken()).to.equal(fyToken.address)
+      expect(await borrower.flashAmount()).to.equal(WAD)
+      expect(await borrower.flashInitiator()).to.equal(borrower.address)
+    })
+
+    it('the receiver needs to approve the repayment if not the initiator', async () => {
+      await expect(fyToken.flashLoan(borrower.address, fyToken.address, WAD, actions.normal)).to.be.revertedWith(
+        'ERC20: Insufficient approval'
       )
+    })
+
+    it('needs to have enough funds to repay a flash loan', async () => {
+      await expect(borrower.flashBorrow(fyToken.address, WAD, actions.steal)).to.be.revertedWith(
+        'ERC20: Insufficient balance'
+      )
+    })
+
+    it('should do two nested flash loans', async () => {
+      await borrower.flashBorrow(fyToken.address, WAD, actions.reenter) // It will borrow WAD, and then reenter and borrow WAD * 2
+      expect(await borrower.flashBalance()).to.equal(WAD.mul(3))
+    })
+
+    describe('with a non-zero fee', async () => {
+      beforeEach(async () => {
+        const feeFactor = WAD.mul(5).div(100) // 5%
+        await fyToken.setFlashFeeFactor(feeFactor)
+      })
+
+      it('should do a simple flash loan', async () => {
+        const principal = WAD
+        const fee = principal.mul(5).div(100)
+        await fyToken.mint(borrower.address, fee)
+        await expect(borrower.flashBorrow(fyToken.address, principal, actions.normal))
+          .to.emit(fyToken, 'Transfer')
+          .withArgs(borrower.address, '0x0000000000000000000000000000000000000000', principal.add(fee))
+
+        expect(await fyToken.balanceOf(owner)).to.equal(0)
+        expect(await borrower.flashBalance()).to.equal(principal.add(fee))
+        expect(await borrower.flashToken()).to.equal(fyToken.address)
+        expect(await borrower.flashAmount()).to.equal(principal)
+        expect(await borrower.flashInitiator()).to.equal(borrower.address)
+      })
+    })
+
+    describe('after maturity', async () => {
+      beforeEach(async () => {
+        await ethers.provider.send('evm_mine', [(await fyToken.maturity()).toNumber()])
+      })
+
+      it('does not allow to flash mint after maturity', async () => {
+        await expect(borrower.flashBorrow(fyToken.address, WAD, actions.normal)).to.be.revertedWith(
+          'Only before maturity'
+        )
+      })
     })
   })
 })

--- a/test/032_fyToken_flash.ts
+++ b/test/032_fyToken_flash.ts
@@ -83,6 +83,7 @@ describe('FYToken - flash', function () {
       expect(await borrower.flashBalance()).to.equal(WAD)
       expect(await borrower.flashToken()).to.equal(fyToken.address)
       expect(await borrower.flashAmount()).to.equal(WAD)
+      expect(await borrower.flashFee()).to.equal(0)
       expect(await borrower.flashInitiator()).to.equal(borrower.address)
     })
 
@@ -121,6 +122,7 @@ describe('FYToken - flash', function () {
         expect(await borrower.flashBalance()).to.equal(principal.add(fee))
         expect(await borrower.flashToken()).to.equal(fyToken.address)
         expect(await borrower.flashAmount()).to.equal(principal)
+        expect(await borrower.flashFee()).to.equal(fee)
         expect(await borrower.flashInitiator()).to.equal(borrower.address)
       })
     })

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -399,6 +399,7 @@ export class YieldEnvironment {
           id(fyToken.interface, 'mint(address,uint256)'),
           id(fyToken.interface, 'burn(address,uint256)'),
           id(fyToken.interface, 'point(bytes32,address)'),
+          id(fyToken.interface, 'setFlashFeeFactor(uint256)'),
         ],
         ownerAdd
       ) // Only test environment


### PR DESCRIPTION
*Summary*
Disable flash loans by default on fyToken, following the Join pattern.

*Details*
We can be subject to DoS attacks when releasing new series, particularly if doing so at the same time that we roll a strategy onto them.

If we deploy a pool and we don't roll a strategy onto it in the same transaction, a malicious actor can skew the ratio in the pool using the free fyToken flash loans, just to make our slippage protection kick in and revert the governance action. While no funds would be lost, service continuity would be affected.

This PR sets the fyToken flash loans to be disabled by default, along with allowing to charge a fee in case that would be necessary to protect from unforeseen attacks.