### PR TITLE
Feat/c4rena competition

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,14 @@
 {
   "semi": false,
   "singleQuote": true,
-  "printWidth": 120
+  "printWidth": 120,
+  "overrides": [
+    {
+      "files": "*.sol",
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
 }
+

--- a/contracts/mocks/ConvexYieldWrapperMock.sol
+++ b/contracts/mocks/ConvexYieldWrapperMock.sol
@@ -206,11 +206,9 @@ contract ConvexYieldWrapperMock is ERC20, AccessControl {
         uint256 collateral;
         Balances memory balance;
         for (uint256 i = 0; i < userVault.length; i++) {
-            if (userVault[i] != bytes12(0)) {
-                if (cauldron.vaults(userVault[i]).owner == account_) {
-                    balance = cauldron.balances(userVault[i]);
-                    collateral = collateral + balance.ink;
-                }
+            if (cauldron.vaults(userVault[i]).owner == account_) {
+                balance = cauldron.balances(userVault[i]);
+                collateral = collateral + balance.ink;
             }
         }
 

--- a/contracts/oracles/convex/Cvx3CrvOracle.sol
+++ b/contracts/oracles/convex/Cvx3CrvOracle.sol
@@ -110,7 +110,7 @@ contract Cvx3CrvOracle is IOracle, AccessControl {
         (, int256 usdcPrice, , , ) = USDC.latestRoundData();
         (, int256 usdtPrice, , , ) = USDT.latestRoundData();
 
-        require(daiPrice > 0 && usdcPrice > 0 && usdtPrice > 0, 'Chainlink pricefeed reporting 0');
+        require(daiPrice != 0 && usdcPrice != 0 && usdtPrice != 0, 'Chainlink pricefeed reporting 0');
 
         // This won't overflow as the max value for int256 is less than the max value for uint256
         uint256 minStable = min(uint256(daiPrice), min(uint256(usdcPrice), uint256(usdtPrice)));

--- a/contracts/oracles/convex/Cvx3CrvOracle.sol
+++ b/contracts/oracles/convex/Cvx3CrvOracle.sol
@@ -109,7 +109,7 @@ contract Cvx3CrvOracle is IOracle, AccessControl {
         (, int256 usdcPrice, , , ) = USDC.latestRoundData();
         (, int256 usdtPrice, , , ) = USDT.latestRoundData();
 
-        require(daiPrice != 0 && usdcPrice != 0 && usdtPrice != 0, 'Chainlink pricefeed reporting 0');
+        require(daiPrice > 0 && usdcPrice > 0 && usdtPrice > 0, 'Chainlink pricefeed reporting 0');
 
         // This won't overflow as the max value for int256 is less than the max value for uint256
         uint256 minStable = min(uint256(daiPrice), min(uint256(usdcPrice), uint256(usdtPrice)));

--- a/contracts/oracles/convex/Cvx3CrvOracle.sol
+++ b/contracts/oracles/convex/Cvx3CrvOracle.sol
@@ -12,8 +12,7 @@ import '../chainlink/AggregatorV3Interface.sol';
 /**
  *@title  Cvx3CrvOracle
  *@notice Provides current values for Cvx3Crv
- *@dev    Both peek() and get() are provided for convenience
- *        Prices are calculated, never based on cached values
+ *@dev    Both peek() (view) and get() (transactional) are provided for convenience
  */
 contract Cvx3CrvOracle is IOracle, AccessControl {
     using CastBytes32Bytes6 for bytes32;

--- a/contracts/oracles/convex/Cvx3CrvOracle.sol
+++ b/contracts/oracles/convex/Cvx3CrvOracle.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.6;
 
-import '@yield-protocol/utils-v2/contracts/access/AccessControl.sol';
-import '@yield-protocol/vault-interfaces/IOracle.sol';
-import '@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol';
+import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
+import "@yield-protocol/vault-interfaces/IOracle.sol";
+import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
 
-import './ICurvePool.sol';
-import '../chainlink/AggregatorV3Interface.sol';
+import "./ICurvePool.sol";
+import "../chainlink/AggregatorV3Interface.sol";
 
 // Oracle Code Inspiration: https://github.com/Abracadabra-money/magic-internet-money/blob/main/contracts/oracles/3CrvOracle.sol
 /**
@@ -103,7 +103,7 @@ contract Cvx3CrvOracle is IOracle, AccessControl {
     ) private view returns (uint256 quoteAmount, uint256 updateTime) {
         require(
             (base == ethId && quote == cvx3CrvId) || (base == cvx3CrvId && quote == ethId),
-            'Invalid quote or base'
+            "Invalid quote or base"
         );
         (, int256 daiPrice, , , ) = DAI.latestRoundData();
         (, int256 usdcPrice, , , ) = USDC.latestRoundData();

--- a/contracts/oracles/convex/Cvx3CrvOracle.sol
+++ b/contracts/oracles/convex/Cvx3CrvOracle.sol
@@ -119,8 +119,7 @@ contract Cvx3CrvOracle is IOracle, AccessControl {
 
         if (base == cvx3CrvId && quote == ethId) {
             quoteAmount = (baseAmount * price) / 1e18;
-        }
-        if (quote == cvx3CrvId && base == ethId) {
+        } else {
             quoteAmount = (baseAmount * 1e18) / price;
         }
 

--- a/contracts/oracles/convex/Cvx3CrvOracle.sol
+++ b/contracts/oracles/convex/Cvx3CrvOracle.sol
@@ -109,7 +109,7 @@ contract Cvx3CrvOracle is IOracle, AccessControl {
         (, int256 usdcPrice, , , ) = USDC.latestRoundData();
         (, int256 usdtPrice, , , ) = USDT.latestRoundData();
 
-        require(daiPrice > 0 && usdcPrice > 0 && usdtPrice > 0, 'Chainlink pricefeed reporting 0');
+        require(daiPrice > 0 && usdcPrice > 0 && usdtPrice > 0, "Chainlink pricefeed reporting 0");
 
         // This won't overflow as the max value for int256 is less than the max value for uint256
         uint256 minStable = min(uint256(daiPrice), min(uint256(usdcPrice), uint256(usdtPrice)));

--- a/contracts/oracles/convex/Cvx3CrvOracle.sol
+++ b/contracts/oracles/convex/Cvx3CrvOracle.sol
@@ -59,7 +59,11 @@ contract Cvx3CrvOracle is IOracle, AccessControl {
 
     /**
      * @notice Retrieve the value of the amount at the latest oracle price.
-     * Only `cvx3crvid` and `ethId` are accepted as asset identifiers.
+     * @dev Only cvx3crvid and ethId are accepted as asset identifiers.
+     * @param base Id of base token
+     * @param quote Id of quoted token
+     * @return quoteAmount Total amount in terms of quoted token
+     * @return updateTime Time quote was last updated
      */
     function peek(
         bytes32 base,
@@ -71,7 +75,11 @@ contract Cvx3CrvOracle is IOracle, AccessControl {
 
     /**
      * @notice Retrieve the value of the amount at the latest oracle price. Same as `peek` for this oracle.
-     * Only `cvx3crvid` and `ethId` are accepted as asset identifiers.
+     * @dev Only cvx3crvid and ethId are accepted as asset identifiers.
+     * @param base Id of base token
+     * @param quote Id of quoted token
+     * @return quoteAmount Total amount in terms of quoted token
+     * @return updateTime Time quote was last updated
      */
     function get(
         bytes32 base,
@@ -83,7 +91,11 @@ contract Cvx3CrvOracle is IOracle, AccessControl {
 
     /**
      * @notice Retrieve the value of the amount at the latest oracle price.
-     * Only `cvx3crvid` and `ethId` are accepted as asset identifiers.
+     * @dev Only cvx3crvid and ethId are accepted as asset identifiers.
+     * @param base Id of base token
+     * @param quote Id of quoted token
+     * @return quoteAmount Total amount in terms of quoted token
+     * @return updateTime Time quote was last updated
      */
     function _peek(
         bytes6 base,

--- a/contracts/utils/convex/ConvexModule.sol
+++ b/contracts/utils/convex/ConvexModule.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.6;
 import '@yield-protocol/vault-interfaces/ICauldron.sol';
-import '@yield-protocol/vault-interfaces/IFYToken.sol';
 import '@yield-protocol/vault-interfaces/DataTypes.sol';
 import './interfaces/IConvexYieldWrapper.sol';
 import '../../LadleStorage.sol';

--- a/contracts/utils/convex/ConvexModule.sol
+++ b/contracts/utils/convex/ConvexModule.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.6;
-import '@yield-protocol/vault-interfaces/ICauldron.sol';
-import '@yield-protocol/vault-interfaces/DataTypes.sol';
-import './interfaces/IConvexYieldWrapper.sol';
-import '../../LadleStorage.sol';
+import "@yield-protocol/vault-interfaces/ICauldron.sol";
+import "@yield-protocol/vault-interfaces/DataTypes.sol";
+import "./interfaces/IConvexYieldWrapper.sol";
+import "../../LadleStorage.sol";
 
 /// @title Convex Ladle Module to handle vault addition
 contract ConvexModule is LadleStorage {

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -229,7 +229,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
         //update reward total
         if (bal != cvxRewardRemaining) {
-            cvxRewardRemaining = bal;
+            cvx_reward_remaining = bal;
         }
     }
 
@@ -286,7 +286,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
         //update remaining reward here since balance could have changed if claiming
         if (bal != rewardRemaining) {
-            rewardRemaining = uint128(bal);
+            reward.reward_remaining = uint128(bal);
         }
     }
 

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -198,7 +198,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         uint256 d_cvxreward = bal - cvxRewardRemaining;
         uint256 cvxRewardIntegral = cvx_reward_integral;
 
-        if (_supply != 0 && d_cvxreward != 0) {
+        if (_supply > 0 && d_cvxreward > 0) {
             cvxRewardIntegral = cvxRewardIntegral + (d_cvxreward * 1e20) / (_supply);
             cvx_reward_integral = cvxRewardIntegral;
         }
@@ -215,7 +215,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
                 uint256 receiveable = cvx_claimable_reward[_accounts[u]] +
                     ((_balances[u] * (cvxRewardIntegral - userI)) / 1e20);
                 if (_isClaim) {
-                    if (receiveable != 0) {
+                    if (receiveable > 0) {
                         cvx_claimable_reward[_accounts[u]] = 0;
                         IERC20(cvx).safeTransfer(_accounts[u], receiveable);
                         bal = bal - (receiveable);
@@ -254,7 +254,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         //get difference in balance and remaining rewards
         //getReward is unguarded so we use reward_remaining to keep track of how much was actually claimed
         uint256 bal = IERC20(reward.reward_token).balanceOf(address(this));
-        if (_supply != 0 && (bal - rewardRemaining) != 0) {
+        if (_supply > 0 && (bal - rewardRemaining) > 0) {
             rewardIntegral = uint128(rewardIntegral) + uint128(((bal - rewardRemaining) * 1e20) / _supply);
             reward.reward_integral = uint128(rewardIntegral);
         }
@@ -270,7 +270,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
                 if (_isClaim) {
                     uint256 receiveable = reward.claimable_reward[_accounts[u]] +
                         ((_balances[u] * (uint256(rewardIntegral) - userI)) / 1e20);
-                    if (receiveable != 0) {
+                    if (receiveable > 0) {
                         reward.claimable_reward[_accounts[u]] = 0;
                         IERC20(reward.reward_token).safeTransfer(_accounts[u], receiveable);
                         bal = bal - receiveable;
@@ -358,7 +358,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
             d_reward = d_reward + IRewardStaking(reward.reward_pool).earned(address(this));
 
             uint256 I = reward.reward_integral;
-            if (supply != 0) {
+            if (supply > 0) {
                 I = I + (d_reward * 1e20) / supply;
             }
 
@@ -393,7 +393,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
         //dont need to call checkpoint since _mint() will
 
-        if (_amount != 0) {
+        if (_amount > 0) {
             _mint(_to, _amount);
             IERC20(curveToken).safeTransferFrom(msg.sender, address(this), _amount);
             IConvexDeposits(convexBooster).deposit(convexPoolId, _amount, true);
@@ -410,7 +410,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
         //dont need to call checkpoint since _mint() will
 
-        if (_amount != 0) {
+        if (_amount > 0) {
             _mint(_to, _amount);
             IERC20(convexToken).safeTransferFrom(msg.sender, address(this), _amount);
             IRewardStaking(convexPool).stake(_amount);
@@ -424,7 +424,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
     function withdraw(uint256 _amount) external nonReentrant {
         //dont need to call checkpoint since _burn() will
 
-        if (_amount != 0) {
+        if (_amount > 0) {
             _burn(msg.sender, _amount);
             IRewardStaking(convexPool).withdraw(_amount, false);
             IERC20(convexToken).safeTransfer(msg.sender, _amount);
@@ -438,7 +438,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
     function withdrawAndUnwrap(uint256 _amount) external nonReentrant {
         //dont need to call checkpoint since _burn() will
 
-        if (_amount != 0) {
+        if (_amount > 0) {
             _burn(msg.sender, _amount);
             IRewardStaking(convexPool).withdrawAndUnwrap(_amount, false);
             IERC20(curveToken).safeTransfer(msg.sender, _amount);

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -98,7 +98,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         string memory name,
         string memory symbol,
         uint8 decimals
-    ) public ERC20(name, symbol, decimals) {
+    ) ERC20(name, symbol, decimals) {
         curveToken = _curveToken;
         convexToken = _convexToken;
         convexPool = _convexPool;

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -139,16 +139,19 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
     function addRewards() public {
         address mainPool = convexPool;
 
-        if (rewards.length == 0) {
+        uint256 rewardsLength = rewards.length;
+
+        if (rewardsLength == 0) {
             RewardType storage reward = rewards.push();
             reward.reward_token = crv;
             reward.reward_pool = mainPool;
             reward.reward_integral = 0;
             reward.reward_remaining = 0;
+            rewardsLength += 1;
         }
 
         uint256 extraCount = IRewardStaking(mainPool).extraRewardsLength();
-        uint256 startIndex = rewards.length - 1;
+        uint256 startIndex = rewardsLength - 1;
         for (uint256 i = startIndex; i < extraCount; i++) {
             address extraPool = IRewardStaking(mainPool).extraRewards(i);
             RewardType storage reward = rewards.push();

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -198,7 +198,8 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         bool _isClaim
     ) internal {
         uint256 bal = IERC20(cvx).balanceOf(address(this));
-        uint256 d_cvxreward = bal - cvx_reward_remaining;
+        uint256 cvxRewardRemaining = cvx_reward_remaining;
+        uint256 d_cvxreward = bal - cvxRewardRemaining;
         uint256 cvxRewardIntegral = cvx_reward_integral;
 
         if (_supply > 0 && d_cvxreward > 0) {
@@ -231,8 +232,8 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         }
 
         //update reward total
-        if (bal != cvx_reward_remaining) {
-            cvx_reward_remaining = bal;
+        if (bal != cvxRewardRemaining) {
+            cvxRewardRemaining = bal;
         }
     }
 

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -2,13 +2,13 @@
 // Original contract: https://github.com/convex-eth/platform/blob/main/contracts/contracts/wrappers/ConvexStakingWrapper.sol
 pragma solidity 0.8.6;
 
-import '@yield-protocol/utils-v2/contracts/token/IERC20.sol';
-import '@yield-protocol/utils-v2/contracts/token/ERC20.sol';
-import '@yield-protocol/utils-v2/contracts/access/AccessControl.sol';
-import '@yield-protocol/utils-v2/contracts/token/TransferHelper.sol';
-import './interfaces/IRewardStaking.sol';
-import './interfaces/IConvexDeposits.sol';
-import './interfaces/ICvx.sol';
+import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
+import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
+import "@yield-protocol/utils-v2/contracts/token/TransferHelper.sol";
+import "./interfaces/IRewardStaking.sol";
+import "./interfaces/IConvexDeposits.sol";
+import "./interfaces/ICvx.sol";
 
 library CvxMining {
     ICvx public constant cvx = ICvx(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
@@ -109,7 +109,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
     modifier nonReentrant() {
         // On the first call to nonReentrant, _notEntered will be true
-        require(_status != _ENTERED, 'ReentrancyGuard: reentrant call');
+        require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
         // Any calls to nonReentrant after this point will fail
         _status = _ENTERED;
         _;
@@ -378,7 +378,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
     //deposit a curve token
     function deposit(uint256 _amount, address _to) external nonReentrant {
-        require(!isShutdown, 'shutdown');
+        require(!isShutdown, "shutdown");
 
         //dont need to call checkpoint since _mint() will
 
@@ -393,7 +393,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
     //stake a convex token
     function stake(uint256 _amount, address _to) external nonReentrant {
-        require(!isShutdown, 'shutdown');
+        require(!isShutdown, "shutdown");
 
         //dont need to call checkpoint since _mint() will
 

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -199,9 +199,12 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
     ) internal {
         uint256 bal = IERC20(cvx).balanceOf(address(this));
         uint256 d_cvxreward = bal - cvx_reward_remaining;
+        uint256 cvxRewardIntegral = cvx_reward_integral;
 
         if (_supply > 0 && d_cvxreward > 0) {
-            cvx_reward_integral = cvx_reward_integral + (d_cvxreward * 1e20) / (_supply);
+            cvxRewardIntegral = cvxRewardIntegral + (d_cvxreward * 1e20) / (_supply);
+            cvx_reward_integral = cvxRewardIntegral;
+
         }
 
         //update user integrals for cvx
@@ -211,9 +214,9 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
             if (_accounts[u] == collateralVault) continue;
 
             uint256 userI = cvx_reward_integral_for[_accounts[u]];
-            if (_isClaim || userI < cvx_reward_integral) {
+            if (_isClaim || userI < cvxRewardIntegral) {
                 uint256 receiveable = cvx_claimable_reward[_accounts[u]] +
-                    ((_balances[u] * (cvx_reward_integral - userI)) / 1e20);
+                    ((_balances[u] * (cvxRewardIntegral - userI)) / 1e20);
                 if (_isClaim) {
                     if (receiveable > 0) {
                         cvx_claimable_reward[_accounts[u]] = 0;
@@ -223,7 +226,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
                 } else {
                     cvx_claimable_reward[_accounts[u]] = receiveable;
                 }
-                cvx_reward_integral_for[_accounts[u]] = cvx_reward_integral;
+                cvx_reward_integral_for[_accounts[u]] = cvxRewardIntegral;
             }
         }
 

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -198,7 +198,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         uint256 d_cvxreward = bal - cvxRewardRemaining;
         uint256 cvxRewardIntegral = cvx_reward_integral;
 
-        if (_supply > 0 && d_cvxreward > 0) {
+        if (_supply != 0 && d_cvxreward != 0) {
             cvxRewardIntegral = cvxRewardIntegral + (d_cvxreward * 1e20) / (_supply);
             cvx_reward_integral = cvxRewardIntegral;
 
@@ -216,7 +216,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
                 uint256 receiveable = cvx_claimable_reward[_accounts[u]] +
                     ((_balances[u] * (cvxRewardIntegral - userI)) / 1e20);
                 if (_isClaim) {
-                    if (receiveable > 0) {
+                    if (receiveable != 0) {
                         cvx_claimable_reward[_accounts[u]] = 0;
                         IERC20(cvx).safeTransfer(_accounts[u], receiveable);
                         bal = bal - (receiveable);
@@ -255,7 +255,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         //get difference in balance and remaining rewards
         //getReward is unguarded so we use reward_remaining to keep track of how much was actually claimed
         uint256 bal = IERC20(reward.reward_token).balanceOf(address(this));
-        if (_supply > 0 && (bal - rewardRemaining) > 0) {
+        if (_supply != 0 && (bal - rewardRemaining) != 0) {
             rewardIntegral =
                 uint128(rewardIntegral) +
                 uint128(((bal - rewardRemaining) * 1e20) / _supply);
@@ -273,7 +273,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
                 if (_isClaim) {
                     uint256 receiveable = reward.claimable_reward[_accounts[u]] +
                         ((_balances[u] * (uint256(rewardIntegral) - userI)) / 1e20);
-                    if (receiveable > 0) {
+                    if (receiveable != 0) {
                         reward.claimable_reward[_accounts[u]] = 0;
                         IERC20(reward.reward_token).safeTransfer(_accounts[u], receiveable);
                         bal = bal - receiveable;
@@ -361,7 +361,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
             d_reward = d_reward + IRewardStaking(reward.reward_pool).earned(address(this));
 
             uint256 I = reward.reward_integral;
-            if (supply > 0) {
+            if (supply != 0) {
                 I = I + (d_reward * 1e20) / supply;
             }
 
@@ -394,7 +394,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
         //dont need to call checkpoint since _mint() will
 
-        if (_amount > 0) {
+        if (_amount != 0) {
             _mint(_to, _amount);
             IERC20(curveToken).safeTransferFrom(msg.sender, address(this), _amount);
             IConvexDeposits(convexBooster).deposit(convexPoolId, _amount, true);
@@ -409,7 +409,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
         //dont need to call checkpoint since _mint() will
 
-        if (_amount > 0) {
+        if (_amount != 0) {
             _mint(_to, _amount);
             IERC20(convexToken).safeTransferFrom(msg.sender, address(this), _amount);
             IRewardStaking(convexPool).stake(_amount);
@@ -422,7 +422,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
     function withdraw(uint256 _amount) external nonReentrant {
         //dont need to call checkpoint since _burn() will
 
-        if (_amount > 0) {
+        if (_amount != 0) {
             _burn(msg.sender, _amount);
             IRewardStaking(convexPool).withdraw(_amount, false);
             IERC20(convexToken).safeTransfer(msg.sender, _amount);
@@ -435,7 +435,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
     function withdrawAndUnwrap(uint256 _amount) external nonReentrant {
         //dont need to call checkpoint since _burn() will
 
-        if (_amount > 0) {
+        if (_amount != 0) {
             _burn(msg.sender, _amount);
             IRewardStaking(convexPool).withdrawAndUnwrap(_amount, false);
             IERC20(curveToken).safeTransfer(msg.sender, _amount);

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -181,7 +181,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
     }
 
     /// @notice TotalSupply of wrapped token
-    /// @return Returns the total supply of wrapped token
+    /// @return The total supply of wrapped token
     function _getTotalSupply() internal view virtual returns (uint256) {
         return _totalSupply;
     }
@@ -339,7 +339,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
     /// @notice Get the amount of tokens the user has earned
     /// @param _account Address whose balance is to be checked
-    /// @return claimable Array of earned tokens and their amount
+    /// @return Claimable Array of earned tokens and their amount
     function earned(address _account) external view returns (EarnedData[] memory claimable) {
         uint256 supply = _getTotalSupply();
         // uint256 depositedBalance = _getDepositedBalance(_account);

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -145,6 +145,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
     /// @notice TotalSupply of wrapped token
     /// @return The total supply of wrapped token
+    /// @dev This function is provided and marked virtual as convenience to future development
     function _getTotalSupply() internal view virtual returns (uint256) {
         return _totalSupply;
     }

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -43,6 +43,7 @@ library CvxMining {
     }
 }
 
+/// @notice Wrapper used to manage staking of Convex tokens
 contract ConvexStakingWrapper is ERC20, AccessControl {
     using TransferHelper for IERC20;
 
@@ -387,7 +388,9 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         _checkpointAndClaim([_account, address(0)]);
     }
 
-    //deposit a curve token
+    /// @notice Deposit a curve token, receive a convex token
+    /// @param _amount Amount being deposited
+    /// @param _to Address to send the convex tokens to
     function deposit(uint256 _amount, address _to) external nonReentrant {
         require(!isShutdown, "shutdown");
 
@@ -402,7 +405,9 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         emit Deposited(msg.sender, _to, _amount, true);
     }
 
-    //stake a convex token
+    /// @notice Deposit and stake a convex token
+    /// @param _amount Amount being deposited
+    /// @param _to Address to send the convex tokens to
     function stake(uint256 _amount, address _to) external nonReentrant {
         require(!isShutdown, "shutdown");
 
@@ -417,7 +422,8 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         emit Deposited(msg.sender, _to, _amount, false);
     }
 
-    //withdraw to convex deposit token
+    /// @notice Withdraw to convex deposit token
+    /// @param _amount Amount being withdrawn
     function withdraw(uint256 _amount) external nonReentrant {
         //dont need to call checkpoint since _burn() will
 
@@ -430,7 +436,8 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         emit Withdrawn(msg.sender, _amount, false);
     }
 
-    //withdraw to underlying curve lp token
+    /// @notice Withdraw convex tokena nd unwrap to underlying curve lp token
+    /// @param _amount Amount being withdrawn and unwrapped
     function withdrawAndUnwrap(uint256 _amount) external nonReentrant {
         //dont need to call checkpoint since _burn() will
 

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -91,6 +91,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
     /// @notice Give maximum approval to the pool & convex booster contract to transfer funds from wrapper
     function setApprovals() public {
+        IERC20(curveToken).approve(convexBooster, 0);
         IERC20(curveToken).approve(convexBooster, type(uint256).max);
         IERC20(convexToken).approve(convexPool, type(uint256).max);
     }

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -348,15 +348,15 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
     /// @return claimable Array of earned tokens and their amount
     function earned(address _account) external view returns (EarnedData[] memory claimable) {
         uint256 supply = _getTotalSupply();
-        // uint256 depositedBalance = _getDepositedBalance(_account);
         uint256 rewardCount = rewards.length;
         claimable = new EarnedData[](rewardCount + 1);
 
         for (uint256 i = 0; i < rewardCount; i++) {
             RewardType storage reward = rewards[i];
+            address rewardToken = reward.reward_token;
 
             //change in reward is current balance - remaining reward + earned
-            uint256 bal = IERC20(reward.reward_token).balanceOf(address(this));
+            uint256 bal = IERC20(rewardToken).balanceOf(address(this));
             uint256 d_reward = bal - reward.reward_remaining;
             d_reward = d_reward + IRewardStaking(reward.reward_pool).earned(address(this));
 
@@ -368,10 +368,10 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
             uint256 newlyClaimable = (_getDepositedBalance(_account) * (I - reward.reward_integral_for[_account])) /
                 1e20;
             claimable[i].amount = reward.claimable_reward[_account] + newlyClaimable;
-            claimable[i].token = reward.reward_token;
+            claimable[i].token = rewardToken;
 
             //calc cvx here
-            if (reward.reward_token == crv) {
+            if (rewardToken == crv) {
                 claimable[rewardCount].amount =
                     cvx_claimable_reward[_account] +
                     CvxMining.ConvertCrvToCvx(newlyClaimable);

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -2,13 +2,13 @@
 // Original contract: https://github.com/convex-eth/platform/blob/main/contracts/contracts/wrappers/ConvexStakingWrapper.sol
 pragma solidity 0.8.6;
 
-import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
-import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
-import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
-import "@yield-protocol/utils-v2/contracts/token/TransferHelper.sol";
-import "./interfaces/IRewardStaking.sol";
-import "./interfaces/IConvexDeposits.sol";
-import "./interfaces/ICvx.sol";
+import '@yield-protocol/utils-v2/contracts/token/IERC20.sol';
+import '@yield-protocol/utils-v2/contracts/token/ERC20.sol';
+import '@yield-protocol/utils-v2/contracts/access/AccessControl.sol';
+import '@yield-protocol/utils-v2/contracts/token/TransferHelper.sol';
+import './interfaces/IRewardStaking.sol';
+import './interfaces/IConvexDeposits.sol';
+import './interfaces/ICvx.sol';
 
 /// @notice Contains function to calc amount of CVX to mint from a given amount of CRV
 library CvxMining {
@@ -112,7 +112,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
     modifier nonReentrant() {
         // On the first call to nonReentrant, _notEntered will be true
-        require(_status != _ENTERED, "ReentrancyGuard: reentrant call");
+        require(_status != _ENTERED, 'ReentrancyGuard: reentrant call');
         // Any calls to nonReentrant after this point will fail
         _status = _ENTERED;
         _;
@@ -201,7 +201,6 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         if (_supply != 0 && d_cvxreward != 0) {
             cvxRewardIntegral = cvxRewardIntegral + (d_cvxreward * 1e20) / (_supply);
             cvx_reward_integral = cvxRewardIntegral;
-
         }
 
         //update user integrals for cvx
@@ -256,9 +255,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         //getReward is unguarded so we use reward_remaining to keep track of how much was actually claimed
         uint256 bal = IERC20(reward.reward_token).balanceOf(address(this));
         if (_supply != 0 && (bal - rewardRemaining) != 0) {
-            rewardIntegral =
-                uint128(rewardIntegral) +
-                uint128(((bal - rewardRemaining) * 1e20) / _supply);
+            rewardIntegral = uint128(rewardIntegral) + uint128(((bal - rewardRemaining) * 1e20) / _supply);
             reward.reward_integral = uint128(rewardIntegral);
         }
         //update user integrals
@@ -392,7 +389,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
     /// @param _amount Amount being deposited
     /// @param _to Address to send the convex tokens to
     function deposit(uint256 _amount, address _to) external nonReentrant {
-        require(!isShutdown, "shutdown");
+        require(!isShutdown, 'shutdown');
 
         //dont need to call checkpoint since _mint() will
 
@@ -409,7 +406,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
     /// @param _amount Amount being deposited
     /// @param _to Address to send the convex tokens to
     function stake(uint256 _amount, address _to) external nonReentrant {
-        require(!isShutdown, "shutdown");
+        require(!isShutdown, 'shutdown');
 
         //dont need to call checkpoint since _mint() will
 

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -209,7 +209,8 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
         }
 
         //update user integrals for cvx
-        for (uint256 u = 0; u < _accounts.length; u++) {
+        uint256 accountsLength = _accounts.length;
+        for (uint256 u = 0; u < accountsLength; u++) {
             //do not give rewards to address 0
             if (_accounts[u] == address(0)) continue;
             if (_accounts[u] == collateralVault) continue;
@@ -261,7 +262,8 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
                 uint128(((bal - reward.reward_remaining) * 1e20) / _supply);
         }
         //update user integrals
-        for (uint256 u = 0; u < _accounts.length; u++) {
+        uint256 accountsLength = _accounts.length;
+        for (uint256 u = 0; u < accountsLength; u++) {
             //do not give rewards to address 0
             if (_accounts[u] == address(0)) continue;
             if (_accounts[u] == collateralVault) continue;

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -10,9 +10,12 @@ import "./interfaces/IRewardStaking.sol";
 import "./interfaces/IConvexDeposits.sol";
 import "./interfaces/ICvx.sol";
 
+/// @notice Contains function to calc amount of CVX to mint from a given amount of CRV
 library CvxMining {
     ICvx public constant cvx = ICvx(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
 
+    /// @param _amount The amount of CRV to burn
+    /// @return The amount of CVX to mint
     function ConvertCrvToCvx(uint256 _amount) internal view returns (uint256) {
         uint256 supply = cvx.totalSupply();
         uint256 reductionPerCliff = cvx.reductionPerCliff();
@@ -157,7 +160,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
     }
 
     /// @notice Returns the length of the reward tokens added
-    /// @return Returns the count of reward tokens
+    /// @return The count of reward tokens
     function rewardLength() external view returns (uint256) {
         return rewards.length;
     }

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -87,7 +87,6 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
     event Deposited(address indexed _user, address indexed _account, uint256 _amount, bool _wrapped);
     event Withdrawn(address indexed _user, uint256 _amount, bool _unwrapped);
-    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     constructor(
         address _curveToken,

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -145,8 +145,6 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
             RewardType storage reward = rewards.push();
             reward.reward_token = crv;
             reward.reward_pool = mainPool;
-            reward.reward_integral = 0;
-            reward.reward_remaining = 0;
             rewardsLength += 1;
         }
 
@@ -157,8 +155,6 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
             RewardType storage reward = rewards.push();
             reward.reward_token = IRewardStaking(extraPool).rewardToken();
             reward.reward_pool = extraPool;
-            reward.reward_integral = 0;
-            reward.reward_remaining = 0;
         }
     }
 

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -342,7 +342,7 @@ contract ConvexStakingWrapper is ERC20, AccessControl {
 
     /// @notice Get the amount of tokens the user has earned
     /// @param _account Address whose balance is to be checked
-    /// @return Claimable Array of earned tokens and their amount
+    /// @return claimable Array of earned tokens and their amount
     function earned(address _account) external view returns (EarnedData[] memory claimable) {
         uint256 supply = _getTotalSupply();
         // uint256 depositedBalance = _getDepositedBalance(_account);

--- a/contracts/utils/convex/ConvexYieldWrapper.sol
+++ b/contracts/utils/convex/ConvexYieldWrapper.sol
@@ -71,7 +71,11 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
             uint256 vaultsLength = vaults_.length;
             for (uint256 i = 0; i < vaultsLength; i++) {
                 if (vaults_[i] == vaultId) {
-                    delete vaults_[i];
+                    bool isLast = i == vaultsLength - 1;
+                    if (!isLast) {
+                        vaults_[i] = vaults_[vaultsLength - 1];
+                    }
+                    vaults_.pop();
                     emit VaultRemoved(account, vaultId);
                     break;
                 }

--- a/contracts/utils/convex/ConvexYieldWrapper.sol
+++ b/contracts/utils/convex/ConvexYieldWrapper.sol
@@ -117,7 +117,7 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
     function wrap(address to_, address from_) external {
         require(!isShutdown, 'shutdown');
         uint256 amount_ = IERC20(convexToken).balanceOf(address(this));
-        require(amount_ > 0, 'No convex token to wrap');
+        require(amount_ != 0, 'No convex token to wrap');
 
         _checkpoint([address(0), from_]);
         _mint(to_, amount_);
@@ -131,7 +131,7 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
     function unwrap(address to_) external {
         require(!isShutdown, 'shutdown');
         uint256 amount_ = _balanceOf[address(this)];
-        require(amount_ > 0, 'No wrapped convex token');
+        require(amount_ != 0, 'No wrapped convex token');
 
         _checkpoint([address(0), to_]);
         _burn(address(this), amount_);

--- a/contracts/utils/convex/ConvexYieldWrapper.sol
+++ b/contracts/utils/convex/ConvexYieldWrapper.sol
@@ -30,7 +30,7 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
     /// @param token Address of the token being rescued
     /// @param amount Amount of the token being rescued
     /// @param destination Address to which the rescued tokens have been sent
-    event Recovered(address token, uint256 amount, address destination);
+    event Recovered(address indexed token, uint256 amount, address indexed destination);
 
     constructor(
         address curveToken_,

--- a/contracts/utils/convex/ConvexYieldWrapper.sol
+++ b/contracts/utils/convex/ConvexYieldWrapper.sol
@@ -174,15 +174,6 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
 
             // Transfer the withdrawn convex tokens to rescue address
             IERC20(convexToken).safeTransfer(rescueAddress_, balance_);
-
-            // Transfer the reward tokens if any to the rescueAddress
-            uint256 rewardCount = rewards.length;
-            for (uint256 i = 0; i < rewardCount; i++) {
-                RewardType storage reward = rewards[i];
-                address rewardToken = reward.reward_token;
-                balance_ = IERC20(rewardToken).balanceOf(address(this));
-                if (balance_ != 0) IERC20(rewardToken).safeTransfer(rescueAddress_, balance_);
-            }
         }
         // Shutdown the contract
         isShutdown = true;

--- a/contracts/utils/convex/ConvexYieldWrapper.sol
+++ b/contracts/utils/convex/ConvexYieldWrapper.sol
@@ -115,7 +115,7 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
     function wrap(address to_, address from_) external {
         require(!isShutdown, 'shutdown');
         uint256 amount_ = IERC20(convexToken).balanceOf(address(this));
-        require(amount_ != 0, 'No convex token to wrap');
+        require(amount_ > 0, 'No convex token to wrap');
 
         _checkpoint([address(0), from_]);
         _mint(to_, amount_);
@@ -129,7 +129,7 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
     function unwrap(address to_) external {
         require(!isShutdown, 'shutdown');
         uint256 amount_ = _balanceOf[address(this)];
-        require(amount_ != 0, 'No wrapped convex token');
+        require(amount_ > 0, 'No wrapped convex token');
 
         _checkpoint([address(0), to_]);
         _burn(address(this), amount_);

--- a/contracts/utils/convex/ConvexYieldWrapper.sol
+++ b/contracts/utils/convex/ConvexYieldWrapper.sol
@@ -99,11 +99,9 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
         DataTypes.Balances memory balance;
         uint256 userVaultLength = userVault.length;
         for (uint256 i = 0; i < userVaultLength; i++) {
-            if (userVault[i] != bytes12(0)) {
-                if (cauldron.vaults(userVault[i]).owner == account_) {
-                    balance = cauldron.balances(userVault[i]);
-                    collateral = collateral + balance.ink;
-                }
+            if (cauldron.vaults(userVault[i]).owner == account_) {
+                balance = cauldron.balances(userVault[i]);
+                collateral = collateral + balance.ink;
             }
         }
 

--- a/contracts/utils/convex/ConvexYieldWrapper.sol
+++ b/contracts/utils/convex/ConvexYieldWrapper.sol
@@ -52,7 +52,8 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
         address account = cauldron.vaults(vaultId).owner;
         require(account != address(0), 'No owner for the vault');
         bytes12[] storage vaults_ = vaults[account];
-        for (uint256 i = 0; i < vaults_.length; i++) {
+        uint256 vaultsLength = vaults_.length;
+        for (uint256 i = 0; i < vaultsLength; i++) {
             require(vaults_[i] != vaultId, 'already added');
         }
         vaults_.push(vaultId);
@@ -67,7 +68,8 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
         address owner = cauldron.vaults(vaultId).owner;
         if (account != owner) {
             bytes12[] storage vaults_ = vaults[account];
-            for (uint256 i = 0; i < vaults_.length; i++) {
+            uint256 vaultsLength = vaults_.length;
+            for (uint256 i = 0; i < vaultsLength; i++) {
                 if (vaults_[i] == vaultId) {
                     vaults_[i] = bytes12(0);
                     emit VaultRemoved(account, vaultId);
@@ -91,7 +93,8 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
         //add up all balances of all vaults
         uint256 collateral;
         DataTypes.Balances memory balance;
-        for (uint256 i = 0; i < userVault.length; i++) {
+        uint256 userVaultLength = userVault.length;
+        for (uint256 i = 0; i < userVaultLength; i++) {
             if (userVault[i] != bytes12(0)) {
                 if (cauldron.vaults(userVault[i]).owner == account_) {
                     balance = cauldron.balances(userVault[i]);

--- a/contracts/utils/convex/ConvexYieldWrapper.sol
+++ b/contracts/utils/convex/ConvexYieldWrapper.sol
@@ -179,8 +179,9 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
             uint256 rewardCount = rewards.length;
             for (uint256 i = 0; i < rewardCount; i++) {
                 RewardType storage reward = rewards[i];
-                balance_ = IERC20(reward.reward_token).balanceOf(address(this));
-                if (balance_ != 0) IERC20(reward.reward_token).safeTransfer(rescueAddress_, balance_);
+                uint256 rewardToken = reward.reward_token;
+                balance_ = IERC20(rewardToken).balanceOf(address(this));
+                if (balance_ != 0) IERC20(rewardToken).safeTransfer(rescueAddress_, balance_);
             }
         }
         // Shutdown the contract

--- a/contracts/utils/convex/ConvexYieldWrapper.sol
+++ b/contracts/utils/convex/ConvexYieldWrapper.sol
@@ -179,7 +179,7 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
             uint256 rewardCount = rewards.length;
             for (uint256 i = 0; i < rewardCount; i++) {
                 RewardType storage reward = rewards[i];
-                uint256 rewardToken = reward.reward_token;
+                address rewardToken = reward.reward_token;
                 balance_ = IERC20(rewardToken).balanceOf(address(this));
                 if (balance_ != 0) IERC20(rewardToken).safeTransfer(rescueAddress_, balance_);
             }

--- a/contracts/utils/convex/ConvexYieldWrapper.sol
+++ b/contracts/utils/convex/ConvexYieldWrapper.sol
@@ -71,7 +71,7 @@ contract ConvexYieldWrapper is ConvexStakingWrapper {
             uint256 vaultsLength = vaults_.length;
             for (uint256 i = 0; i < vaultsLength; i++) {
                 if (vaults_[i] == vaultId) {
-                    vaults_[i] = bytes12(0);
+                    delete vaults_[i];
                     emit VaultRemoved(account, vaultId);
                     break;
                 }

--- a/contracts/utils/convex/CvxMining.sol
+++ b/contracts/utils/convex/CvxMining.sol
@@ -3,10 +3,13 @@ pragma solidity 0.8.6;
 
 import "./interfaces/ICvx.sol";
 
-library CvxMining{
+/// @notice Contains function to calc amount of CVX to mint from a given amount of CRV
+library CvxMining {
     ICvx public constant cvx = ICvx(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
 
-    function ConvertCrvToCvx(uint256 _amount) external view returns(uint256){
+    /// @param _amount The amount of CRV to burn
+    /// @return The amount of CVX to mint
+    function ConvertCrvToCvx(uint256 _amount) internal view returns (uint256) {
         uint256 supply = cvx.totalSupply();
         uint256 reductionPerCliff = cvx.reductionPerCliff();
         uint256 totalCliffs = cvx.totalCliffs();
@@ -14,15 +17,15 @@ library CvxMining{
 
         uint256 cliff = supply / reductionPerCliff;
         //mint if below total cliffs
-        if(cliff < totalCliffs){
+        if (cliff < totalCliffs) {
             //for reduction% take inverse of current cliff
             uint256 reduction = totalCliffs - cliff;
             //reduce
-            _amount = _amount * reduction / totalCliffs;
+            _amount = (_amount * reduction) / totalCliffs;
 
             //supply cap check
             uint256 amtTillMax = maxSupply - supply;
-            if(_amount > amtTillMax){
+            if (_amount > amtTillMax) {
                 _amount = amtTillMax;
             }
 


### PR DESCRIPTION
# questions / comments for @alcueca @iamsahu :
 - [x] setApprovals() - why do we set to 0 first?
 - [x] If there's a good reason for `ConvexStakingWrapper._getTotalSupply` we should disclose it (or else delete the fn)
 - [x] Is there a reason `ConvexStakingWrapper._getTotalSupply` is marked as "virtual"?  If yes, document, if no, then maybe remove virtual
 - [x] Fyi - looks like the CvxMining library is duped, once in its own file and once in ConvexStakingWrapper.sol.  I updated the one in ConvexStakingWrapper.sol but completely ignored the CvxMining.sol file
 - [x] I didn't have time to double check the decimals in the oracle, I'm assuming this was done in the code review
 
# Known issues / Intentional deviations from best practices
- We intentionally do not check validity of contract addresses using `isContract` or some other means
- We intentionally chose not to use Yul for minor gas savings in favor of readability
- We intentionally did not make use of custom errors in spite of the potential gas savings
- The length of each revert string is intentional and we do not wish to save gas by shortening them
- We intentionally did not apply "unchecked" to the incrementing of loop counter variables, preferring readability to small runtime gas savings
- Any "missing" address == 0 checks were intentionally omitted to save gas
- We have intentionally inlined as much logic as we care to and do not wish to save any additional runtime gas by inlining more
- We have abstracted as much logic as we care to and do not wish to reduce bytecode size to save deployment gas by abstracting more
-  In `Cvx3CrvOracle.sol`, `peek()` and `get()` both point to the same internal fn `_peek()`, however `get()` is transactional.  This is all done intentionally to emulate behavior of Yield oracles.


# Naming conventions:
- We intentionally use all-caps variable names instead of mixed case for state variables DAI, USDC, USDT, and IWETH9
- We intentionally use PascalCase for certain function names to be consistent with the [contracts](https://github.com/convex-eth/platform/blob/main/contracts/contracts/wrappers/ConvexStakingWrapperAbra.sol) these were based on
- We intentionally use snake_case for certain variable names to be consistent with the [contracts](https://github.com/convex-eth/platform/blob/main/contracts/contracts/wrappers/ConvexStakingWrapperAbra.sol) these were based on
- We intentionally use variable name `I` to represent integral to be consistent with the [contracts](https://github.com/convex-eth/platform/blob/main/contracts/contracts/wrappers/ConvexStakingWrapperAbra.sol) these were based on

# NatSpec
- We intentionally only include @notice and @dev comments for contracts and functions when we think it is helpful.  If it is omitted, it is intentional.
