### PR TITLE
Addition of authenticated `seize` vault function

### DIFF
--- a/contracts/utils/Giver.sol
+++ b/contracts/utils/Giver.sol
@@ -36,4 +36,14 @@ contract Giver is AccessControl {
         require(!bannedIlks[vault.ilkId], "ilk is banned");
         vault = cauldron.give(vaultId, receiver);
     }
+
+    /// @notice A give function which allows the authenticated address to give the vault of any user to another address
+    /// @param vaultId The vaultId of the vault to be given
+    /// @param receiver The address to which the vault is being given to
+    /// @return vault The vault which has been given
+    function seize(bytes12 vaultId, address receiver) external auth returns (DataTypes.Vault memory vault) {
+        vault = cauldron.vaults(vaultId);
+        require(!bannedIlks[vault.ilkId], "ilk is banned");
+        vault = cauldron.give(vaultId, receiver);
+    }
 }

--- a/test/092_giver.ts
+++ b/test/092_giver.ts
@@ -86,4 +86,15 @@ describe('Giver', function () {
     const vaultData = await cauldron.vaults(vaultId)
     expect(vaultData['owner']).to.not.eq(owner2)
   })
+
+  it('Cannot call the seize function without authentication', async () => {
+    await expect(giver.connect(ownerAcc).seize(vaultId, owner2)).to.be.revertedWith('Access denied')
+  })
+
+  it('Can call the seize function with authentication', async () => {
+    await giver.grantRole(id(giver.interface, 'seize(bytes12,address)'), owner)
+    await giver.connect(ownerAcc).seize(vaultId, owner2)
+    const vaultData = await cauldron.vaults(vaultId)
+    expect(vaultData['owner']).to.not.eq(owner)
+  })
 })


### PR DESCRIPTION
To allow contracts to transfer vaults from one address to another we have added a seize function which moves vault from one user to another without checking whether the owner of the vault is `msg.sender`