### PR TITLE
Update CI for use with forge mainnet forking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,4 +147,4 @@ jobs:
         run: forge build     
 
       - name: Run tests
-        run: forge test
+        run: forge test --fork-url ${{ secrets.ALCHEMY_MAINNET_RPC }}


### PR DESCRIPTION
This PR adds the capacity for the CI to use mainnet forking with forge through the use of an RPC url. 