### PR TITLE
ConvexYieldWrapper: Mock contracts for tests

### DIFF
--- a/contracts/mocks/CurveProxy.sol
+++ b/contracts/mocks/CurveProxy.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// Original contract: https://github.com/convex-eth/platform/blob/main/contracts/contracts/wrappers/ConvexStakingWrapper.sol
+pragma solidity 0.8.6;
+import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+
+contract CurveProxy {
+    IERC20 immutable _curve;
+
+    constructor(IERC20 curve_) {
+        _curve = curve_;
+    }
+
+    // function set(address curve_) public {
+    //     _curve = IERC20(curve_);
+    // }
+
+    /// @param _owner The address from which the balance will be retrieved
+    /// @return balance the balance
+    function balanceOf(address _owner) external view returns (uint256 balance){
+        return _curve.balanceOf(_owner);
+    }
+
+    /// @notice send `_value` token to `_to` from `msg.sender`
+    /// @param _to The address of the recipient
+    /// @param _value The amount of token to be transferred
+    /// @return success Whether the transfer was successful or not
+    function transfer(address _to, uint256 _value)  external returns (bool success){
+        return _curve.transfer(_to, _value);
+    }
+
+    /// @notice send `_value` token to `_to` from `_from` on the condition it is approved by `_from`
+    /// @param _from The address of the sender
+    /// @param _to The address of the recipient
+    /// @param _value The amount of token to be transferred
+    /// @return success Whether the transfer was successful or not
+    function transferFrom(address _from, address _to, uint256 _value) external returns (bool success){
+        return _curve.transferFrom(_from, _to, _value);
+    }
+
+    /// @notice `msg.sender` approves `_addr` to spend `_value` tokens
+    /// @param _spender The address of the account able to transfer the tokens
+    /// @param _value The amount of wei to be approved for transfer
+    /// @return success Whether the approval was successful or not
+    function approve(address _spender  , uint256 _value) external returns (bool success){
+        return _curve.approve(_spender, _value);
+    }
+
+    /// @param _owner The address of the account owning tokens
+    /// @param _spender The address of the account able to transfer the tokens
+    /// @return remaining Amount of remaining tokens allowed to spent
+    function allowance(address _owner, address _spender) external view returns (uint256 remaining){
+        return _curve.allowance(_owner, _spender);
+    }
+
+
+}

--- a/contracts/mocks/TokenProxy.sol
+++ b/contracts/mocks/TokenProxy.sol
@@ -1,19 +1,19 @@
-// SPDX-License-Identifier: MIT
-// Original contract: https://github.com/convex-eth/platform/blob/main/contracts/contracts/wrappers/ConvexStakingWrapper.sol
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.6;
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
 
+/// @notice A simple contract which could be used as a proxy for ERC20 contracts
 contract TokenProxy {
-    ERC20 immutable _curve;
+    ERC20 immutable _token;
 
-    constructor(ERC20 curve_) {
-        _curve = curve_;
+    constructor(ERC20 token_) {
+        _token = token_;
     }
 
     /// @param _owner The address from which the balance will be retrieved
     /// @return balance the balance
     function balanceOf(address _owner) external view returns (uint256 balance) {
-        return _curve.balanceOf(_owner);
+        return _token.balanceOf(_owner);
     }
 
     /// @notice send `_value` token to `_to` from `msg.sender`
@@ -21,7 +21,7 @@ contract TokenProxy {
     /// @param _value The amount of token to be transferred
     /// @return success Whether the transfer was successful or not
     function transfer(address _to, uint256 _value) external returns (bool success) {
-        return _curve.transfer(_to, _value);
+        return _token.transfer(_to, _value);
     }
 
     /// @notice send `_value` token to `_to` from `_from` on the condition it is approved by `_from`
@@ -34,7 +34,7 @@ contract TokenProxy {
         address _to,
         uint256 _value
     ) external returns (bool success) {
-        return _curve.transferFrom(_from, _to, _value);
+        return _token.transferFrom(_from, _to, _value);
     }
 
     /// @notice `msg.sender` approves `_addr` to spend `_value` tokens
@@ -42,13 +42,13 @@ contract TokenProxy {
     /// @param _value The amount of wei to be approved for transfer
     /// @return success Whether the approval was successful or not
     function approve(address _spender, uint256 _value) external returns (bool success) {
-        return _curve.approve(_spender, _value);
+        return _token.approve(_spender, _value);
     }
 
     /// @param _owner The address of the account owning tokens
     /// @param _spender The address of the account able to transfer the tokens
     /// @return remaining Amount of remaining tokens allowed to spent
     function allowance(address _owner, address _spender) external view returns (uint256 remaining) {
-        return _curve.allowance(_owner, _spender);
+        return _token.allowance(_owner, _spender);
     }
 }

--- a/contracts/mocks/TokenProxy.sol
+++ b/contracts/mocks/TokenProxy.sol
@@ -1,22 +1,18 @@
 // SPDX-License-Identifier: MIT
 // Original contract: https://github.com/convex-eth/platform/blob/main/contracts/contracts/wrappers/ConvexStakingWrapper.sol
 pragma solidity 0.8.6;
-import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
 
-contract CurveProxy {
-    IERC20 immutable _curve;
+contract TokenProxy {
+    ERC20 immutable _curve;
 
-    constructor(IERC20 curve_) {
+    constructor(ERC20 curve_) {
         _curve = curve_;
     }
 
-    // function set(address curve_) public {
-    //     _curve = IERC20(curve_);
-    // }
-
     /// @param _owner The address from which the balance will be retrieved
     /// @return balance the balance
-    function balanceOf(address _owner) external view returns (uint256 balance){
+    function balanceOf(address _owner) external view returns (uint256 balance) {
         return _curve.balanceOf(_owner);
     }
 
@@ -24,7 +20,7 @@ contract CurveProxy {
     /// @param _to The address of the recipient
     /// @param _value The amount of token to be transferred
     /// @return success Whether the transfer was successful or not
-    function transfer(address _to, uint256 _value)  external returns (bool success){
+    function transfer(address _to, uint256 _value) external returns (bool success) {
         return _curve.transfer(_to, _value);
     }
 
@@ -33,7 +29,11 @@ contract CurveProxy {
     /// @param _to The address of the recipient
     /// @param _value The amount of token to be transferred
     /// @return success Whether the transfer was successful or not
-    function transferFrom(address _from, address _to, uint256 _value) external returns (bool success){
+    function transferFrom(
+        address _from,
+        address _to,
+        uint256 _value
+    ) external returns (bool success) {
         return _curve.transferFrom(_from, _to, _value);
     }
 
@@ -41,16 +41,14 @@ contract CurveProxy {
     /// @param _spender The address of the account able to transfer the tokens
     /// @param _value The amount of wei to be approved for transfer
     /// @return success Whether the approval was successful or not
-    function approve(address _spender  , uint256 _value) external returns (bool success){
+    function approve(address _spender, uint256 _value) external returns (bool success) {
         return _curve.approve(_spender, _value);
     }
 
     /// @param _owner The address of the account owning tokens
     /// @param _spender The address of the account able to transfer the tokens
     /// @return remaining Amount of remaining tokens allowed to spent
-    function allowance(address _owner, address _spender) external view returns (uint256 remaining){
+    function allowance(address _owner, address _spender) external view returns (uint256 remaining) {
         return _curve.allowance(_owner, _spender);
     }
-
-
 }

--- a/contracts/utils/convex/ConvexStakingWrapper.sol
+++ b/contracts/utils/convex/ConvexStakingWrapper.sol
@@ -5,13 +5,14 @@ pragma solidity 0.8.6;
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
 import "@yield-protocol/utils-v2/contracts/token/TransferHelper.sol";
+import "@yield-protocol/utils-v2/contracts/cast/CastU256U128.sol";
 import "./interfaces/IRewardStaking.sol";
 import "./CvxMining.sol";
 
 /// @notice Wrapper used to manage staking of Convex tokens
 contract ConvexStakingWrapper is ERC20 {
     using TransferHelper for IERC20;
-
+    using CastU256U128 for uint256;
     struct EarnedData {
         address token;
         uint256 amount;
@@ -171,18 +172,20 @@ contract ConvexStakingWrapper is ERC20 {
         if (_account != collateralVault && _account != address(this)) {
             uint256 userI = cvx_reward_integral_for[_account];
             if (_isClaim || userI < cvxRewardIntegral) {
-                if (_isClaim) {
-                    uint256 receiveable = cvx_claimable_reward[_account] +
-                        ((_balance * (cvxRewardIntegral - userI)) / 1e20);
-                    if (receiveable > 0) {
-                        cvx_claimable_reward[_account] = 0;
-                        IERC20(cvx).safeTransfer(_account, receiveable);
-                        bal -= receiveable;
+                unchecked {
+                    if (_isClaim) {
+                        uint256 receiveable = cvx_claimable_reward[_account] +
+                            ((_balance * (cvxRewardIntegral - userI)) / 1e20);
+                        if (receiveable > 0) {
+                            cvx_claimable_reward[_account] = 0;
+                            IERC20(cvx).safeTransfer(_account, receiveable);
+                            bal -= receiveable;
+                        }
+                    } else {
+                        cvx_claimable_reward[_account] =
+                            cvx_claimable_reward[_account] +
+                            ((_balance * (cvxRewardIntegral - userI)) / 1e20);
                     }
-                } else {
-                    cvx_claimable_reward[_account] =
-                        cvx_claimable_reward[_account] +
-                        ((_balance * (cvxRewardIntegral - userI)) / 1e20);
                 }
                 cvx_reward_integral_for[_account] = cvxRewardIntegral;
             }
@@ -211,13 +214,14 @@ contract ConvexStakingWrapper is ERC20 {
 
         uint256 rewardIntegral = reward.reward_integral;
         uint256 rewardRemaining = reward.reward_remaining;
-
         //get difference in balance and remaining rewards
         //getReward is unguarded so we use reward_remaining to keep track of how much was actually claimed
         uint256 bal = IERC20(reward.reward_token).balanceOf(address(this));
         if (_supply > 0 && (bal - rewardRemaining) > 0) {
-            rewardIntegral = uint128(rewardIntegral) + uint128(((bal - rewardRemaining) * 1e20) / _supply);
-            reward.reward_integral = uint128(rewardIntegral);
+            unchecked {
+                rewardIntegral = rewardIntegral + ((bal - rewardRemaining) * 1e20) / _supply;
+            }
+            reward.reward_integral = rewardIntegral.u128();
         }
 
         //do not give rewards to collateralVault or this contract
@@ -225,18 +229,20 @@ contract ConvexStakingWrapper is ERC20 {
             //update user integrals
             uint256 userI = reward.reward_integral_for[_account];
             if (_isClaim || userI < rewardIntegral) {
-                if (_isClaim) {
-                    uint256 receiveable = reward.claimable_reward[_account] +
-                        ((_balance * (uint256(rewardIntegral) - userI)) / 1e20);
-                    if (receiveable > 0) {
-                        reward.claimable_reward[_account] = 0;
-                        IERC20(reward.reward_token).safeTransfer(_account, receiveable);
-                        bal = bal - receiveable;
+                unchecked {
+                    if (_isClaim) {
+                        uint256 receiveable = reward.claimable_reward[_account] +
+                            ((_balance * (rewardIntegral - userI)) / 1e20);
+                        if (receiveable > 0) {
+                            reward.claimable_reward[_account] = 0;
+                            IERC20(reward.reward_token).safeTransfer(_account, receiveable);
+                            bal -= receiveable;
+                        }
+                    } else {
+                        reward.claimable_reward[_account] =
+                            reward.claimable_reward[_account] +
+                            ((_balance * (rewardIntegral - userI)) / 1e20);
                     }
-                } else {
-                    reward.claimable_reward[_account] =
-                        reward.claimable_reward[_account] +
-                        ((_balance * (uint256(rewardIntegral) - userI)) / 1e20);
                 }
                 reward.reward_integral_for[_account] = rewardIntegral;
             }
@@ -244,7 +250,7 @@ contract ConvexStakingWrapper is ERC20 {
 
         //update remaining reward here since balance could have changed if claiming
         if (bal != rewardRemaining) {
-            reward.reward_remaining = uint128(bal);
+            reward.reward_remaining = bal.u128();
         }
     }
 
@@ -285,7 +291,7 @@ contract ConvexStakingWrapper is ERC20 {
 
     /// @notice Create a checkpoint for the supplied addresses by updating the reward integrals & claimable reward for them
     /// @param _account The accounts for which checkpoints have to be calculated
-    function user_checkpoint(address _account) external returns (bool) {
+    function user_checkpoint(address _account) external nonReentrant returns (bool) {
         _checkpoint(_account);
         return true;
     }

--- a/contracts/utils/convex/ConvexYieldWrapper.sol
+++ b/contracts/utils/convex/ConvexYieldWrapper.sol
@@ -78,9 +78,11 @@ contract ConvexYieldWrapper is ConvexStakingWrapper, AccessControl {
         uint256 vaultsLength = vaults_.length;
         for (uint256 i; i < vaultsLength; ++i) {
             if (vaults_[i] == vaultId) {
-                bool isLast = i == vaultsLength - 1;
-                if (!isLast) {
-                    vaults_[i] = vaults_[vaultsLength - 1];
+                unchecked {
+                    bool isLast = i == vaultsLength - 1;
+                    if (!isLast) {
+                        vaults_[i] = vaults_[vaultsLength - 1];
+                    }
                 }
                 vaults_.pop();
                 emit VaultRemoved(account, vaultId);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "erc3156": "^0.4.8",
     "ethereum-waffle": "^3.2.2",
     "ethers": "^5.0.0",
-    "hardhat": "^2.2.0",
+    "hardhat": "2.4.3",
     "hardhat-abi-exporter": "^2.0.3",
     "hardhat-contract-sizer": "^2.0.3",
     "hardhat-deploy": "^0.7.0-beta.44",

--- a/test/092_convex_wrapper.ts
+++ b/test/092_convex_wrapper.ts
@@ -231,8 +231,6 @@ describe('Convex Wrapper', async function () {
     await convex.mint(convexPool.address, ethers.utils.parseEther('10'))
 
     //Minting tokens to the proxy
-    console.log(await convexWrapper.crv())
-    console.log(await convexWrapper.cvx())
     await crv.mint(await convexWrapper.crv(), ethers.utils.parseEther('10'))
     await convex.mint(await convexWrapper.cvx(), ethers.utils.parseEther('10'))
   })
@@ -294,6 +292,8 @@ describe('Convex Wrapper', async function () {
     var cvxAfter = await convex.balanceOf(ownerAcc.address)
     console.log('User Total Crv ' + crvAfter.toString())
     console.log('Earned Crv ' + crvAfter.sub(crvBefore).toString())
+    console.log('User Total cvx ' + cvxAfter.toString())
+    console.log('Earned cvx ' + cvxAfter.sub(cvxBefore).toString())
     if (crvBefore.gt(crvAfter)) throw 'Reward claim failed'
     if (cvxBefore.gt(cvxAfter)) throw 'Reward claim failed'
 
@@ -322,6 +322,8 @@ describe('Convex Wrapper', async function () {
     cvxAfter = await convex.balanceOf(ownerAcc.address)
     console.log('User Earned Crv ' + crvAfter.sub(crvBefore).toString())
     console.log('Total User Crv ' + crvAfter.toString())
+    console.log('User Earned cvx ' + cvxAfter.sub(cvxBefore).toString())
+    console.log('Total User cvx ' + cvxAfter.toString())
     if (crvBefore.gt(crvAfter)) throw 'Reward claim failed'
     if (cvxBefore.gt(cvxAfter)) throw 'Reward claim failed'
   })
@@ -383,6 +385,8 @@ describe('Convex Wrapper', async function () {
     var cvxAfter = await convex.balanceOf(ownerAcc.address)
     console.log('User Total Crv ' + crvAfter.toString())
     console.log('User Earned Crv ' + crvAfter.sub(crvBefore).toString())
+    console.log('User Total cvx ' + cvxAfter.toString())
+    console.log('Earned cvx ' + cvxAfter.sub(cvxBefore).toString())
     if (crvBefore.gt(crvAfter)) throw 'Reward claim failed'
     if (cvxBefore.gt(cvxAfter)) throw 'Reward claim failed'
 
@@ -411,6 +415,8 @@ describe('Convex Wrapper', async function () {
     cvxAfter = await convex.balanceOf(ownerAcc.address)
     console.log('User Earned Crv ' + crvAfter.sub(crvBefore).toString())
     console.log('Total User Crv ' + crvAfter.toString())
+    console.log('User Earned cvx ' + cvxAfter.sub(cvxBefore).toString())
+    console.log('Total User cvx ' + cvxAfter.toString())
     if (crvBefore.gt(crvAfter)) throw 'Reward claim failed'
     if (cvxBefore.gt(cvxAfter)) throw 'Reward claim failed'
   })

--- a/test/092_convex_wrapper.ts
+++ b/test/092_convex_wrapper.ts
@@ -230,11 +230,9 @@ describe('Convex Wrapper', async function () {
     await cvx3CRV.mint(ownerAcc.address, ethers.utils.parseEther('100000000'))
     await crv.mint(convexPool.address, ethers.utils.parseEther('100000000'))
     await convex.mint(convexPool.address, ethers.utils.parseEther('100000000'))
-    await crv.mint(curveProxy.address, ethers.utils.parseEther('100000000'))
-    await convex.mint(cvxProxy.address, ethers.utils.parseEther('100000000'))
 
-    await crv.mint('0xD533a949740bb3306d119CC777fa900bA034cd52', ethers.utils.parseEther('100000000'))
-    await convex.mint('0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B', ethers.utils.parseEther('100000000'))
+    await crv.mint(await convexWrapper.crv(), ethers.utils.parseEther('100000000'))
+    await convex.mint(await convexWrapper.cvx(), ethers.utils.parseEther('100000000'))
   })
 
   it('Borrow USDC with CVX3CRV collateral', async () => {
@@ -292,8 +290,8 @@ describe('Convex Wrapper', async function () {
     await convexWrapper.getReward(ownerAcc.address)
     var crvAfter = await crv.balanceOf(ownerAcc.address)
     var cvxAfter = await convex.balanceOf(ownerAcc.address)
-    console.log('User1 ' + crvAfter.toString())
-    console.log('Earned ' + crvAfter.sub(crvBefore).toString())
+    console.log('User Total Crv ' + crvAfter.toString())
+    console.log('Earned Crv ' + crvAfter.sub(crvBefore).toString())
     if (crvBefore.gt(crvAfter)) throw 'Reward claim failed'
     if (cvxBefore.gt(cvxAfter)) throw 'Reward claim failed'
 
@@ -322,8 +320,8 @@ describe('Convex Wrapper', async function () {
     await convexWrapper.getReward(ownerAcc.address)
     crvAfter = await crv.balanceOf(ownerAcc.address)
     cvxAfter = await convex.balanceOf(ownerAcc.address)
-    console.log('Earned ' + crvAfter.sub(crvBefore).toString())
-    console.log('User1 ' + crvAfter.toString())
+    console.log('User Earned Crv ' + crvAfter.sub(crvBefore).toString())
+    console.log('Total User Crv ' + crvAfter.toString())
     if (crvBefore.gt(crvAfter)) throw 'Reward claim failed'
     if (cvxBefore.gt(cvxAfter)) throw 'Reward claim failed'
   })
@@ -383,8 +381,8 @@ describe('Convex Wrapper', async function () {
     await convexWrapper.getReward(ownerAcc.address)
     var crvAfter = await crv.balanceOf(ownerAcc.address)
     var cvxAfter = await convex.balanceOf(ownerAcc.address)
-    console.log('User1 ' + crvAfter.toString())
-    console.log('Earned ' + crvAfter.sub(crvBefore).toString())
+    console.log('User Total Crv ' + crvAfter.toString())
+    console.log('User Earned Crv ' + crvAfter.sub(crvBefore).toString())
     if (crvBefore.gt(crvAfter)) throw 'Reward claim failed'
     if (cvxBefore.gt(cvxAfter)) throw 'Reward claim failed'
 
@@ -413,8 +411,8 @@ describe('Convex Wrapper', async function () {
     await convexWrapper.getReward(ownerAcc.address)
     crvAfter = await crv.balanceOf(ownerAcc.address)
     cvxAfter = await convex.balanceOf(ownerAcc.address)
-    console.log('Earned ' + crvAfter.sub(crvBefore).toString())
-    console.log('User1 ' + crvAfter.toString())
+    console.log('User Earned Crv ' + crvAfter.sub(crvBefore).toString())
+    console.log('Total User Crv ' + crvAfter.toString())
     if (crvBefore.gt(crvAfter)) throw 'Reward claim failed'
     if (cvxBefore.gt(cvxAfter)) throw 'Reward claim failed'
   })

--- a/test/092_convex_wrapper.ts
+++ b/test/092_convex_wrapper.ts
@@ -94,6 +94,7 @@ describe('Convex Wrapper', async function () {
   async function fixture() {
     return await YieldEnvironment.setup(ownerAcc, [USDC, DAI, ETH], [seriesId, seriesId2])
   }
+
   before(async () => {
     this.timeout(0)
 
@@ -208,9 +209,10 @@ describe('Convex Wrapper', async function () {
     await compositeMultiOracle.setPath(DAI, CVX3CRV, [ETH])
     await compositeMultiOracle.setPath(USDC, CVX3CRV, [ETH])
 
+    // Setting the mainnet crv to mock CRV
     const crv_proxy_code = await ethers.provider.getCode(curveProxy.address)
     expect(await network.provider.send('hardhat_setCode', [await convexWrapper.crv(), crv_proxy_code])).to.be.true
-
+    // Setting the mainnet cvx to mock CVX
     const cvx_proxy_code = await ethers.provider.getCode(cvxProxy.address)
     expect(await network.provider.send('hardhat_setCode', [await convexWrapper.cvx(), cvx_proxy_code])).to.be.true
 
@@ -231,6 +233,7 @@ describe('Convex Wrapper', async function () {
     await crv.mint(convexPool.address, ethers.utils.parseEther('100000000'))
     await convex.mint(convexPool.address, ethers.utils.parseEther('100000000'))
 
+    //Minting tokens to the proxy
     await crv.mint(await convexWrapper.crv(), ethers.utils.parseEther('100000000'))
     await convex.mint(await convexWrapper.cvx(), ethers.utils.parseEther('100000000'))
   })
@@ -299,9 +302,7 @@ describe('Convex Wrapper', async function () {
     await fyToken.transfer(fyToken.address, borrowed)
 
     var unwrapCall = convexWrapper.interface.encodeFunctionData('unwrap', [ownerAcc.address])
-    var preUnwrapCall = convexWrapper.interface.encodeFunctionData('user_checkpoint', [
-      ['0x0000000000000000000000000000000000000000', ownerAcc.address],
-    ])
+    var preUnwrapCall = convexWrapper.interface.encodeFunctionData('user_checkpoint', [ownerAcc.address])
 
     await ladle.batch([
       ladle.routeAction(convexWrapper.address, preUnwrapCall),
@@ -390,9 +391,7 @@ describe('Convex Wrapper', async function () {
     await fyToken.transfer(fyToken.address, borrowed)
 
     var unwrapCall = convexWrapper.interface.encodeFunctionData('unwrap', [ownerAcc.address])
-    var preUnwrapCall = convexWrapper.interface.encodeFunctionData('user_checkpoint', [
-      ['0x0000000000000000000000000000000000000000', ownerAcc.address],
-    ])
+    var preUnwrapCall = convexWrapper.interface.encodeFunctionData('user_checkpoint', [ownerAcc.address])
 
     await ladle.batch([
       ladle.routeAction(convexWrapper.address, preUnwrapCall),

--- a/test/092_convex_wrapper.ts
+++ b/test/092_convex_wrapper.ts
@@ -121,10 +121,7 @@ describe('Convex Wrapper', async function () {
       'Cvx3Crv Mock',
     ])) as ERC20Mock
     crv = (await deployContract(ownerAcc, ERC20MockArtifact, ['CurveDAO Token Mock', 'CRV'])) as ERC20Mock
-
-    await convex.mint(ownerAcc.address, parseEther('1000000'))
-    await crv.mint(ownerAcc.address, parseEther('1000000'))
-
+    
     curvePool = (await deployContract(ownerAcc, CurvePoolMockArtifact)) as unknown as CurvePoolMock
     convexPool = (await deployContract(ownerAcc, ConvexPoolMockArtifact, [
       crv.address,
@@ -229,13 +226,15 @@ describe('Convex Wrapper', async function () {
 
     await ladle.ladle.addToken(cvx3CRV.address, true)
 
-    await cvx3CRV.mint(ownerAcc.address, ethers.utils.parseEther('100000000'))
-    await crv.mint(convexPool.address, ethers.utils.parseEther('100000000'))
-    await convex.mint(convexPool.address, ethers.utils.parseEther('100000000'))
+    await cvx3CRV.mint(ownerAcc.address, ethers.utils.parseEther('10'))
+    await crv.mint(convexPool.address, ethers.utils.parseEther('10'))
+    await convex.mint(convexPool.address, ethers.utils.parseEther('10'))
 
     //Minting tokens to the proxy
-    await crv.mint(await convexWrapper.crv(), ethers.utils.parseEther('100000000'))
-    await convex.mint(await convexWrapper.cvx(), ethers.utils.parseEther('100000000'))
+    console.log(await convexWrapper.crv())
+    console.log(await convexWrapper.cvx())
+    await crv.mint(await convexWrapper.crv(), ethers.utils.parseEther('10'))
+    await convex.mint(await convexWrapper.cvx(), ethers.utils.parseEther('10'))
   })
 
   it('Borrow USDC with CVX3CRV collateral', async () => {
@@ -314,7 +313,7 @@ describe('Convex Wrapper', async function () {
     const cvx3CrvAfter = (await cvx3CRV.balanceOf(ownerAcc.address)).toString()
     console.log(`${cvx3CrvAfter} cvx3Crv after`)
     if (cvx3CrvAfter !== cvx3CrvBefore) throw 'cvx3Crv balance mismatch'
-
+    console.log('Claiming leftover rewards')
     // Claim leftover rewards
     crvBefore = await crv.balanceOf(ownerAcc.address)
     cvxBefore = await convex.balanceOf(ownerAcc.address)
@@ -392,18 +391,18 @@ describe('Convex Wrapper', async function () {
 
     var unwrapCall = convexWrapper.interface.encodeFunctionData('unwrap', [ownerAcc.address])
     var preUnwrapCall = convexWrapper.interface.encodeFunctionData('user_checkpoint', [ownerAcc.address])
-
+    
     await ladle.batch([
       ladle.routeAction(convexWrapper.address, preUnwrapCall),
       ladle.pourAction(vaultId, convexWrapper.address, posted.mul(-1), borrowed.mul(-1)),
       ladle.routeAction(convexWrapper.address, unwrapCall),
     ])
-
+    
     console.log(`repaid and withdrawn`)
     const cvx3CrvAfter = (await cvx3CRV.balanceOf(ownerAcc.address)).toString()
     console.log(`${cvx3CrvAfter} cvx3Crv after`)
     if (cvx3CrvAfter !== cvx3CrvBefore) throw 'cvx3Crv balance mismatch'
-
+    console.log('Claiming leftover rewards')
     // Claim leftover rewards
     crvBefore = await crv.balanceOf(ownerAcc.address)
     cvxBefore = await convex.balanceOf(ownerAcc.address)

--- a/test/092_convex_wrapper.ts
+++ b/test/092_convex_wrapper.ts
@@ -121,7 +121,7 @@ describe('Convex Wrapper', async function () {
       'Cvx3Crv Mock',
     ])) as ERC20Mock
     crv = (await deployContract(ownerAcc, ERC20MockArtifact, ['CurveDAO Token Mock', 'CRV'])) as ERC20Mock
-    
+
     curvePool = (await deployContract(ownerAcc, CurvePoolMockArtifact)) as unknown as CurvePoolMock
     convexPool = (await deployContract(ownerAcc, ConvexPoolMockArtifact, [
       crv.address,
@@ -391,13 +391,13 @@ describe('Convex Wrapper', async function () {
 
     var unwrapCall = convexWrapper.interface.encodeFunctionData('unwrap', [ownerAcc.address])
     var preUnwrapCall = convexWrapper.interface.encodeFunctionData('user_checkpoint', [ownerAcc.address])
-    
+
     await ladle.batch([
       ladle.routeAction(convexWrapper.address, preUnwrapCall),
       ladle.pourAction(vaultId, convexWrapper.address, posted.mul(-1), borrowed.mul(-1)),
       ladle.routeAction(convexWrapper.address, unwrapCall),
     ])
-    
+
     console.log(`repaid and withdrawn`)
     const cvx3CrvAfter = (await cvx3CRV.balanceOf(ownerAcc.address)).toString()
     console.log(`${cvx3CrvAfter} cvx3Crv after`)


### PR DESCRIPTION
## Goal
Mock the `crv` & `convexbooster` contract such that we can use the `ConvexYieldWrapper` directly in tests rather than creating a separate `ConvexYieldWrapperMock`