### PR TITLE
Fix `forge snapshot` for use with tests that use mainnet forking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         run: yarn workspace @yield-protocol/vault-v2 forge:build
 
       - name: Check gas consumption
-        run: yarn workspace @yield-protocol/vault-v2 forge:snapshot --check
+        run: yarn workspace @yield-protocol/vault-v2 forge:snapshot --check --fork-url ${{ secrets.ALCHEMY_MAINNET_RPC }}
 
       - name: Run tests
         run: yarn workspace @yield-protocol/vault-v2 forge:test --fork-url ${{ secrets.ALCHEMY_MAINNET_RPC }}


### PR DESCRIPTION
Adds Alchemy RPC to `forge snapshot` so that tests using mainnet forking do not break on this run. 