### PR TITLE
Notional fCash as collateral

### DIFF
--- a/contracts/Join.sol
+++ b/contracts/Join.sol
@@ -20,7 +20,7 @@ contract Join is IJoin, IERC3156FlashLender, AccessControl() {
     event FlashFeeFactorSet(uint256 indexed fee);
 
     bytes32 constant internal FLASH_LOAN_RETURN = keccak256("ERC3156FlashBorrower.onFlashLoan");
-    uint256 constant FLASH_LOANS_DISABLED = type(uint256).max;
+    uint256 constant public FLASH_LOANS_DISABLED = type(uint256).max;
 
     address public immutable override asset;
     uint256 public storedBalance;

--- a/contracts/Join.sol
+++ b/contracts/Join.sol
@@ -56,8 +56,10 @@ contract Join is IJoin, IERC3156FlashLender, AccessControl() {
         IERC20 token = IERC20(asset);
         uint256 _storedBalance = storedBalance;
         uint256 available = token.balanceOf(address(this)) - _storedBalance; // Fine to panic if this underflows
-        storedBalance = _storedBalance + amount;
-        unchecked { if (available < amount) token.safeTransferFrom(user, address(this), amount - available); }
+        unchecked {
+            storedBalance = _storedBalance + amount;    // Unlikely that a uint128 added to the stored balance will make it overflow
+            if (available < amount) token.safeTransferFrom(user, address(this), amount - available); 
+        }
         return amount;        
     }
 

--- a/contracts/Ladle.sol
+++ b/contracts/Ladle.sol
@@ -236,7 +236,7 @@ contract Ladle is LadleStorage, AccessControl() {
     }
 
     /// @dev The WETH9 contract will send ether to BorrowProxy on `weth.withdraw` using this function.
-    receive() external payable { 
+    receive() external payable {
         require (msg.sender == address(weth), "Only receive from WETH");
     }
 

--- a/contracts/other/README.md
+++ b/contracts/other/README.md
@@ -1,0 +1,1 @@
+This directory contains custom implementations to integrate with other platforms

--- a/contracts/other/notional/ERC1155.sol
+++ b/contracts/other/notional/ERC1155.sol
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+/// @notice Minimalist and gas efficient standard ERC1155 implementation.
+/// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/tokens/ERC1155.sol)
+abstract contract ERC1155 {
+    /*///////////////////////////////////////////////////////////////
+                                EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    event TransferSingle(
+        address indexed operator,
+        address indexed from,
+        address indexed to,
+        uint256 id,
+        uint256 amount
+    );
+
+    event TransferBatch(
+        address indexed operator,
+        address indexed from,
+        address indexed to,
+        uint256[] ids,
+        uint256[] amounts
+    );
+
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    event URI(string value, uint256 indexed id);
+
+    /*///////////////////////////////////////////////////////////////
+                            ERC1155 STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    mapping(address => mapping(uint256 => uint256)) public balanceOf;
+
+    mapping(address => mapping(address => bool)) public isApprovedForAll;
+
+    /*///////////////////////////////////////////////////////////////
+                             METADATA LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function uri(uint256 id) public view virtual returns (string memory);
+
+    /*///////////////////////////////////////////////////////////////
+                             ERC1155 LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function setApprovalForAll(address operator, bool approved) public virtual {
+        isApprovedForAll[msg.sender][operator] = approved;
+
+        emit ApprovalForAll(msg.sender, operator, approved);
+    }
+
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) public virtual {
+        require(msg.sender == from || isApprovedForAll[from][msg.sender], "NOT_AUTHORIZED");
+
+        balanceOf[from][id] -= amount;
+        balanceOf[to][id] += amount;
+
+        emit TransferSingle(msg.sender, from, to, id, amount);
+
+        require(
+            to.code.length == 0
+                ? to != address(0)
+                : ERC1155TokenReceiver(to).onERC1155Received(msg.sender, from, id, amount, data) ==
+                    ERC1155TokenReceiver.onERC1155Received.selector,
+            "UNSAFE_RECIPIENT"
+        );
+    }
+
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes memory data
+    ) public virtual {
+        uint256 idsLength = ids.length; // Saves MLOADs.
+
+        require(idsLength == amounts.length, "LENGTH_MISMATCH");
+
+        require(msg.sender == from || isApprovedForAll[from][msg.sender], "NOT_AUTHORIZED");
+
+        for (uint256 i = 0; i < idsLength; ) {
+            uint256 id = ids[i];
+            uint256 amount = amounts[i];
+
+            balanceOf[from][id] -= amount;
+            balanceOf[to][id] += amount;
+
+            // An array can't have a total length
+            // larger than the max uint256 value.
+            unchecked {
+                i++;
+            }
+        }
+
+        emit TransferBatch(msg.sender, from, to, ids, amounts);
+
+        require(
+            to.code.length == 0
+                ? to != address(0)
+                : ERC1155TokenReceiver(to).onERC1155BatchReceived(msg.sender, from, ids, amounts, data) ==
+                    ERC1155TokenReceiver.onERC1155BatchReceived.selector,
+            "UNSAFE_RECIPIENT"
+        );
+    }
+
+    function balanceOfBatch(address[] memory owners, uint256[] memory ids)
+        public
+        view
+        virtual
+        returns (uint256[] memory balances)
+    {
+        uint256 ownersLength = owners.length; // Saves MLOADs.
+
+        require(ownersLength == ids.length, "LENGTH_MISMATCH");
+
+        balances = new uint256[](owners.length);
+
+        // Unchecked because the only math done is incrementing
+        // the array index counter which cannot possibly overflow.
+        unchecked {
+            for (uint256 i = 0; i < ownersLength; i++) {
+                balances[i] = balanceOf[owners[i]][ids[i]];
+            }
+        }
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                              ERC165 LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function supportsInterface(bytes4 interfaceId) public pure virtual returns (bool) {
+        return
+            interfaceId == 0x01ffc9a7 || // ERC165 Interface ID for ERC165
+            interfaceId == 0xd9b67a26 || // ERC165 Interface ID for ERC1155
+            interfaceId == 0x0e89341c; // ERC165 Interface ID for ERC1155MetadataURI
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                        INTERNAL MINT/BURN LOGIC
+    //////////////////////////////////////////////////////////////*/
+
+    function _mint(
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) internal {
+        balanceOf[to][id] += amount;
+
+        emit TransferSingle(msg.sender, address(0), to, id, amount);
+
+        require(
+            to.code.length == 0
+                ? to != address(0)
+                : ERC1155TokenReceiver(to).onERC1155Received(msg.sender, address(0), id, amount, data) ==
+                    ERC1155TokenReceiver.onERC1155Received.selector,
+            "UNSAFE_RECIPIENT"
+        );
+    }
+
+    function _batchMint(
+        address to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes memory data
+    ) internal {
+        uint256 idsLength = ids.length; // Saves MLOADs.
+
+        require(idsLength == amounts.length, "LENGTH_MISMATCH");
+
+        for (uint256 i = 0; i < idsLength; ) {
+            balanceOf[to][ids[i]] += amounts[i];
+
+            // An array can't have a total length
+            // larger than the max uint256 value.
+            unchecked {
+                i++;
+            }
+        }
+
+        emit TransferBatch(msg.sender, address(0), to, ids, amounts);
+
+        require(
+            to.code.length == 0
+                ? to != address(0)
+                : ERC1155TokenReceiver(to).onERC1155BatchReceived(msg.sender, address(0), ids, amounts, data) ==
+                    ERC1155TokenReceiver.onERC1155BatchReceived.selector,
+            "UNSAFE_RECIPIENT"
+        );
+    }
+
+    function _batchBurn(
+        address from,
+        uint256[] memory ids,
+        uint256[] memory amounts
+    ) internal {
+        uint256 idsLength = ids.length; // Saves MLOADs.
+
+        require(idsLength == amounts.length, "LENGTH_MISMATCH");
+
+        for (uint256 i = 0; i < idsLength; ) {
+            balanceOf[from][ids[i]] -= amounts[i];
+
+            // An array can't have a total length
+            // larger than the max uint256 value.
+            unchecked {
+                i++;
+            }
+        }
+
+        emit TransferBatch(msg.sender, from, address(0), ids, amounts);
+    }
+
+    function _burn(
+        address from,
+        uint256 id,
+        uint256 amount
+    ) internal {
+        balanceOf[from][id] -= amount;
+
+        emit TransferSingle(msg.sender, from, address(0), id, amount);
+    }
+}
+
+/// @notice A generic interface for a contract which properly accepts ERC1155 tokens.
+/// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/tokens/ERC1155.sol)
+interface ERC1155TokenReceiver {
+    function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    ) external returns (bytes4);
+
+    function onERC1155BatchReceived(
+        address operator,
+        address from,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) external returns (bytes4);
+}

--- a/contracts/other/notional/ERC1155Mock.sol
+++ b/contracts/other/notional/ERC1155Mock.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+import "./ERC1155.sol"; // TODO: Move to yield-utils-v2
+
+
+contract ERC1155Mock is ERC1155 {
+
+    function uri(uint256) public view virtual override returns (string memory) {
+        return "";
+    }
+
+    function mint(
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) external {
+        _mint(to, id, amount, data);
+    }
+}

--- a/contracts/other/notional/Join1155.sol
+++ b/contracts/other/notional/Join1155.sol
@@ -17,7 +17,7 @@ contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
     event FlashFeeFactorSet(uint256 indexed fee);
 
     bytes32 constant internal FLASH_LOAN_RETURN = keccak256("ERC3156FlashBorrower.onFlashLoan");
-    uint256 constant FLASH_LOANS_DISABLED = type(uint256).max;
+    uint256 constant public FLASH_LOANS_DISABLED = type(uint256).max;
 
     address public immutable override asset;
     uint256 public immutable id;    // This ERC1155 Join only accepts one id from the ERC1155 token

--- a/contracts/other/notional/Join1155.sol
+++ b/contracts/other/notional/Join1155.sol
@@ -31,8 +31,10 @@ contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
 
     /// @dev Advertising through ERC165 the available functions
     function supportsInterface(bytes4 interfaceID) external view returns (bool) {
-        return  interfaceID == Join1155.supportsInterface.selector ||    // ERC-165 support (i.e. `bytes4(keccak256('supportsInterface(bytes4)'))`).
-                interfaceID == ERC1155TokenReceiver.onERC1155Received.selector ^ ERC1155TokenReceiver.onERC1155BatchReceived.selector;      // ERC-1155 `ERC1155TokenReceiver` support (i.e. `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)")) ^ bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`).
+        // ERC-165 support = `bytes4(keccak256('supportsInterface(bytes4)'))`.
+        // ERC-1155 `ERC1155TokenReceiver` support = `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)")) ^ bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`.
+        return  interfaceID == Join1155.supportsInterface.selector ||
+                interfaceID == ERC1155TokenReceiver.onERC1155Received.selector ^ ERC1155TokenReceiver.onERC1155BatchReceived.selector;
     }
 
     /// @dev Called by the sender after a transfer to verify it was received. Ensures only `id` tokens are received.

--- a/contracts/other/notional/Join1155.sol
+++ b/contracts/other/notional/Join1155.sol
@@ -108,20 +108,20 @@ contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
         return amount;
     }
 
+    /// @dev Retrieve any ERC20 tokens. Useful for airdropped tokens.
+    function retrieve(IERC20 token, address to)
+        external
+        auth
+    {
+        MinimalTransferHelper.safeTransfer(token, to, token.balanceOf(address(this)));
+    }
+
     /// @dev Retrieve any ERC1155 tokens other than the `asset`. Useful for airdropped tokens.
-    function retrieve(ERC1155 token, uint256 id_, address to)
+    function retrieveERC1155(ERC1155 token, uint256 id_, address to)
         external
         auth
     {
         require(address(token) != address(asset) || id_ != id, "Use exit for asset");
         token.safeTransferFrom(address(this), to, id_, token.balanceOf(address(this), id_), "");
-    }
-
-    /// @dev Retrieve any ERC20 tokens. Useful for airdropped tokens.
-    function retrieveERC20(IERC20 token, address to)
-        external
-        auth
-    {
-        MinimalTransferHelper.safeTransfer(token, to, token.balanceOf(address(this)));
     }
 }

--- a/contracts/other/notional/Join1155.sol
+++ b/contracts/other/notional/Join1155.sol
@@ -80,8 +80,11 @@ contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
         ERC1155 token = ERC1155(asset);
         uint256 _storedBalance = storedBalance;
         uint256 available = token.balanceOf(address(this), id) - _storedBalance; // Fine to panic if this underflows
-        storedBalance = _storedBalance + amount;
-        unchecked { if (available < amount) token.safeTransferFrom(user, address(this), id, amount - available, ""); }
+        
+        unchecked {
+            storedBalance = _storedBalance + amount;    // Unlikely that a uint128 added to the stored balance will make it overflow
+            if (available < amount) token.safeTransferFrom(user, address(this), id, amount - available, "");
+        }
         return amount;        
     }
 

--- a/contracts/other/notional/Join1155.sol
+++ b/contracts/other/notional/Join1155.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.6;
+
+import "@yield-protocol/vault-interfaces/IJoin.sol";
+import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+import "@yield-protocol/utils-v2/contracts/token/MinimalTransferHelper.sol";
+import "@yield-protocol/utils-v2/contracts/token/IERC1155.sol";
+import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
+import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
+import "@yield-protocol/utils-v2/contracts/cast/CastU256U128.sol";
+
+/**
+    Note: The ERC-165 identifier for this interface is 0x4e2312e0.
+*/
+interface ERC1155TokenReceiver {
+    /**
+        @notice Handle the receipt of a single ERC1155 token type.
+        @dev An ERC1155-compliant smart contract MUST call this function on the token recipient contract, at the end of a `safeTransferFrom` after the balance has been updated.        
+        This function MUST return `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))` (i.e. 0xf23a6e61) if it accepts the transfer.
+        This function MUST revert if it rejects the transfer.
+        Return of any other value than the prescribed keccak256 generated value MUST result in the transaction being reverted by the caller.
+        @param _operator  The address which initiated the transfer (i.e. msg.sender)
+        @param _from      The address which previously owned the token
+        @param _id        The ID of the token being transferred
+        @param _value     The amount of tokens being transferred
+        @param _data      Additional data with no specified format
+        @return           `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))`
+    */
+    function onERC1155Received(address _operator, address _from, uint256 _id, uint256 _value, bytes calldata _data) external returns(bytes4);
+
+    /**
+        @notice Handle the receipt of multiple ERC1155 token types.
+        @dev An ERC1155-compliant smart contract MUST call this function on the token recipient contract, at the end of a `safeBatchTransferFrom` after the balances have been updated.        
+        This function MUST return `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` (i.e. 0xbc197c81) if it accepts the transfer(s).
+        This function MUST revert if it rejects the transfer(s).
+        Return of any other value than the prescribed keccak256 generated value MUST result in the transaction being reverted by the caller.
+        @param _operator  The address which initiated the batch transfer (i.e. msg.sender)
+        @param _from      The address which previously owned the token
+        @param _ids       An array containing ids of each token being transferred (order and length must match _values array)
+        @param _values    An array containing amounts of each token being transferred (order and length must match _ids array)
+        @param _data      Additional data with no specified format
+        @return           `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`
+    */
+    function onERC1155BatchReceived(address _operator, address _from, uint256[] calldata _ids, uint256[] calldata _values, bytes calldata _data) external returns(bytes4);       
+}
+
+
+contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
+    using WMul for uint256;
+    using CastU256U128 for uint256;
+
+    event FlashFeeFactorSet(uint256 indexed fee);
+
+    bytes32 constant internal FLASH_LOAN_RETURN = keccak256("ERC3156FlashBorrower.onFlashLoan");
+    uint256 constant FLASH_LOANS_DISABLED = type(uint256).max;
+
+    address public immutable override asset;
+    address public immutable id;    // This ERC1155 Join only accepts one id from the ERC1155 token
+    uint256 public storedBalance;
+    uint256 public flashFeeFactor = FLASH_LOANS_DISABLED; // Fee on flash loans, as a percentage in fixed point with 18 decimals. Flash loans disabled by default.
+
+    constructor(address asset_, uint256 id_) {
+        asset = asset_;
+        id = id_;
+    }
+
+    /// @dev Advertising through ERC165 the available functions
+    function supportsInterface(bytes4 interfaceID) external view returns (bool) {
+        return  interfaceID == Join1155.supportsInterface.selector ||    // ERC-165 support (i.e. `bytes4(keccak256('supportsInterface(bytes4)'))`).
+                interfaceID == ERC1155TokenReceiver.onERC1155Received.selector ^ ERC1155TokenReceiver.onERC1155BatchReceived.selector;      // ERC-1155 `ERC1155TokenReceiver` support (i.e. `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)")) ^ bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`).
+    }
+
+    /// @dev Called by the sender after a transfer to verify it was received. Ensures only `id` tokens are received.
+    function onERC1155Received(address _operator, address _from, uint256 _id, uint256 _value, bytes calldata _data) external returns(bytes4) {
+        require (_id == id, "Token id not accepted");
+        return ERC1155TokenReceiver.onERC1155Received.selector;
+    }
+
+    /// @dev Called by the sender after a batch transfer to verify it was received. Ensures only `id` tokens are received.
+    function onERC1155BatchReceived(address _operator, address _from, uint256[] calldata _ids, uint256[] calldata _values, bytes calldata _data) external returns(bytes4) {
+        uint256 length = _ids.length;
+        for (uint256 i; i < length; ++1)
+            require (_ids[i] == id, "Token id not accepted");
+        return ERC1155TokenReceiver.onERC1155BatchReceived.selector;
+    }
+
+    /// @dev Take `amount` `asset` from `user` using `transferFrom`, minus any unaccounted `asset` in this contract.
+    function join(address user, uint128 amount)
+        external override
+        auth
+        returns (uint128)
+    {
+        return _join(user, amount);
+    }
+
+    /// @dev Take `amount` `asset` from `user` using `transferFrom`, minus any unaccounted `asset` in this contract.
+    function _join(address user, uint128 amount)
+        internal
+        returns (uint128)
+    {
+        IERC1155 token = IERC1155(asset);
+        uint256 _storedBalance = storedBalance;
+        uint256 available = token.balanceOf(address(this), id) - _storedBalance; // Fine to panic if this underflows
+        storedBalance = _storedBalance + amount;
+        unchecked { if (available < amount) token.safeTransferFrom(user, address(this), id, amount - available, ""); }
+        return amount;        
+    }
+
+    /// @dev Transfer `amount` `asset` to `user`
+    function exit(address user, uint128 amount)
+        external override
+        auth
+        returns (uint128)
+    {
+        return _exit(user, amount);
+    }
+
+    /// @dev Transfer `amount` `asset` to `user`
+    function _exit(address user, uint128 amount)
+        internal
+        returns (uint128)
+    {
+        IERC1155 token = IERC1155(asset);
+        storedBalance -= amount;
+        token.safeTransferFrom(address(this), user, amount, id, "");
+        return amount;
+    }
+
+    /// @dev Retrieve any ERC1155 tokens other than the `asset`. Useful for airdropped tokens.
+    function retrieve(IERC1155 token, uint256 id_, address to)
+        external
+        auth
+    {
+        require(address(token) != address(asset) && id_ != id, "Use exit for asset");
+        token.safeTransferFrom(address(this), to, id_, token.balanceOf(address(this)), "");
+    }
+
+    /// @dev Retrieve any ERC20 tokens. Useful for airdropped tokens.
+    function retrieveERC20(IERC20 token, address to)
+        external
+        auth
+    {
+        MinimalTransferHelper.safeTransfer(token, to, token.balanceOf(address(this)));
+    }
+}

--- a/contracts/other/notional/Join1155.sol
+++ b/contracts/other/notional/Join1155.sol
@@ -4,46 +4,11 @@ pragma solidity 0.8.6;
 import "@yield-protocol/vault-interfaces/IJoin.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "@yield-protocol/utils-v2/contracts/token/MinimalTransferHelper.sol";
-import "@yield-protocol/utils-v2/contracts/token/IERC1155.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastU256U128.sol";
-
-/**
-    Note: The ERC-165 identifier for this interface is 0x4e2312e0.
-*/
-interface ERC1155TokenReceiver {
-    /**
-        @notice Handle the receipt of a single ERC1155 token type.
-        @dev An ERC1155-compliant smart contract MUST call this function on the token recipient contract, at the end of a `safeTransferFrom` after the balance has been updated.        
-        This function MUST return `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))` (i.e. 0xf23a6e61) if it accepts the transfer.
-        This function MUST revert if it rejects the transfer.
-        Return of any other value than the prescribed keccak256 generated value MUST result in the transaction being reverted by the caller.
-        @param _operator  The address which initiated the transfer (i.e. msg.sender)
-        @param _from      The address which previously owned the token
-        @param _id        The ID of the token being transferred
-        @param _value     The amount of tokens being transferred
-        @param _data      Additional data with no specified format
-        @return           `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))`
-    */
-    function onERC1155Received(address _operator, address _from, uint256 _id, uint256 _value, bytes calldata _data) external returns(bytes4);
-
-    /**
-        @notice Handle the receipt of multiple ERC1155 token types.
-        @dev An ERC1155-compliant smart contract MUST call this function on the token recipient contract, at the end of a `safeBatchTransferFrom` after the balances have been updated.        
-        This function MUST return `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` (i.e. 0xbc197c81) if it accepts the transfer(s).
-        This function MUST revert if it rejects the transfer(s).
-        Return of any other value than the prescribed keccak256 generated value MUST result in the transaction being reverted by the caller.
-        @param _operator  The address which initiated the batch transfer (i.e. msg.sender)
-        @param _from      The address which previously owned the token
-        @param _ids       An array containing ids of each token being transferred (order and length must match _values array)
-        @param _values    An array containing amounts of each token being transferred (order and length must match _ids array)
-        @param _data      Additional data with no specified format
-        @return           `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`
-    */
-    function onERC1155BatchReceived(address _operator, address _from, uint256[] calldata _ids, uint256[] calldata _values, bytes calldata _data) external returns(bytes4);       
-}
-
+import "./ERC1155.sol"; // TODO: Use solmate
+// ERC1155TokenReceiver is in ERC1155.sol
 
 contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
     using WMul for uint256;
@@ -55,7 +20,7 @@ contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
     uint256 constant FLASH_LOANS_DISABLED = type(uint256).max;
 
     address public immutable override asset;
-    address public immutable id;    // This ERC1155 Join only accepts one id from the ERC1155 token
+    uint256 public immutable id;    // This ERC1155 Join only accepts one id from the ERC1155 token
     uint256 public storedBalance;
     uint256 public flashFeeFactor = FLASH_LOANS_DISABLED; // Fee on flash loans, as a percentage in fixed point with 18 decimals. Flash loans disabled by default.
 
@@ -71,15 +36,27 @@ contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
     }
 
     /// @dev Called by the sender after a transfer to verify it was received. Ensures only `id` tokens are received.
-    function onERC1155Received(address _operator, address _from, uint256 _id, uint256 _value, bytes calldata _data) external returns(bytes4) {
+    function onERC1155Received(
+        address _operator,
+        address _from,
+        uint256 _id,
+        uint256 _value,
+        bytes calldata _data
+    ) external override returns(bytes4) {
         require (_id == id, "Token id not accepted");
         return ERC1155TokenReceiver.onERC1155Received.selector;
     }
 
     /// @dev Called by the sender after a batch transfer to verify it was received. Ensures only `id` tokens are received.
-    function onERC1155BatchReceived(address _operator, address _from, uint256[] calldata _ids, uint256[] calldata _values, bytes calldata _data) external returns(bytes4) {
+    function onERC1155BatchReceived(
+        address _operator,
+        address _from,
+        uint256[] calldata _ids,
+        uint256[] calldata _values,
+        bytes calldata _data
+    ) external override returns(bytes4) {
         uint256 length = _ids.length;
-        for (uint256 i; i < length; ++1)
+        for (uint256 i; i < length; ++i)
             require (_ids[i] == id, "Token id not accepted");
         return ERC1155TokenReceiver.onERC1155BatchReceived.selector;
     }
@@ -98,7 +75,7 @@ contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
         internal
         returns (uint128)
     {
-        IERC1155 token = IERC1155(asset);
+        ERC1155 token = ERC1155(asset);
         uint256 _storedBalance = storedBalance;
         uint256 available = token.balanceOf(address(this), id) - _storedBalance; // Fine to panic if this underflows
         storedBalance = _storedBalance + amount;
@@ -120,19 +97,19 @@ contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
         internal
         returns (uint128)
     {
-        IERC1155 token = IERC1155(asset);
+        ERC1155 token = ERC1155(asset);
         storedBalance -= amount;
         token.safeTransferFrom(address(this), user, amount, id, "");
         return amount;
     }
 
     /// @dev Retrieve any ERC1155 tokens other than the `asset`. Useful for airdropped tokens.
-    function retrieve(IERC1155 token, uint256 id_, address to)
+    function retrieve(ERC1155 token, uint256 id_, address to)
         external
         auth
     {
         require(address(token) != address(asset) && id_ != id, "Use exit for asset");
-        token.safeTransferFrom(address(this), to, id_, token.balanceOf(address(this)), "");
+        token.safeTransferFrom(address(this), to, id_, token.balanceOf(address(this), id_), "");
     }
 
     /// @dev Retrieve any ERC20 tokens. Useful for airdropped tokens.

--- a/contracts/other/notional/Join1155.sol
+++ b/contracts/other/notional/Join1155.sol
@@ -7,7 +7,7 @@ import "@yield-protocol/utils-v2/contracts/token/MinimalTransferHelper.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastU256U128.sol";
-import "./ERC1155.sol"; // TODO: Use solmate
+import "./ERC1155.sol"; // TODO: Move to yield-utils-v2
 // ERC1155TokenReceiver is in ERC1155.sol
 
 contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
@@ -99,7 +99,7 @@ contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
     {
         ERC1155 token = ERC1155(asset);
         storedBalance -= amount;
-        token.safeTransferFrom(address(this), user, amount, id, "");
+        token.safeTransferFrom(address(this), user, id, amount, "");
         return amount;
     }
 
@@ -108,7 +108,7 @@ contract Join1155 is IJoin, ERC1155TokenReceiver, AccessControl() {
         external
         auth
     {
-        require(address(token) != address(asset) && id_ != id, "Use exit for asset");
+        require(address(token) != address(asset) || id_ != id, "Use exit for asset");
         token.safeTransferFrom(address(this), to, id_, token.balanceOf(address(this), id_), "");
     }
 

--- a/contracts/other/notional/NotionalMultiOracle.sol
+++ b/contracts/other/notional/NotionalMultiOracle.sol
@@ -9,7 +9,8 @@ import "@yield-protocol/vault-interfaces/IOracle.sol";
 
 /**
  * @title NotionalMultiOracle
- * @notice We value fCash assets at face value
+  * @notice We value fCash assets at face value. We still need to account from conversions
+ * between fCash's 8 decimals and the decimals of the underlying.
  */
 contract NotionalMultiOracle is IOracle, AccessControl {
     using CastBytes32Bytes6 for bytes32;
@@ -19,9 +20,10 @@ contract NotionalMultiOracle is IOracle, AccessControl {
     struct Source {
         uint8 baseDecimals;
         uint8 quoteDecimals;
-        bool inverse;
+        bool set;
     }
 
+    uint8 public constant FCASH_DECIMALS = 8;
     mapping(bytes6 => mapping(bytes6 => Source)) public sources;
 
     /// @dev Set or reset an oracle source and its inverse
@@ -30,16 +32,16 @@ contract NotionalMultiOracle is IOracle, AccessControl {
     {
         require (notionalId != underlyingId, "Wrong input");
         sources[notionalId][underlyingId] = Source({
-            baseDecimals: 18, // I'm assuming here that fCash has 18 decimals
+            baseDecimals: FCASH_DECIMALS, // I'm assuming here that fCash has 18 decimals
             quoteDecimals: underlying.decimals(), // Ideally we would get the underlying from fCash
-            inverse: false
+            set: true
         });
         emit SourceSet(notionalId, underlyingId, address(underlying));
 
         sources[underlyingId][notionalId] = Source({
             baseDecimals: underlying.decimals(), // We are reversing the base and the quote
-            quoteDecimals: 18,
-            inverse: true
+            quoteDecimals: FCASH_DECIMALS,
+            set: true
         });
         emit SourceSet(underlyingId, notionalId, address(underlying));
     }
@@ -68,15 +70,9 @@ contract NotionalMultiOracle is IOracle, AccessControl {
         returns (uint amountQuote, uint updateTime)
     {
         Source memory source = sources[baseId][quoteId];
-        require (source.baseDecimals == 18 || source.quoteDecimals == 18, "Source not found"); // A bit meh as a test of existence
-        int price = 1e18; // We price fCash at face value
-        if (source.inverse == true) {
-            // fUSDC/USDC: 1 fUSDC (*10^18) * (1^6)/(10^18 fUSDC per USDC) = 10^6 USDC wei
-            amountQuote = amountBase * (10 ** source.baseDecimals) / (10 ** source.quoteDecimals);
-        } else {
-            // USDC/fUSDC: 1 USDC (*10^6) * 10^18 fUSDC per USDC / 10^6 = 10^18 fUSDC wei
-            amountQuote = amountBase * (10 ** source.quoteDecimals) / (10 ** source.baseDecimals);
-        }
+        require (source.set == true, "Source not found");
+        // fUSDC/USDC: 1 fUSDC (*10^8) * (1^6)/(10^8 fUSDC per USDC) = 10^6 USDC wei
+        amountQuote = amountBase * (10 ** source.quoteDecimals) / (10 ** source.baseDecimals);
         updateTime = block.timestamp;
     }
 }

--- a/contracts/other/notional/NotionalMultiOracle.sol
+++ b/contracts/other/notional/NotionalMultiOracle.sol
@@ -72,10 +72,10 @@ contract NotionalMultiOracle is IOracle, AccessControl {
         int price = 1e18; // We price fCash at face value
         if (source.inverse == true) {
             // fUSDC/USDC: 1 fUSDC (*10^18) * (1^6)/(10^18 fUSDC per USDC) = 10^6 USDC wei
-            amountQuote = amountBase * (10 ** source.quoteDecimals) / uint(price);
+            amountQuote = amountBase * (10 ** source.baseDecimals) / (10 ** source.quoteDecimals);
         } else {
             // USDC/fUSDC: 1 USDC (*10^6) * 10^18 fUSDC per USDC / 10^6 = 10^18 fUSDC wei
-            amountQuote = amountBase * uint(price) / (10 ** source.baseDecimals);
+            amountQuote = amountBase * (10 ** source.quoteDecimals) / (10 ** source.baseDecimals);
         }  
     }
 }

--- a/contracts/other/notional/NotionalMultiOracle.sol
+++ b/contracts/other/notional/NotionalMultiOracle.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.6;
+
+import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
+import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
+import "@yield-protocol/utils-v2/contracts/token/IERC20Metadata.sol";
+import "@yield-protocol/vault-interfaces/IOracle.sol";
+
+
+/**
+ * @title NotionalMultiOracle
+ * @notice We value fCash assets at face value
+ */
+contract NotionalMultiOracle is IOracle, AccessControl {
+    using CastBytes32Bytes6 for bytes32;
+
+    event SourceSet(bytes6 indexed baseId, bytes6 indexed quoteId, address source, uint256 id, address underlying);
+
+    struct Source {
+        address source;
+        uint8 baseDecimals;
+        uint8 quoteDecimals;
+        uint256 id;
+        bool inverse;
+    }
+
+    mapping(bytes6 => mapping(bytes6 => Source)) public sources;
+
+    /// @dev Set or reset an oracle source and its inverse
+    function setSource(bytes6 baseId, bytes6 quoteId, address source, uint id, IERC20Metadata underlying)
+        external auth
+    {
+        sources[baseId][quoteId] = Source({
+            source: source,
+            id: id;
+            baseDecimals: 18, // I'm assuming here that fCash has 18 decimals
+            quoteDecimals: underlying.decimals(), // Ideally we would get the underlying from fCash
+            inverse: false
+        });
+        emit SourceSet(baseId, quoteId, source, id, underlying);
+
+        if (baseId != quoteId) {
+            sources[quoteId][baseId] = Source({
+                source: source,
+                id: id;
+                baseDecimals: underlying.decimals(), // We are reversing the base and the quote
+                quoteDecimals: 18,
+                inverse: true
+            });
+            emit SourceSet(quoteId, baseId, source, id, underlying);
+        }
+    }
+
+    /// @dev Convert amountBase base into quote at the latest oracle price.
+    function peek(bytes32 baseId, bytes32 quoteId, uint256 amountBase)
+        external view virtual override
+        returns (uint256 amountQuote, uint256 updateTime)
+    {
+        if (baseId == quoteId) return (amountBase, block.timestamp);
+        (amountQuote, updateTime) = _peek(baseId.b6(), quoteId.b6(), amountBase);
+    }
+
+    /// @dev Convert amountBase base into quote at the latest oracle price, updating state if necessary. Same as `peek` for this oracle.
+    function get(bytes32 baseId, bytes32 quoteId, uint256 amountBase)
+        external virtual override
+        returns (uint256 amountQuote, uint256 updateTime)
+    {
+        if (baseId == quoteId) return (amountBase, block.timestamp);
+        (amountQuote, updateTime) = _peek(baseId.b6(), quoteId.b6(), amountBase);
+    }
+
+    /// @dev Convert amountBase base into quote at the latest oracle price.
+    function _peek(bytes6 baseId, bytes6 quoteId, uint256 amountBase)
+        private view
+        returns (uint amountQuote, uint updateTime)
+    {
+        Source memory source = sources[baseId][quoteId];
+        require (source.source != address(0), "Source not found");
+        int price = 1e18;
+        if (source.inverse == true) {
+            // fUSDC/USDC: 1 fUSDC (*10^18) * (1^6)/(10^18 fUSDC per USDC) = 10^6 USDC wei
+            amountQuote = amountBase * (10 ** source.quoteDecimals) / uint(price);
+        } else {
+            // USDC/fUSDC: 1 USDC (*10^6) * 10^18 fUSDC per USDC / 10^6 = 10^18 fUSDC wei
+            amountQuote = amountBase * uint(price) / (10 ** source.baseDecimals);
+        }  
+    }
+}

--- a/contracts/other/notional/NotionalMultiOracle.sol
+++ b/contracts/other/notional/NotionalMultiOracle.sol
@@ -76,6 +76,7 @@ contract NotionalMultiOracle is IOracle, AccessControl {
         } else {
             // USDC/fUSDC: 1 USDC (*10^6) * 10^18 fUSDC per USDC / 10^6 = 10^18 fUSDC wei
             amountQuote = amountBase * (10 ** source.quoteDecimals) / (10 ** source.baseDecimals);
-        }  
+        }
+        updateTime = block.timestamp;
     }
 }

--- a/contracts/other/notional/README.md
+++ b/contracts/other/notional/README.md
@@ -29,6 +29,18 @@ Mar 29 2022 = 212 * (86400 * 90) = 1648512000
 Jun 27 2022 = 213 * (86400 * 90) = 1656288000
 Dec 24 2022 = 215 * (86400 * 90) = 1671840000
 
+```
+        currencyId  maturity  assetTypeId
+Format:       FFFF FFFFFFFFFF FF
+```
+
+`fDAI Mar 29 2022  = 2*(16**12)+1648512000*(16**2)+1 = 563371972493313`
+`fDAI Jun 27 2022  = 2*(16**12)+1656288000*(16**2)+1 = 563373963149313`
+`fDAI Dec 24 2022  = 2*(16**12)+1671840000*(16**2)+1 = 563377944461313`
+`fUSDC Mar 29 2022 = 3*(16**12)+1648512000*(16**2)+1 = 844846949203969`
+`fUSDC Jun 27 2022 = 3*(16**12)+1656288000*(16**2)+1 = 844848939859969`
+`fUSDC Dec 24 2022 = 3*(16**12)+1671840000*(16**2)+1 = 844852921171969`
+
 ## fCash in Yield
 A Join to handle ERC1155 assets is included in this folder. Each Join1155 contract can handle only *one* token type from a given ERC1155 contract, meaning that we will need a Join1155 for fDAI-Jun22, another for fDAI-Sep22, and so on.
 

--- a/contracts/other/notional/README.md
+++ b/contracts/other/notional/README.md
@@ -1,0 +1,35 @@
+# Notional fCash as collateral
+
+## About fCash
+Notional borrowing and lending positions are stored as [fCash](https://docs.notional.finance/notional-v2/notional-v2-basics/fcash).
+
+fCash positions can be positive or negative. If positive they are equivalent for a lending position, and are redeemable at maturity for their face value. If negative they are borrowing positions.
+
+We want to use fCash lending positions as collateral. Given that we know that they are redeemable for their face value at maturity and their volatility is low, they are good assets for that purpose.
+
+Accepting fCash as collateral also eases arbitraging and leverage between Notional an Yield. By taking positive fCash balances as collateral, we facilitate lending on Notional and borrowing from Yield.
+
+fCash is kept internally in the Notional contracts, but there is a [proxy](https://github.com/notional-finance/contracts-v2/blob/master/contracts/external/actions/ERC1155Action.sol) that allows working with fCash as an ERC1155 token.
+
+The Notional [proxy](0x1344A36A1B56144C3Bc62E7757377D288fDE0369) is deployed on the Ethereum mainnet. It has links to the [ERC1155](0xffd7531ed937f703b269815950cb75bdaaa341c9) and [Views](0xde14d5f07456c86f070c108a04ae2fafdbd2a939) proxies. Not sure but I think that you call all functions on the main proxy.
+
+The fCash id is [built](https://github.com/notional-finance/contracts-v2/blob/master/contracts/internal/portfolio/TransferAssets.sol#L17-L47) from the currency id, maturity and asset type.
+
+Currencies:
+1: ETH
+2: DAI
+3: USDC
+4: WBTC
+
+The asset type for fCash is 1
+
+The maturities are in strict 90 day intervals, with `x = 90 * 86400` as all valid maturities.
+
+## fCash in Yield
+A Join to handle ERC1155 assets is included in this folder. Each Join1155 contract can handle only *one* token type from a given ERC1155 contract, meaning that we will need a Join1155 for fDAI-Jun22, another for fDAI-Sep22, and so on.
+
+The Ladle can't natively transfer ERC1155 assets, so a simple module is included to add this functionality. The ERC1155 contract needs to be added as a `token` to the Ladle registry. The Ladle needs to be approved to move ERC1155 tokens with `token.setApprovalForAll(ladle.address, true)`. There are no off-chain signatures.
+
+Pricing fCash accurately would be rather complex, but we can price it at face value given that we know that it will eventually be worth its face value, and that it has limited volatility. Still, a collateralization ratio above 100% would be recommended.
+
+With these tools, each fCash token can be added as a separate asset in the Cauldron, get its own Join, and be registered as an ilk for any base.

--- a/contracts/other/notional/README.md
+++ b/contracts/other/notional/README.md
@@ -11,7 +11,7 @@ Accepting fCash as collateral also eases arbitraging and leverage between Notion
 
 fCash is kept internally in the Notional contracts, but there is a [proxy](https://github.com/notional-finance/contracts-v2/blob/master/contracts/external/actions/ERC1155Action.sol) that allows working with fCash as an ERC1155 token.
 
-The Notional [proxy]([0x1344A36A1B56144C3Bc62E7757377D288fDE0369](https://etherscan.io/address/0x1344A36A1B56144C3Bc62E7757377D288fDE0369)) is deployed on the Ethereum mainnet. It has links to the [ERC1155]([0xffd7531ed937f703b269815950cb75bdaaa341c9](https://etherscan.io/address/0xffd7531ed937f703b269815950cb75bdaaa341c9)) and [Views]([0xde14d5f07456c86f070c108a04ae2fafdbd2a939](https://etherscan.io/address/0xde14d5f07456c86f070c108a04ae2fafdbd2a939)) proxies. Not sure but I think that you call all functions on the main proxy.
+The Notional [proxy]([0x1344A36A1B56144C3Bc62E7757377D288fDE0369](https://etherscan.io/address/0x1344A36A1B56144C3Bc62E7757377D288fDE0369)) is deployed on the Ethereum mainnet. It has links to the [ERC1155]([0xffd7531ed937f703b269815950cb75bdaaa341c9](https://etherscan.io/address/0xffd7531ed937f703b269815950cb75bdaaa341c9)) and [Views]([0xde14d5f07456c86f070c108a04ae2fafdbd2a939](https://etherscan.io/address/0xde14d5f07456c86f070c108a04ae2fafdbd2a939)) proxies. You call all functions on the main proxy.
 
 FCash are kept with 8 decimals in Notional, as it happens for any other monetary amounts.
 

--- a/contracts/other/notional/README.md
+++ b/contracts/other/notional/README.md
@@ -25,6 +25,10 @@ The asset type for fCash is 1
 
 The maturities are in strict 90 day intervals, with `x = 90 * 86400` as all valid maturities.
 
+Mar 29 2022 = 212 * (86400 * 90) = 1648512000
+Jun 27 2022 = 213 * (86400 * 90) = 1656288000
+Dec 24 2022 = 215 * (86400 * 90) = 1671840000
+
 ## fCash in Yield
 A Join to handle ERC1155 assets is included in this folder. Each Join1155 contract can handle only *one* token type from a given ERC1155 contract, meaning that we will need a Join1155 for fDAI-Jun22, another for fDAI-Sep22, and so on.
 

--- a/contracts/other/notional/README.md
+++ b/contracts/other/notional/README.md
@@ -11,7 +11,7 @@ Accepting fCash as collateral also eases arbitraging and leverage between Notion
 
 fCash is kept internally in the Notional contracts, but there is a [proxy](https://github.com/notional-finance/contracts-v2/blob/master/contracts/external/actions/ERC1155Action.sol) that allows working with fCash as an ERC1155 token.
 
-The Notional [proxy](0x1344A36A1B56144C3Bc62E7757377D288fDE0369) is deployed on the Ethereum mainnet. It has links to the [ERC1155](0xffd7531ed937f703b269815950cb75bdaaa341c9) and [Views](0xde14d5f07456c86f070c108a04ae2fafdbd2a939) proxies. Not sure but I think that you call all functions on the main proxy.
+The Notional [proxy]([0x1344A36A1B56144C3Bc62E7757377D288fDE0369](https://etherscan.io/address/0x1344A36A1B56144C3Bc62E7757377D288fDE0369)) is deployed on the Ethereum mainnet. It has links to the [ERC1155]([0xffd7531ed937f703b269815950cb75bdaaa341c9](https://etherscan.io/address/0xffd7531ed937f703b269815950cb75bdaaa341c9)) and [Views]([0xde14d5f07456c86f070c108a04ae2fafdbd2a939](https://etherscan.io/address/0xde14d5f07456c86f070c108a04ae2fafdbd2a939)) proxies. Not sure but I think that you call all functions on the main proxy.
 
 The fCash id is [built](https://github.com/notional-finance/contracts-v2/blob/master/contracts/internal/portfolio/TransferAssets.sol#L17-L47) from the currency id, maturity and asset type.
 

--- a/contracts/other/notional/README.md
+++ b/contracts/other/notional/README.md
@@ -13,6 +13,8 @@ fCash is kept internally in the Notional contracts, but there is a [proxy](https
 
 The Notional [proxy]([0x1344A36A1B56144C3Bc62E7757377D288fDE0369](https://etherscan.io/address/0x1344A36A1B56144C3Bc62E7757377D288fDE0369)) is deployed on the Ethereum mainnet. It has links to the [ERC1155]([0xffd7531ed937f703b269815950cb75bdaaa341c9](https://etherscan.io/address/0xffd7531ed937f703b269815950cb75bdaaa341c9)) and [Views]([0xde14d5f07456c86f070c108a04ae2fafdbd2a939](https://etherscan.io/address/0xde14d5f07456c86f070c108a04ae2fafdbd2a939)) proxies. Not sure but I think that you call all functions on the main proxy.
 
+FCash are kept with 8 decimals in Notional, as it happens for any other monetary amounts.
+
 The fCash id is [built](https://github.com/notional-finance/contracts-v2/blob/master/contracts/internal/portfolio/TransferAssets.sol#L17-L47) from the currency id, maturity and asset type.
 
 Currencies:

--- a/contracts/other/notional/Transfer1155Module.sol
+++ b/contracts/other/notional/Transfer1155Module.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.6;
-import "@yield-protocol/utils-v2/contracts/token/IERC1155.sol";
-import "../LadleStorage.sol";
+import "./ERC1155.sol"; // TODO: Use solmate
+import "../../LadleStorage.sol";
 
 
 /// @dev Module to allow the Ladle to transfer ERC1155 tokens
 contract Transfer1155Module is LadleStorage {
+
+    /// @dev We won't use these, but still we need them in the constructor to not be abstract.
+    constructor (ICauldron cauldron, IWETH9 weth) LadleStorage(cauldron, weth) { }
+
     /// @dev Allow users to trigger an ERC1155 token transfer from themselves to a receiver through the ladle, to be used with batch
-    function transfer1155(IERC1155 token, uint256 id, address receiver, uint128 wad, bytes memory data)
+    function transfer1155(ERC1155 token, uint256 id, address receiver, uint128 wad, bytes memory data)
         external payable
     {
         require(tokens[address(token)], "Unknown token");

--- a/contracts/other/notional/Transfer1155Module.sol
+++ b/contracts/other/notional/Transfer1155Module.sol
@@ -15,6 +15,6 @@ contract Transfer1155Module is LadleStorage {
         external payable
     {
         require(tokens[address(token)], "Unknown token");
-        token.safeTransferFrom(msg.sender, receiver, wad, id, data);
+        token.safeTransferFrom(msg.sender, receiver, id, wad, data);
     }
 }

--- a/contracts/other/notional/Transfer1155Module.sol
+++ b/contracts/other/notional/Transfer1155Module.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.6;
+import "@yield-protocol/utils-v2/contracts/token/IERC1155.sol";
+import "../LadleStorage.sol";
+
+
+/// @dev Module to allow the Ladle to transfer ERC1155 tokens
+contract Transfer1155Module is LadleStorage {
+    /// @dev Allow users to trigger an ERC1155 token transfer from themselves to a receiver through the ladle, to be used with batch
+    function transfer1155(IERC1155 token, uint256 id, address receiver, uint128 wad, bytes memory data)
+        external payable
+    {
+        require(tokens[address(token)], "Unknown token");
+        token.safeTransferFrom(msg.sender, receiver, wad, id, data);
+    }
+}

--- a/contracts/other/notional/Transfer1155Module.sol
+++ b/contracts/other/notional/Transfer1155Module.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.6;
-import "./ERC1155.sol"; // TODO: Use solmate
+import "./ERC1155.sol"; // TODO: Move to yield-utils-v2
 import "../../LadleStorage.sol";
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.15.1-notional-rc1",
+  "version": "0.15.1-notional-rc2",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.15.0",
+  "version": "0.15.1-notional-rc0",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [
@@ -14,6 +14,7 @@
     "contracts/oracles/uniswap/*.sol",
     "contracts/oracles/lido/*.sol",
     "contracts/oracles/convex/*.sol",
+    "contracts/other/notional/*.sol",
     "contracts/utils/*.sol",
     "contracts/utils/convex/*.sol",
     "contracts/utils/convex/interfaces/*.sol",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.15.1-notional-rc0",
+  "version": "0.15.1-notional-rc1",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
   "files": [
@@ -14,6 +14,7 @@
     "contracts/oracles/uniswap/*.sol",
     "contracts/oracles/lido/*.sol",
     "contracts/oracles/convex/*.sol",
+    "contracts/oracles/yearn/*.sol",
     "contracts/other/notional/*.sol",
     "contracts/utils/*.sol",
     "contracts/utils/convex/*.sol",

--- a/test/020_oracles_notional.ts
+++ b/test/020_oracles_notional.ts
@@ -73,21 +73,21 @@ describe('Oracles - Notional', function () {
     expect(
       (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(DAI), bytes6ToBytes32(FDAI), WAD.mul(2500)))[0]
     ).to.equal(WAD.mul(2500))
-    expect((await notionalMultiOracle.callStatic.get(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]).to.equal(
-      WAD.mul(2500)
-    )
+    expect(
+      (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]
+    ).to.equal(WAD.mul(2500))
 
-    expect(
-      (await notionalMultiOracle.peek(bytes6ToBytes32(FDAI), bytes6ToBytes32(DAI), WAD.mul(2500)))[0]
-    ).to.equal(WAD.mul(2500))
-    expect(
-      (await notionalMultiOracle.peek(bytes6ToBytes32(FUSDC), bytes6ToBytes32(USDC), WAD.mul(2500)))[0]
-    ).to.equal(oneUSDC.mul(2500))
-    expect(
-      (await notionalMultiOracle.peek(bytes6ToBytes32(DAI), bytes6ToBytes32(FDAI), WAD.mul(2500)))[0]
-    ).to.equal(WAD.mul(2500))
-    expect((await notionalMultiOracle.peek(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]).to.equal(
+    expect((await notionalMultiOracle.peek(bytes6ToBytes32(FDAI), bytes6ToBytes32(DAI), WAD.mul(2500)))[0]).to.equal(
       WAD.mul(2500)
     )
+    expect((await notionalMultiOracle.peek(bytes6ToBytes32(FUSDC), bytes6ToBytes32(USDC), WAD.mul(2500)))[0]).to.equal(
+      oneUSDC.mul(2500)
+    )
+    expect((await notionalMultiOracle.peek(bytes6ToBytes32(DAI), bytes6ToBytes32(FDAI), WAD.mul(2500)))[0]).to.equal(
+      WAD.mul(2500)
+    )
+    expect(
+      (await notionalMultiOracle.peek(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]
+    ).to.equal(WAD.mul(2500))
   })
 })

--- a/test/020_oracles_notional.ts
+++ b/test/020_oracles_notional.ts
@@ -1,0 +1,83 @@
+import { constants, id } from '@yield-protocol/utils-v2'
+const { WAD } = constants
+import { DAI, USDC } from '../src/constants'
+
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+
+import NotionalMultiOracleArtifact from '../artifacts/contracts/other/notional/NotionalMultiOracle.sol/NotionalMultiOracle.json'
+import DAIMockArtifact from '../artifacts/contracts/mocks/DAIMock.sol/DAIMock.json'
+import USDCMockArtifact from '../artifacts/contracts/mocks/USDCMock.sol/USDCMock.json'
+
+import { IOracle } from '../typechain/IOracle'
+import { NotionalMultiOracle } from '../typechain/NotionalMultiOracle'
+import { DAIMock } from '../typechain/DAIMock'
+import { USDCMock } from '../typechain/USDCMock'
+
+import { ethers, waffle } from 'hardhat'
+import { expect } from 'chai'
+const { deployContract } = waffle
+
+function bytes6ToBytes32(x: string): string {
+  return x + '00'.repeat(26)
+}
+
+describe('Oracles - Notional', function () {
+  this.timeout(0)
+
+  let ownerAcc: SignerWithAddress
+  let owner: string
+  let oracle: IOracle
+  let notionalMultiOracle: NotionalMultiOracle
+  let dai: DAIMock
+  let usdc: USDCMock
+  const FDAI = ethers.utils.hexlify(ethers.utils.randomBytes(6))
+  const FUSDC = ethers.utils.hexlify(ethers.utils.randomBytes(6))
+
+  const oneUSDC = WAD.div(1000000000000)
+
+  before(async () => {
+    const signers = await ethers.getSigners()
+    ownerAcc = signers[0]
+    owner = await ownerAcc.getAddress()
+  })
+
+  beforeEach(async () => {
+    dai = (await deployContract(ownerAcc, DAIMockArtifact)) as DAIMock
+    usdc = (await deployContract(ownerAcc, USDCMockArtifact)) as USDCMock
+
+    notionalMultiOracle = (await deployContract(ownerAcc, NotionalMultiOracleArtifact, [])) as NotionalMultiOracle
+    await notionalMultiOracle.grantRole(
+      id(notionalMultiOracle.interface, 'setSource(bytes6,bytes6,address)'),
+      owner
+    )
+    await notionalMultiOracle.setSource(FDAI, DAI, dai.address)
+    await notionalMultiOracle.setSource(USDC, FUSDC, usdc.address)
+  })
+
+  it('revert on unknown sources', async () => {
+    await expect(
+      notionalMultiOracle.callStatic.get(bytes6ToBytes32(FDAI), bytes6ToBytes32(USDC), WAD)
+    ).to.be.revertedWith('Source not found')
+  })
+
+  it('returns the input when baseId == quoteId', async () => {
+    expect(
+      (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(FDAI), bytes6ToBytes32(FDAI), WAD.mul(2500)))[0]
+    ).to.equal(WAD.mul(2500))
+  })
+
+  it('retrieves the face value from a notional multioracle', async () => {
+    expect(
+      (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(FDAI), bytes6ToBytes32(DAI), WAD.mul(2500)))[0]
+    ).to.equal(WAD.mul(2500))
+    expect(
+      (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(FUSDC), bytes6ToBytes32(USDC), WAD.mul(2500)))[0]
+    ).to.equal(oneUSDC.mul(2500))
+    expect((await notionalMultiOracle.callStatic.get(bytes6ToBytes32(DAI), bytes6ToBytes32(FDAI), WAD.mul(2500)))[0]).to.equal(
+      WAD.mul(2500)
+    )
+    // expect((await notionalMultiOracle.callStatic.get(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]).to.equal(
+    //   WAD.mul(2500)
+    // )
+  })
+})

--- a/test/020_oracles_notional.ts
+++ b/test/020_oracles_notional.ts
@@ -73,8 +73,8 @@ describe('Oracles - Notional', function () {
     expect(
       (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(DAI), bytes6ToBytes32(FDAI), WAD.mul(2500)))[0]
     ).to.equal(WAD.mul(2500))
-    // expect((await notionalMultiOracle.callStatic.get(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]).to.equal(
-    //   WAD.mul(2500)
-    // )
+    expect((await notionalMultiOracle.callStatic.get(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]).to.equal(
+      WAD.mul(2500)
+    )
   })
 })

--- a/test/020_oracles_notional.ts
+++ b/test/020_oracles_notional.ts
@@ -1,4 +1,5 @@
 import { constants, id } from '@yield-protocol/utils-v2'
+import { BigNumber } from 'ethers'
 const { WAD } = constants
 import { DAI, USDC } from '../src/constants'
 
@@ -33,7 +34,8 @@ describe('Oracles - Notional', function () {
   const FDAI = ethers.utils.hexlify(ethers.utils.randomBytes(6))
   const FUSDC = ethers.utils.hexlify(ethers.utils.randomBytes(6))
 
-  const oneUSDC = WAD.div(1000000000000)
+  const oneUSDC = BigNumber.from(10).pow(6)
+  const oneFCASH = BigNumber.from(10).pow(8)
 
   before(async () => {
     const signers = await ethers.getSigners()
@@ -48,12 +50,12 @@ describe('Oracles - Notional', function () {
     notionalMultiOracle = (await deployContract(ownerAcc, NotionalMultiOracleArtifact, [])) as NotionalMultiOracle
     await notionalMultiOracle.grantRole(id(notionalMultiOracle.interface, 'setSource(bytes6,bytes6,address)'), owner)
     await notionalMultiOracle.setSource(FDAI, DAI, dai.address)
-    await notionalMultiOracle.setSource(USDC, FUSDC, usdc.address)
+    await notionalMultiOracle.setSource(FUSDC, USDC, usdc.address)
   })
 
   it('revert on unknown sources', async () => {
     await expect(
-      notionalMultiOracle.callStatic.get(bytes6ToBytes32(FDAI), bytes6ToBytes32(USDC), WAD)
+      notionalMultiOracle.callStatic.get(bytes6ToBytes32(FDAI), bytes6ToBytes32(USDC), oneFCASH)
     ).to.be.revertedWith('Source not found')
   })
 
@@ -65,29 +67,29 @@ describe('Oracles - Notional', function () {
 
   it('retrieves the face value from a notional multioracle', async () => {
     expect(
-      (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(FDAI), bytes6ToBytes32(DAI), WAD.mul(2500)))[0]
+      (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(FDAI), bytes6ToBytes32(DAI), oneFCASH.mul(2500)))[0]
     ).to.equal(WAD.mul(2500))
     expect(
-      (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(FUSDC), bytes6ToBytes32(USDC), WAD.mul(2500)))[0]
+      (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(FUSDC), bytes6ToBytes32(USDC), oneFCASH.mul(2500)))[0]
     ).to.equal(oneUSDC.mul(2500))
     expect(
       (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(DAI), bytes6ToBytes32(FDAI), WAD.mul(2500)))[0]
-    ).to.equal(WAD.mul(2500))
+    ).to.equal(oneFCASH.mul(2500))
     expect(
       (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]
-    ).to.equal(WAD.mul(2500))
+    ).to.equal(oneFCASH.mul(2500))
 
-    expect((await notionalMultiOracle.peek(bytes6ToBytes32(FDAI), bytes6ToBytes32(DAI), WAD.mul(2500)))[0]).to.equal(
+    expect((await notionalMultiOracle.peek(bytes6ToBytes32(FDAI), bytes6ToBytes32(DAI), oneFCASH.mul(2500)))[0]).to.equal(
       WAD.mul(2500)
     )
-    expect((await notionalMultiOracle.peek(bytes6ToBytes32(FUSDC), bytes6ToBytes32(USDC), WAD.mul(2500)))[0]).to.equal(
+    expect((await notionalMultiOracle.peek(bytes6ToBytes32(FUSDC), bytes6ToBytes32(USDC), oneFCASH.mul(2500)))[0]).to.equal(
       oneUSDC.mul(2500)
     )
     expect((await notionalMultiOracle.peek(bytes6ToBytes32(DAI), bytes6ToBytes32(FDAI), WAD.mul(2500)))[0]).to.equal(
-      WAD.mul(2500)
+      oneFCASH.mul(2500)
     )
     expect(
       (await notionalMultiOracle.peek(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]
-    ).to.equal(WAD.mul(2500))
+    ).to.equal(oneFCASH.mul(2500))
   })
 })

--- a/test/020_oracles_notional.ts
+++ b/test/020_oracles_notional.ts
@@ -76,5 +76,18 @@ describe('Oracles - Notional', function () {
     expect((await notionalMultiOracle.callStatic.get(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]).to.equal(
       WAD.mul(2500)
     )
+
+    expect(
+      (await notionalMultiOracle.peek(bytes6ToBytes32(FDAI), bytes6ToBytes32(DAI), WAD.mul(2500)))[0]
+    ).to.equal(WAD.mul(2500))
+    expect(
+      (await notionalMultiOracle.peek(bytes6ToBytes32(FUSDC), bytes6ToBytes32(USDC), WAD.mul(2500)))[0]
+    ).to.equal(oneUSDC.mul(2500))
+    expect(
+      (await notionalMultiOracle.peek(bytes6ToBytes32(DAI), bytes6ToBytes32(FDAI), WAD.mul(2500)))[0]
+    ).to.equal(WAD.mul(2500))
+    expect((await notionalMultiOracle.peek(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]).to.equal(
+      WAD.mul(2500)
+    )
   })
 })

--- a/test/020_oracles_notional.ts
+++ b/test/020_oracles_notional.ts
@@ -79,12 +79,12 @@ describe('Oracles - Notional', function () {
       (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]
     ).to.equal(oneFCASH.mul(2500))
 
-    expect((await notionalMultiOracle.peek(bytes6ToBytes32(FDAI), bytes6ToBytes32(DAI), oneFCASH.mul(2500)))[0]).to.equal(
-      WAD.mul(2500)
-    )
-    expect((await notionalMultiOracle.peek(bytes6ToBytes32(FUSDC), bytes6ToBytes32(USDC), oneFCASH.mul(2500)))[0]).to.equal(
-      oneUSDC.mul(2500)
-    )
+    expect(
+      (await notionalMultiOracle.peek(bytes6ToBytes32(FDAI), bytes6ToBytes32(DAI), oneFCASH.mul(2500)))[0]
+    ).to.equal(WAD.mul(2500))
+    expect(
+      (await notionalMultiOracle.peek(bytes6ToBytes32(FUSDC), bytes6ToBytes32(USDC), oneFCASH.mul(2500)))[0]
+    ).to.equal(oneUSDC.mul(2500))
     expect((await notionalMultiOracle.peek(bytes6ToBytes32(DAI), bytes6ToBytes32(FDAI), WAD.mul(2500)))[0]).to.equal(
       oneFCASH.mul(2500)
     )

--- a/test/020_oracles_notional.ts
+++ b/test/020_oracles_notional.ts
@@ -46,10 +46,7 @@ describe('Oracles - Notional', function () {
     usdc = (await deployContract(ownerAcc, USDCMockArtifact)) as USDCMock
 
     notionalMultiOracle = (await deployContract(ownerAcc, NotionalMultiOracleArtifact, [])) as NotionalMultiOracle
-    await notionalMultiOracle.grantRole(
-      id(notionalMultiOracle.interface, 'setSource(bytes6,bytes6,address)'),
-      owner
-    )
+    await notionalMultiOracle.grantRole(id(notionalMultiOracle.interface, 'setSource(bytes6,bytes6,address)'), owner)
     await notionalMultiOracle.setSource(FDAI, DAI, dai.address)
     await notionalMultiOracle.setSource(USDC, FUSDC, usdc.address)
   })
@@ -73,9 +70,9 @@ describe('Oracles - Notional', function () {
     expect(
       (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(FUSDC), bytes6ToBytes32(USDC), WAD.mul(2500)))[0]
     ).to.equal(oneUSDC.mul(2500))
-    expect((await notionalMultiOracle.callStatic.get(bytes6ToBytes32(DAI), bytes6ToBytes32(FDAI), WAD.mul(2500)))[0]).to.equal(
-      WAD.mul(2500)
-    )
+    expect(
+      (await notionalMultiOracle.callStatic.get(bytes6ToBytes32(DAI), bytes6ToBytes32(FDAI), WAD.mul(2500)))[0]
+    ).to.equal(WAD.mul(2500))
     // expect((await notionalMultiOracle.callStatic.get(bytes6ToBytes32(USDC), bytes6ToBytes32(FUSDC), oneUSDC.mul(2500)))[0]).to.equal(
     //   WAD.mul(2500)
     // )

--- a/test/023_join1155.ts
+++ b/test/023_join1155.ts
@@ -1,0 +1,120 @@
+import { constants, id } from '@yield-protocol/utils-v2'
+
+import { sendStatic } from './shared/helpers'
+
+import { Contract } from '@ethersproject/contracts'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { Event } from '@ethersproject/contracts/lib/index'
+import { Result } from '@ethersproject/abi'
+
+const { WAD, MAX256 } = constants
+const MAX = MAX256
+
+import Join1155Artifact from '../artifacts/contracts/other/notional/Join1155.sol/Join1155.json'
+import ERC20MockArtifact from '../artifacts/contracts/mocks/ERC20Mock.sol/ERC20Mock.json'
+import ERC1155MockArtifact from '../artifacts/contracts/other/notional/ERC1155Mock.sol/ERC1155Mock.json'
+
+
+import { Join1155 } from '../typechain/Join1155'
+import { ERC20Mock } from '../typechain/ERC20Mock'
+import { ERC1155Mock } from '../typechain/ERC1155Mock'
+
+import { ethers, waffle } from 'hardhat'
+import { expect } from 'chai'
+const { deployContract } = waffle
+
+describe('Join1155', function () {
+  this.timeout(0)
+
+  let ownerAcc: SignerWithAddress
+  let owner: string
+  let otherAcc: SignerWithAddress
+  let other: string
+  let join: Join1155
+  let token: ERC1155Mock
+  let tokenId: number = 1
+  let otherERC20: ERC20Mock
+  let otherERC1155: ERC1155Mock
+
+  before(async () => {
+    const signers = await ethers.getSigners()
+    ownerAcc = signers[0]
+    owner = await ownerAcc.getAddress()
+
+    otherAcc = signers[1]
+    other = await otherAcc.getAddress()
+  })
+
+  beforeEach(async () => {
+    token = (await deployContract(ownerAcc, ERC1155MockArtifact)) as ERC1155Mock
+    otherERC20 = (await deployContract(ownerAcc, ERC20MockArtifact, ['', ''])) as ERC20Mock
+    otherERC1155 = (await deployContract(ownerAcc, ERC1155MockArtifact)) as ERC1155Mock
+    join = (await deployContract(ownerAcc, Join1155Artifact, [token.address, tokenId])) as Join1155
+
+
+    await join.grantRoles(
+      [
+        id(join.interface, 'join(address,uint128)'),
+        id(join.interface, 'exit(address,uint128)'),
+        id(join.interface, 'retrieve(address,uint256,address)'),
+        id(join.interface, 'retrieveERC20(address,address)'),
+      ],
+      owner
+    )
+
+    await token.mint(owner, tokenId, WAD.mul(100), '0x00')
+    await token.setApprovalForAll(join.address, true)
+  })
+
+  it('retrieves airdropped ERC20 tokens', async () => {
+    await otherERC20.mint(join.address, WAD)
+    expect(await join.retrieveERC20(otherERC20.address, other))
+      .to.emit(otherERC20, 'Transfer')
+      .withArgs(join.address, other, WAD)
+  })
+
+  it('retrieves airdropped ERC1155 tokens', async () => {
+    await otherERC1155.mint(join.address, tokenId, WAD, '0x00')
+    expect(await join.retrieve(otherERC1155.address, tokenId, other))
+      .to.emit(otherERC1155, 'TransferSingle')
+      .withArgs(join.address, join.address, other, tokenId, WAD)
+  })
+
+  it('pulls tokens from user', async () => {
+    expect(await join.join(owner, WAD))
+      .to.emit(token, 'TransferSingle')
+      .withArgs(join.address, owner, join.address, tokenId, WAD)
+    expect(await join.storedBalance()).to.equal(WAD)
+  })
+
+  describe('with tokens in the join', async () => {
+    beforeEach(async () => {
+      await token.safeTransferFrom(owner, join.address, tokenId, WAD, '0x00')
+    })
+
+    it('accepts surplus as a transfer', async () => {
+      expect(await join.join(owner, WAD)).to.not.emit(token, 'TransferSingle')
+      expect(await join.storedBalance()).to.equal(WAD)
+    })
+
+    it('combines surplus and tokens pulled from the user', async () => {
+      expect(await join.join(owner, WAD.mul(2)))
+        .to.emit(token, 'TransferSingle')
+        .withArgs(join.address, owner, join.address, tokenId, WAD)
+      expect(await join.storedBalance()).to.equal(WAD.mul(2))
+    })
+
+    describe('with a positive stored balance', async () => {
+      beforeEach(async () => {
+        await join.join(owner, WAD)
+      })
+
+      it('pushes tokens to user', async () => {
+        expect(await join.exit(owner, WAD))
+          .to.emit(token, 'TransferSingle')
+          .withArgs(join.address, join.address, owner, tokenId, WAD)
+        expect(await join.storedBalance()).to.equal(0)
+      })
+    })
+  })
+})

--- a/test/023_join1155.ts
+++ b/test/023_join1155.ts
@@ -25,7 +25,7 @@ describe('Join1155', function () {
   let other: string
   let join: Join1155
   let token: ERC1155Mock
-  let tokenId: number = 1
+  let tokenId = '1'
   let otherERC20: ERC20Mock
   let otherERC1155: ERC1155Mock
 

--- a/test/023_join1155.ts
+++ b/test/023_join1155.ts
@@ -8,7 +8,6 @@ import Join1155Artifact from '../artifacts/contracts/other/notional/Join1155.sol
 import ERC20MockArtifact from '../artifacts/contracts/mocks/ERC20Mock.sol/ERC20Mock.json'
 import ERC1155MockArtifact from '../artifacts/contracts/other/notional/ERC1155Mock.sol/ERC1155Mock.json'
 
-
 import { Join1155 } from '../typechain/Join1155'
 import { ERC20Mock } from '../typechain/ERC20Mock'
 import { ERC1155Mock } from '../typechain/ERC1155Mock'
@@ -44,7 +43,6 @@ describe('Join1155', function () {
     otherERC20 = (await deployContract(ownerAcc, ERC20MockArtifact, ['', ''])) as ERC20Mock
     otherERC1155 = (await deployContract(ownerAcc, ERC1155MockArtifact)) as ERC1155Mock
     join = (await deployContract(ownerAcc, Join1155Artifact, [token.address, tokenId])) as Join1155
-
 
     await join.grantRoles(
       [

--- a/test/023_join1155.ts
+++ b/test/023_join1155.ts
@@ -1,14 +1,8 @@
 import { constants, id } from '@yield-protocol/utils-v2'
 
-import { sendStatic } from './shared/helpers'
-
-import { Contract } from '@ethersproject/contracts'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
-import { Event } from '@ethersproject/contracts/lib/index'
-import { Result } from '@ethersproject/abi'
 
 const { WAD, MAX256 } = constants
-const MAX = MAX256
 
 import Join1155Artifact from '../artifacts/contracts/other/notional/Join1155.sol/Join1155.json'
 import ERC20MockArtifact from '../artifacts/contracts/mocks/ERC20Mock.sol/ERC20Mock.json'

--- a/test/023_join1155.ts
+++ b/test/023_join1155.ts
@@ -48,8 +48,8 @@ describe('Join1155', function () {
       [
         id(join.interface, 'join(address,uint128)'),
         id(join.interface, 'exit(address,uint128)'),
-        id(join.interface, 'retrieve(address,uint256,address)'),
-        id(join.interface, 'retrieveERC20(address,address)'),
+        id(join.interface, 'retrieve(address,address)'),
+        id(join.interface, 'retrieveERC1155(address,uint256,address)'),
       ],
       owner
     )
@@ -60,14 +60,14 @@ describe('Join1155', function () {
 
   it('retrieves airdropped ERC20 tokens', async () => {
     await otherERC20.mint(join.address, WAD)
-    expect(await join.retrieveERC20(otherERC20.address, other))
+    expect(await join.retrieve(otherERC20.address, other))
       .to.emit(otherERC20, 'Transfer')
       .withArgs(join.address, other, WAD)
   })
 
   it('retrieves airdropped ERC1155 tokens', async () => {
     await otherERC1155.mint(join.address, tokenId, WAD, '0x00')
-    expect(await join.retrieve(otherERC1155.address, tokenId, other))
+    expect(await join.retrieveERC1155(otherERC1155.address, tokenId, other))
       .to.emit(otherERC1155, 'TransferSingle')
       .withArgs(join.address, join.address, other, tokenId, WAD)
   })

--- a/test/074_module_transferERC1155.ts
+++ b/test/074_module_transferERC1155.ts
@@ -1,0 +1,79 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signer-with-address'
+import { id, constants } from '@yield-protocol/utils-v2'
+const { WAD, MAX256 } = constants
+
+import ERC1155MockArtifact from '../artifacts/contracts/other/notional/ERC1155Mock.sol/ERC1155Mock.json'
+import Transfer1155ModuleArtifact from '../artifacts/contracts/other/notional/Transfer1155Module.sol/Transfer1155Module.json'
+
+import { ERC1155Mock } from '../typechain/ERC1155Mock'
+import { Cauldron } from '../typechain/Cauldron'
+import { Transfer1155Module } from '../typechain/Transfer1155Module'
+
+import { ethers, waffle } from 'hardhat'
+import { expect } from 'chai'
+const { deployContract, loadFixture } = waffle
+
+import { YieldEnvironment } from './shared/fixtures'
+import { LadleWrapper } from '../src/ladleWrapper'
+
+describe('Ladle - module', function () {
+  this.timeout(0)
+
+  let env: YieldEnvironment
+  let ownerAcc: SignerWithAddress
+  let owner: string
+  let other: string
+  let cauldron: Cauldron
+  let ladle: LadleWrapper
+  let token: ERC1155Mock
+  let transferModule: Transfer1155Module
+  const tokenId = 1
+
+  async function fixture() {
+    return await YieldEnvironment.setup(ownerAcc, [], [])
+  }
+
+  before(async () => {
+    const signers = await ethers.getSigners()
+    ownerAcc = signers[0]
+    owner = await ownerAcc.getAddress()
+    other = await signers[1].getAddress()
+  })
+
+  const zeroAddress = '0x' + '0'.repeat(40)
+
+  beforeEach(async () => {
+    env = await loadFixture(fixture)
+    cauldron = env.cauldron
+    ladle = env.ladle
+
+    // ==== Set ERC1155 token ====
+    token = (await deployContract(ownerAcc, ERC1155MockArtifact)) as ERC1155Mock
+    await token.mint(owner, tokenId, WAD.mul(100), '0x00')
+
+    // ==== Set Transfer Module ====
+    transferModule = (await deployContract(ownerAcc, Transfer1155ModuleArtifact, [
+      cauldron.address,
+      zeroAddress,
+    ])) as Transfer1155Module
+    await ladle.grantRoles([id(ladle.ladle.interface, 'addToken(address,bool)')], owner)
+    await ladle.grantRoles([id(ladle.ladle.interface, 'addModule(address,bool)')], owner)
+
+    await ladle.addModule(transferModule.address, true)
+    await ladle.ladle.addToken(token.address, true)
+
+    // Approve the Ladle to move the tokens
+    await token.setApprovalForAll(ladle.address, true)
+  })
+
+  it('transfers ERC1155 through the ladle', async () => {
+    const calldata = transferModule.interface.encodeFunctionData('transfer1155', [token.address, tokenId, other, WAD, '0x00'])
+    await ladle.moduleCall(transferModule.address, calldata)
+    expect(await token.balanceOf(other, tokenId)).to.equal(WAD)
+  })
+
+  it('attempting to transfer an unregistered token reverts', async () => {
+    const calldata = transferModule.interface.encodeFunctionData('transfer1155', [ladle.address, tokenId, other, WAD, '0x00'])
+    await expect(ladle.moduleCall(transferModule.address, calldata)).to.be.revertedWith('Unknown token')
+  })
+})

--- a/test/074_module_transferERC1155.ts
+++ b/test/074_module_transferERC1155.ts
@@ -67,13 +67,25 @@ describe('Ladle - module', function () {
   })
 
   it('transfers ERC1155 through the ladle', async () => {
-    const calldata = transferModule.interface.encodeFunctionData('transfer1155', [token.address, tokenId, other, WAD, '0x00'])
+    const calldata = transferModule.interface.encodeFunctionData('transfer1155', [
+      token.address,
+      tokenId,
+      other,
+      WAD,
+      '0x00',
+    ])
     await ladle.moduleCall(transferModule.address, calldata)
     expect(await token.balanceOf(other, tokenId)).to.equal(WAD)
   })
 
   it('attempting to transfer an unregistered token reverts', async () => {
-    const calldata = transferModule.interface.encodeFunctionData('transfer1155', [ladle.address, tokenId, other, WAD, '0x00'])
+    const calldata = transferModule.interface.encodeFunctionData('transfer1155', [
+      ladle.address,
+      tokenId,
+      other,
+      WAD,
+      '0x00',
+    ])
     await expect(ladle.moduleCall(transferModule.address, calldata)).to.be.revertedWith('Unknown token')
   })
 })


### PR DESCRIPTION
- Regular Join that takes ERC1155 assets, but is locked to a single id. No flash loans.
- Minimal Ladle module to transfer ERC1155 assets. No permit.
- Minimal Oracle that prices fCash at face value.

Check the README for more details.

All files have been stored in `contracts/other/notional`. We can have a discussion on how to organize this repo better.
1. I think that we could keep specific integration contracts in `other`, which would also mean moving a bunch of oracles.
2. The ERC1155.sol contract can be imported from solmate, or copied into `utils`.
3. The `Join1155` could go into a `joins` folder since it is not specific to any solution.