### PR TITLE
feat: mark constants in Constants.sol as constant

### DIFF
--- a/contracts/constants/Constants.sol
+++ b/contracts/constants/Constants.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.6;
 
 contract Constants {
-    bytes32 CHI = "CHI";
-    bytes32 RATE = "RATE";
-    bytes6 ETH = "00";
+    bytes32 constant CHI = "CHI";
+    bytes32 constant RATE = "RATE";
+    bytes6 constant ETH = "00";
 }


### PR DESCRIPTION
This PR is for the marking of the constants `CHI`, `RATE`, and `ETH` in `Constants.sol` with `constant` keyword. Closes #380 