### PR TITLE
fix: make linter happy

### DIFF
--- a/contracts/mocks/oracles/chainlink/FlagsInterfaceMock.sol
+++ b/contracts/mocks/oracles/chainlink/FlagsInterfaceMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.6;
-import '../../../oracles/chainlink/FlagsInterface.sol';
+import "../../../oracles/chainlink/FlagsInterface.sol";
 
 /**
 Mock FlagsInterface
@@ -17,28 +17,28 @@ contract FlagsInterfaceMock is FlagsInterface {
     }
 
     function getFlags(address[] calldata) external pure override returns (bool[] memory) {
-        revert('not implemented');
+        revert("not implemented");
     }
 
     function raiseFlag(address) external pure override {
-        revert('not implemented');
+        revert("not implemented");
     }
 
     function raiseFlags(address[] calldata) external pure override {
-        revert('not implemented');
+        revert("not implemented");
     }
 
     function lowerFlags(address[] calldata) external pure override {
-        revert('not implemented');
+        revert("not implemented");
     }
 
     function setRaisingAccessController(address) external pure override {
-        revert('not implemented');
+        revert("not implemented");
     }
 
     // helpers
     function flagSetArbitrumSeqOffline(bool value) public {
-        address flag = address(bytes20(bytes32(uint256(keccak256('chainlink.flags.arbitrum-seq-offline')) - 1)));
+        address flag = address(bytes20(bytes32(uint256(keccak256("chainlink.flags.arbitrum-seq-offline")) - 1)));
         flags[flag] = value;
     }
 }

--- a/contracts/oracles/chainlink/ChainlinkL2USDMultiOracle.sol
+++ b/contracts/oracles/chainlink/ChainlinkL2USDMultiOracle.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.6;
 
-import './ChainlinkUSDMultiOracle.sol';
+import "./ChainlinkUSDMultiOracle.sol";
 
 
 /**
@@ -17,16 +17,16 @@ contract ChainlinkL2USDMultiOracle is ChainlinkUSDMultiOracle {
     FlagsInterface public chainlinkFlags;
     // https://docs.chain.link/docs/l2-sequencer-flag/
     address internal constant FLAG_ARBITRUM_SEQ_OFFLINE =
-        address(bytes20(bytes32(uint256(keccak256('chainlink.flags.arbitrum-seq-offline')) - 1)));
+        address(bytes20(bytes32(uint256(keccak256("chainlink.flags.arbitrum-seq-offline")) - 1)));
 
     constructor(FlagsInterface flags) {
-        require(address(flags) != address(0), 'FlagsInterface has to be set');
+        require(address(flags) != address(0), "FlagsInterface has to be set");
         chainlinkFlags = flags;
     }
 
     modifier onlyFresh() {
         // If flag is raised we shouldn't perform any critical operations
-        require(!chainlinkFlags.getFlag(FLAG_ARBITRUM_SEQ_OFFLINE), 'Chainlink feeds are not being updated');
+        require(!chainlinkFlags.getFlag(FLAG_ARBITRUM_SEQ_OFFLINE), "Chainlink feeds are not being updated");
         _;
     }
 

--- a/contracts/oracles/chainlink/ChainlinkUSDMultiOracle.sol
+++ b/contracts/oracles/chainlink/ChainlinkUSDMultiOracle.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.6;
 
-import '@yield-protocol/utils-v2/contracts/access/AccessControl.sol';
-import '@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol';
-import '@yield-protocol/utils-v2/contracts/token/IERC20Metadata.sol';
-import '@yield-protocol/vault-interfaces/IOracle.sol';
-import '../../constants/Constants.sol';
-import './AggregatorV3Interface.sol';
-import './FlagsInterface.sol';
+import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
+import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
+import "@yield-protocol/utils-v2/contracts/token/IERC20Metadata.sol";
+import "@yield-protocol/vault-interfaces/IOracle.sol";
+import "../../constants/Constants.sol";
+import "./AggregatorV3Interface.sol";
+import "./FlagsInterface.sol";
 
 /**
  * @title ChainlinkUSDMultiOracle
@@ -31,7 +31,7 @@ contract ChainlinkUSDMultiOracle is IOracle, AccessControl, Constants {
         IERC20Metadata base,
         address source
     ) external auth {
-        require(AggregatorV3Interface(source).decimals() == 8, 'Non-8-decimals USD source');
+        require(AggregatorV3Interface(source).decimals() == 8, "Non-8-decimals USD source");
 
         sources[baseId] = Source({source: source, baseDecimals: base.decimals()});
         emit SourceSet(baseId, base, source);
@@ -73,11 +73,11 @@ contract ChainlinkUSDMultiOracle is IOracle, AccessControl, Constants {
         uint80 roundId;
         uint80 answeredInRound;
         Source memory source = sources[baseId];
-        require(source.source != address(0), 'Source not found');
+        require(source.source != address(0), "Source not found");
         (roundId, price, , updateTime, answeredInRound) = AggregatorV3Interface(source.source).latestRoundData();
-        require(price > 0, 'Chainlink price <= 0');
-        require(updateTime != 0, 'Incomplete round');
-        require(answeredInRound >= roundId, 'Stale price');
+        require(price > 0, "Chainlink price <= 0");
+        require(updateTime != 0, "Incomplete round");
+        require(answeredInRound >= roundId, "Stale price");
 
         uintPrice = uint256(price);
         baseDecimals = source.baseDecimals;


### PR DESCRIPTION
This low priority PR fixes the formatting of string literals in `FlagsInterfaceMock` as well as the Chainlink USD MultiOracles to be consistent with other files and pass linting checks. 