### PR TITLE
ChainlinkETHOracle only accepts ETH data feeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,6 @@ jobs:
       - name: Build contracts
         run: yarn workspace @yield-protocol/vault-v2 forge:build
 
-      - name: Check gas consumption
-        run: yarn workspace @yield-protocol/vault-v2 forge:snapshot --check
-        env: 
-          MAINNET_RPC: ${{ secrets.ALCHEMY_MAINNET_RPC }}
-
       - name: Run tests
         run: yarn workspace @yield-protocol/vault-v2 forge:test
         env:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,27 +1,15 @@
-[submodule "packages/foundry/lib/vault-interfaces"]
-	path = packages/foundry/lib/vault-interfaces
-	url = https://github.com/yieldprotocol/vault-interfaces
 [submodule "packages/foundry/lib/yield-utils-v2"]
 	path = packages/foundry/lib/yield-utils-v2
 	url = https://github.com/yieldprotocol/yield-utils-v2
-[submodule "packages/foundry/lib/yieldspace-v2"]
-	path = packages/foundry/lib/yieldspace-v2
-	url = https://github.com/yieldprotocol/yieldspace-v2
-[submodule "packages/foundry/lib/Yield-UniswapOracleV3"]
-	path = packages/foundry/lib/Yield-UniswapOracleV3
-	url = https://github.com/iamsahu/Yield-UniswapOracleV3
-[submodule "packages/foundry/lib/Yield-UniswapOracleV3"]
-	path = packages/foundry/lib/Yield-UniswapOracleV3
-	url = https://github.com/iamsahu/Yield-UniswapOracleV3
 [submodule "packages/foundry/lib/ERC3156"]
 	path = packages/foundry/lib/ERC3156
 	url = https://github.com/alcueca/ERC3156
-[submodule "packages/foundry/lib/yieldspace-interfaces"]
-	path = packages/foundry/lib/yieldspace-interfaces
-	url = https://github.com/yieldprotocol/yieldspace-interfaces
 [submodule "packages/foundry/lib/dss-interfaces"]
 	path = packages/foundry/lib/dss-interfaces
 	url = https://github.com/makerdao/dss-interfaces
 [submodule "packages/foundry/lib/forge-std"]
 	path = packages/foundry/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "packages/foundry/lib/yieldspace-tv"]
+	path = packages/foundry/lib/yieldspace-tv
+	url = https://github.com/yieldprotocol/yieldspace-tv

--- a/packages/foundry/contracts/Cauldron.sol
+++ b/packages/foundry/contracts/Cauldron.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
-import "@yield-protocol/vault-interfaces/src/IFYToken.sol";
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
-import "@yield-protocol/vault-interfaces/src/DataTypes.sol";
+pragma solidity >=0.8.13;
+import "./interfaces/IFYToken.sol";
+import "./interfaces/IOracle.sol";
+import "./interfaces/DataTypes.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
 import "@yield-protocol/utils-v2/contracts/math/WDiv.sol";

--- a/packages/foundry/contracts/FYToken.sol
+++ b/packages/foundry/contracts/FYToken.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "erc3156/contracts/interfaces/IERC3156FlashBorrower.sol";
 import "erc3156/contracts/interfaces/IERC3156FlashLender.sol";
 import "@yield-protocol/utils-v2/contracts/token/ERC20Permit.sol";
 import "@yield-protocol/utils-v2/contracts/token/SafeERC20Namer.sol";
-import "@yield-protocol/vault-interfaces/src/IFYToken.sol";
-import "@yield-protocol/vault-interfaces/src/IJoin.sol";
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import "./interfaces/IFYToken.sol";
+import "./interfaces/IJoin.sol";
+import "./interfaces/IOracle.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
 import "@yield-protocol/utils-v2/contracts/math/WDiv.sol";

--- a/packages/foundry/contracts/FlashJoin.sol
+++ b/packages/foundry/contracts/FlashJoin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "erc3156/contracts/interfaces/IERC3156FlashBorrower.sol";
 import "erc3156/contracts/interfaces/IERC3156FlashLender.sol";

--- a/packages/foundry/contracts/Join.sol
+++ b/packages/foundry/contracts/Join.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "erc3156/contracts/interfaces/IERC3156FlashBorrower.sol";
 import "erc3156/contracts/interfaces/IERC3156FlashLender.sol";
-import "@yield-protocol/vault-interfaces/src/IJoin.sol";
-import "@yield-protocol/vault-interfaces/src/IJoinFactory.sol";
+import "./interfaces/IJoin.sol";
+import "./interfaces/IJoinFactory.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/token/TransferHelper.sol";

--- a/packages/foundry/contracts/Ladle.sol
+++ b/packages/foundry/contracts/Ladle.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
-import "@yield-protocol/vault-interfaces/src/IFYToken.sol";
-import "@yield-protocol/vault-interfaces/src/IJoin.sol";
-import "@yield-protocol/vault-interfaces/src/ICauldron.sol";
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
-import "@yield-protocol/vault-interfaces/src/DataTypes.sol";
-import "@yield-protocol/yieldspace-interfaces/IPool.sol";
+pragma solidity >=0.8.13;
+import "./interfaces/IFYToken.sol";
+import "./interfaces/IJoin.sol";
+import "./interfaces/ICauldron.sol";
+import "./interfaces/IOracle.sol";
+import "./interfaces/DataTypes.sol";
+import "@yield-protocol/yieldspace-tv/src/interfaces/IPool.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC2612.sol";
-import "dss-interfaces/src/dss/DaiAbstract.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/token/TransferHelper.sol";
 import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastU256U128.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastU256I128.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastU128I128.sol";
+import "dss-interfaces/src/dss/DaiAbstract.sol";
 import "./LadleStorage.sol";
 
 
@@ -128,7 +128,7 @@ contract Ladle is LadleStorage, AccessControl() {
         auth
     {
         IFYToken fyToken = getSeries(seriesId).fyToken;
-        require (fyToken == pool.fyToken(), "Mismatched pool fyToken and series");
+        require (address(fyToken) == address(pool.fyToken()), "Mismatched pool fyToken and series");
         require (fyToken.underlying() == address(pool.base()), "Mismatched pool base and series");
         pools[seriesId] = pool;
 

--- a/packages/foundry/contracts/LadleStorage.sol
+++ b/packages/foundry/contracts/LadleStorage.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
-import "@yield-protocol/vault-interfaces/src/ICauldron.sol";
-import "@yield-protocol/vault-interfaces/src/IJoin.sol";
-import "@yield-protocol/yieldspace-interfaces/IPool.sol";
+pragma solidity >=0.8.13;
+import "./interfaces/ICauldron.sol";
+import "./interfaces/IJoin.sol";
+import "@yield-protocol/yieldspace-tv/src/interfaces/IPool.sol";
 import "@yield-protocol/utils-v2/contracts/interfaces/IWETH9.sol";
 import "./Router.sol";
 

--- a/packages/foundry/contracts/Router.sol
+++ b/packages/foundry/contracts/Router.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "@yield-protocol/utils-v2/contracts/utils/RevertMsgExtractor.sol";
 import "@yield-protocol/utils-v2/contracts/utils/IsContract.sol";
 

--- a/packages/foundry/contracts/Witch.sol
+++ b/packages/foundry/contracts/Witch.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
-import "@yield-protocol/vault-interfaces/src/ILadle.sol";
-import "@yield-protocol/vault-interfaces/src/ICauldron.sol";
-import "@yield-protocol/vault-interfaces/src/IJoin.sol";
-import "@yield-protocol/vault-interfaces/src/DataTypes.sol";
+import "./interfaces/ILadle.sol";
+import "./interfaces/ICauldron.sol";
+import "./interfaces/IJoin.sol";
+import "./interfaces/DataTypes.sol";
 import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
 import "@yield-protocol/utils-v2/contracts/math/WDiv.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastU256U128.sol";

--- a/packages/foundry/contracts/constants/Constants.sol
+++ b/packages/foundry/contracts/constants/Constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 contract Constants {
     bytes32 constant CHI = "CHI";

--- a/packages/foundry/contracts/deprecated/FYTokenFactoryMock.sol
+++ b/packages/foundry/contracts/deprecated/FYTokenFactoryMock.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
-import "@yield-protocol/vault-interfaces/src/IJoin.sol";
-import "@yield-protocol/vault-interfaces/src/IFYTokenFactory.sol";
+import "../interfaces/IOracle.sol";
+import "../interfaces/IJoin.sol";
+import "../interfaces/IFYTokenFactory.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "../FYToken.sol";
 

--- a/packages/foundry/contracts/deprecated/JoinFactoryMock.sol
+++ b/packages/foundry/contracts/deprecated/JoinFactoryMock.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
-import "@yield-protocol/vault-interfaces/src/IJoinFactory.sol";
+import "../interfaces/IJoinFactory.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "../Join.sol";
 

--- a/packages/foundry/contracts/deprecated/PoolFactoryMock.sol
+++ b/packages/foundry/contracts/deprecated/PoolFactoryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "./IPoolFactory.sol";
 import "../mocks/PoolMock.sol";

--- a/packages/foundry/contracts/deprecated/Wand.sol
+++ b/packages/foundry/contracts/deprecated/Wand.sol
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
-import "@yield-protocol/vault-interfaces/src/ICauldronGov.sol";
-import "@yield-protocol/vault-interfaces/src/ILadleGov.sol";
-// import "@yield-protocol/vault-interfaces/src/IWitchGov.sol";
-import "@yield-protocol/vault-interfaces/src/IMultiOracleGov.sol";
-import "@yield-protocol/vault-interfaces/src/IJoinFactory.sol";
-import "@yield-protocol/vault-interfaces/src/IJoin.sol";
-import "@yield-protocol/vault-interfaces/src/IFYTokenFactory.sol";
-import "@yield-protocol/vault-interfaces/src/IFYToken.sol";
-import "@yield-protocol/vault-interfaces/src/DataTypes.sol";
+pragma solidity >=0.8.13;
+import "../interfaces/ICauldronGov.sol";
+import "../interfaces/ILadleGov.sol";
+import "../interfaces/IMultiOracleGov.sol";
+import "../interfaces/IJoinFactory.sol";
+import "../interfaces/IJoin.sol";
+import "../interfaces/IFYTokenFactory.sol";
+import "../interfaces/IFYToken.sol";
+import "../interfaces/DataTypes.sol";
 import "./IPoolFactory.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "../constants/Constants.sol";

--- a/packages/foundry/contracts/deprecated/WitchOld.sol
+++ b/packages/foundry/contracts/deprecated/WitchOld.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
-import "@yield-protocol/vault-interfaces/src/ILadle.sol";
-import "@yield-protocol/vault-interfaces/src/ICauldron.sol";
-import "@yield-protocol/vault-interfaces/src/IJoin.sol";
-import "@yield-protocol/vault-interfaces/src/DataTypes.sol";
+import "../interfaces/ILadle.sol";
+import "../interfaces/ICauldron.sol";
+import "../interfaces/IJoin.sol";
+import "../interfaces/DataTypes.sol";
 import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
 import "@yield-protocol/utils-v2/contracts/math/WMulUp.sol";
 import "@yield-protocol/utils-v2/contracts/math/WDiv.sol";

--- a/packages/foundry/contracts/interfaces/DataTypes.sol
+++ b/packages/foundry/contracts/interfaces/DataTypes.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import "./IFYToken.sol";
+import "./IOracle.sol";
+
+library DataTypes {
+    // ======== Cauldron data types ========
+    struct Series {
+        IFYToken fyToken; // Redeemable token for the series.
+        bytes6 baseId; // Asset received on redemption.
+        uint32 maturity; // Unix time at which redemption becomes possible.
+        // bytes2 free
+    }
+
+    struct Debt {
+        uint96 max; // Maximum debt accepted for a given underlying, across all series
+        uint24 min; // Minimum debt accepted for a given underlying, across all series
+        uint8 dec; // Multiplying factor (10**dec) for max and min
+        uint128 sum; // Current debt for a given underlying, across all series
+    }
+
+    struct SpotOracle {
+        IOracle oracle; // Address for the spot price oracle
+        uint32 ratio; // Collateralization ratio to multiply the price for
+        // bytes8 free
+    }
+
+    struct Vault {
+        address owner;
+        bytes6 seriesId; // Each vault is related to only one series, which also determines the underlying.
+        bytes6 ilkId; // Asset accepted as collateral
+    }
+
+    struct Balances {
+        uint128 art; // Debt amount
+        uint128 ink; // Collateral amount
+    }
+
+    // ======== Witch data types ========
+    struct Auction {
+        address owner;
+        uint32 start;
+        bytes6 baseId; // We cache the baseId here
+        uint128 ink;
+        uint128 art;
+        address auctioneer;
+        bytes6 ilkId; // We cache the ilkId here
+        bytes6 seriesId; // We cache the seriesId here
+    }
+
+    struct Line {
+        uint32 duration; // Time that auctions take to go to minimal price and stay there
+        uint64 proportion; // Proportion of the vault that is available each auction (1e18 = 100%)
+        uint64 initialOffer; // Proportion of collateral that is sold at auction start (1e18 = 100%)
+    }
+
+    struct Limits {
+        uint128 max; // Maximum concurrent auctioned collateral
+        uint128 sum; // Current concurrent auctioned collateral
+    }
+}

--- a/packages/foundry/contracts/interfaces/ICauldron.sol
+++ b/packages/foundry/contracts/interfaces/ICauldron.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import "./IFYToken.sol";
+import "./IOracle.sol";
+import "./DataTypes.sol";
+
+interface ICauldron {
+    /// @dev Variable rate lending oracle for an underlying
+    function lendingOracles(bytes6 baseId) external view returns (IOracle);
+
+    /// @dev An user can own one or more Vaults, with each vault being able to borrow from a single series.
+    function vaults(bytes12 vault)
+        external
+        view
+        returns (DataTypes.Vault memory);
+
+    /// @dev Series available in Cauldron.
+    function series(bytes6 seriesId)
+        external
+        view
+        returns (DataTypes.Series memory);
+
+    /// @dev Assets available in Cauldron.
+    function assets(bytes6 assetsId) external view returns (address);
+
+    /// @dev Each vault records debt and collateral balances_.
+    function balances(bytes12 vault)
+        external
+        view
+        returns (DataTypes.Balances memory);
+
+    /// @dev Max, min and sum of debt per underlying and collateral.
+    function debt(bytes6 baseId, bytes6 ilkId)
+        external
+        view
+        returns (DataTypes.Debt memory);
+
+    // @dev Spot price oracle addresses and collateralization ratios
+    function spotOracles(bytes6 baseId, bytes6 ilkId)
+        external
+        returns (DataTypes.SpotOracle memory);
+
+    /// @dev Create a new vault, linked to a series (and therefore underlying) and up to 5 collateral types
+    function build(
+        address owner,
+        bytes12 vaultId,
+        bytes6 seriesId,
+        bytes6 ilkId
+    ) external returns (DataTypes.Vault memory);
+
+    /// @dev Destroy an empty vault. Used to recover gas costs.
+    function destroy(bytes12 vault) external;
+
+    /// @dev Change a vault series and/or collateral types.
+    function tweak(
+        bytes12 vaultId,
+        bytes6 seriesId,
+        bytes6 ilkId
+    ) external returns (DataTypes.Vault memory);
+
+    /// @dev Give a vault to another user.
+    function give(bytes12 vaultId, address receiver)
+        external
+        returns (DataTypes.Vault memory);
+
+    /// @dev Move collateral and debt between vaults.
+    function stir(
+        bytes12 from,
+        bytes12 to,
+        uint128 ink,
+        uint128 art
+    ) external returns (DataTypes.Balances memory, DataTypes.Balances memory);
+
+    /// @dev Manipulate a vault debt and collateral.
+    function pour(
+        bytes12 vaultId,
+        int128 ink,
+        int128 art
+    ) external returns (DataTypes.Balances memory);
+
+    /// @dev Change series and debt of a vault.
+    /// The module calling this function also needs to buy underlying in the pool for the new series, and sell it in pool for the old series.
+    function roll(
+        bytes12 vaultId,
+        bytes6 seriesId,
+        int128 art
+    ) external returns (DataTypes.Vault memory, DataTypes.Balances memory);
+
+    /// @dev Reduce debt and collateral from a vault, ignoring collateralization checks.
+    function slurp(
+        bytes12 vaultId,
+        uint128 ink,
+        uint128 art
+    ) external returns (DataTypes.Balances memory);
+
+    // ==== Helpers ====
+
+    /// @dev Convert a debt amount for a series from base to fyToken terms.
+    /// @notice Think about rounding if using, since we are dividing.
+    function debtFromBase(bytes6 seriesId, uint128 base)
+        external
+        returns (uint128 art);
+
+    /// @dev Convert a debt amount for a series from fyToken to base terms
+    function debtToBase(bytes6 seriesId, uint128 art)
+        external
+        returns (uint128 base);
+
+    // ==== Accounting ====
+
+    /// @dev Record the borrowing rate at maturity for a series
+    function mature(bytes6 seriesId) external;
+
+    /// @dev Retrieve the rate accrual since maturity, maturing if necessary.
+    function accrual(bytes6 seriesId) external returns (uint256);
+
+    /// @dev Return the collateralization level of a vault. It will be negative if undercollateralized.
+    function level(bytes12 vaultId) external returns (int256);
+}

--- a/packages/foundry/contracts/interfaces/ICauldronGov.sol
+++ b/packages/foundry/contracts/interfaces/ICauldronGov.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import "./IFYToken.sol";
+import "./IOracle.sol";
+import "./DataTypes.sol";
+
+interface ICauldronGov {
+    function assets(bytes6) external view returns (address);
+
+    function series(bytes6) external view returns (DataTypes.Series memory);
+
+    function lendingOracles(bytes6) external view returns (IOracle);
+
+    function addAsset(bytes6, address) external;
+
+    function addSeries(
+        bytes6,
+        bytes6,
+        IFYToken
+    ) external;
+
+    function addIlks(bytes6, bytes6[] memory) external;
+
+    function setLendingOracle(bytes6, IOracle) external;
+
+    function setSpotOracle(
+        bytes6,
+        bytes6,
+        IOracle,
+        uint32
+    ) external;
+
+    function setDebtLimits(
+        bytes6,
+        bytes6,
+        uint96,
+        uint24,
+        uint8
+    ) external;
+}

--- a/packages/foundry/contracts/interfaces/IFYToken.sol
+++ b/packages/foundry/contracts/interfaces/IFYToken.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+import "./IJoin.sol";
+
+interface IFYToken is IERC20 {
+    /// @dev Asset that is returned on redemption.
+    function underlying() external view returns (address);
+
+    /// @dev Source of redemption funds.
+    function join() external view returns (IJoin);
+
+    /// @dev Unix time at which redemption of fyToken for underlying are possible
+    function maturity() external view returns (uint256);
+
+    /// @dev Record price data at maturity
+    function mature() external;
+
+    /// @dev Mint fyToken providing an equal amount of underlying to the protocol
+    function mintWithUnderlying(address to, uint256 amount) external;
+
+    /// @dev Burn fyToken after maturity for an amount of underlying.
+    function redeem(address to, uint256 amount) external returns (uint256);
+
+    /// @dev Mint fyToken.
+    /// This function can only be called by other Yield contracts, not users directly.
+    /// @param to Wallet to mint the fyToken in.
+    /// @param fyTokenAmount Amount of fyToken to mint.
+    function mint(address to, uint256 fyTokenAmount) external;
+
+    /// @dev Burn fyToken.
+    /// This function can only be called by other Yield contracts, not users directly.
+    /// @param from Wallet to burn the fyToken from.
+    /// @param fyTokenAmount Amount of fyToken to burn.
+    function burn(address from, uint256 fyTokenAmount) external;
+}

--- a/packages/foundry/contracts/interfaces/IFYTokenFactory.sol
+++ b/packages/foundry/contracts/interfaces/IFYTokenFactory.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./IOracle.sol";
+import "./IJoin.sol";
+
+interface IFYTokenFactory {
+    event FYTokenCreated(
+        address indexed fyToken,
+        address indexed asset,
+        uint32 indexed maturity
+    );
+
+    function createFYToken(
+        bytes6 baseId,
+        IOracle oracle,
+        IJoin baseJoin,
+        uint32 maturity,
+        string memory name,
+        string memory symbol
+    ) external returns (address);
+}

--- a/packages/foundry/contracts/interfaces/IJoin.sol
+++ b/packages/foundry/contracts/interfaces/IJoin.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+
+interface IJoin {
+    /// @dev asset managed by this contract
+    function asset() external view returns (address);
+
+    /// @dev Add tokens to this contract.
+    function join(address user, uint128 wad) external returns (uint128);
+
+    /// @dev Remove tokens to this contract.
+    function exit(address user, uint128 wad) external returns (uint128);
+}

--- a/packages/foundry/contracts/interfaces/IJoinFactory.sol
+++ b/packages/foundry/contracts/interfaces/IJoinFactory.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IJoinFactory {
+    event JoinCreated(address indexed asset, address pool);
+
+    function createJoin(address asset) external returns (address);
+}

--- a/packages/foundry/contracts/interfaces/ILadle.sol
+++ b/packages/foundry/contracts/interfaces/ILadle.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import "./IJoin.sol";
+import "./ICauldron.sol";
+
+interface ILadle {
+    function joins(bytes6) external view returns (IJoin);
+
+    function pools(bytes6) external returns (address);
+
+    function cauldron() external view returns (ICauldron);
+
+    function build(
+        bytes6 seriesId,
+        bytes6 ilkId,
+        uint8 salt
+    ) external returns (bytes12 vaultId, DataTypes.Vault memory vault);
+
+    function destroy(bytes12 vaultId) external;
+
+    function pour(
+        bytes12 vaultId,
+        address to,
+        int128 ink,
+        int128 art
+    ) external payable;
+
+    function serve(
+        bytes12 vaultId,
+        address to,
+        uint128 ink,
+        uint128 base,
+        uint128 max
+    ) external payable returns (uint128 art);
+
+    function close(
+        bytes12 vaultId,
+        address to,
+        int128 ink,
+        int128 art
+    ) external;
+}

--- a/packages/foundry/contracts/interfaces/ILadleGov.sol
+++ b/packages/foundry/contracts/interfaces/ILadleGov.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./IJoin.sol";
+
+interface ILadleGov {
+    function joins(bytes6) external view returns (IJoin);
+
+    function addJoin(bytes6, address) external;
+
+    function addPool(bytes6, address) external;
+}

--- a/packages/foundry/contracts/interfaces/IMultiOracleGov.sol
+++ b/packages/foundry/contracts/interfaces/IMultiOracleGov.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IMultiOracleGov {
+    function setSource(
+        bytes6,
+        bytes6,
+        address
+    ) external;
+}

--- a/packages/foundry/contracts/interfaces/IOracle.sol
+++ b/packages/foundry/contracts/interfaces/IOracle.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IOracle {
+    /**
+     * @notice Doesn't refresh the price, but returns the latest value available without doing any transactional operations:
+     * @return value in wei
+     */
+    function peek(
+        bytes32 base,
+        bytes32 quote,
+        uint256 amount
+    ) external view returns (uint256 value, uint256 updateTime);
+
+    /**
+     * @notice Does whatever work or queries will yield the most up-to-date price, and returns it.
+     * @return value in wei
+     */
+    function get(
+        bytes32 base,
+        bytes32 quote,
+        uint256 amount
+    ) external returns (uint256 value, uint256 updateTime);
+}

--- a/packages/foundry/contracts/interfaces/IWitch.sol
+++ b/packages/foundry/contracts/interfaces/IWitch.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./ILadle.sol";
+import "./ICauldron.sol";
+import "./DataTypes.sol";
+
+interface IWitch {
+    function cauldron() external returns (ICauldron);
+
+    function ladle() external returns (ILadle);
+
+    function auctions(bytes12) external returns (DataTypes.Auction memory);
+
+    function lines(bytes6, bytes6) external returns (DataTypes.Line memory);
+
+    function limits(bytes6, bytes6) external returns (DataTypes.Limits memory);
+
+    /// @dev Put an undercollateralized vault up for liquidation
+    /// @param vaultId Id of vault to liquidate
+    /// @param to Receiver of the auctioneer reward
+    function auction(bytes12 vaultId, address to)
+        external
+        returns (DataTypes.Auction memory);
+
+    /// @dev Cancel an auction for a vault that isn't undercollateralized anymore
+    /// @param vaultId Id of vault to return
+    function cancel(bytes12 vaultId) external;
+
+    /// @dev Pay at most `maxBaseIn` of the debt in a vault in liquidation, getting at least `minInkOut` collateral.
+    /// @param vaultId Id of vault to buy
+    /// @param to Receiver of the collateral bought
+    /// @param minInkOut Minimum amount of collateral that must be received
+    /// @param maxBaseIn Maximum amount of base that the liquidator will pay
+    /// @return inkOut Amount of vault collateral sold
+    /// @return baseIn Amount of underlying taken
+    function payBase(
+        bytes12 vaultId,
+        address to,
+        uint128 minInkOut,
+        uint128 maxBaseIn
+    ) external returns (uint256 inkOut, uint256 baseIn);
+
+    /// @dev Pay up to `maxArtIn` debt from a vault in liquidation using fyToken, getting at least `minInkOut` collateral.
+    /// @notice If too much fyToken are offered, only the necessary amount are taken.
+    /// @param vaultId Id of vault to buy
+    /// @param to Receiver for the collateral bought
+    /// @param maxArtIn Maximum amount of fyToken that will be paid
+    /// @param minInkOut Minimum amount of collateral that must be received
+    /// @return inkOut Amount of vault collateral sold
+    /// @return artIn Amount of fyToken taken
+    function payFYToken(
+        bytes12 vaultId,
+        address to,
+        uint128 minInkOut,
+        uint128 maxArtIn
+    ) external returns (uint256 inkOut, uint256 artIn);
+
+    /*
+
+        x x x
+    x      x    Hi Fren!
+    x  .  .  x   I want to buy this vault under auction!  I'll pay
+    x        x   you in the same `base` currency of the debt, or in fyToken, but
+    x        x   I want no less than `uint min` of the collateral, ok?
+    x   ===  x
+    x       x
+        xxxxxxx
+        x                             __  Ok Fren!
+        x     ┌────────────┐  _(\    |@@|
+        xxxxxx│ BASE BUCKS │ (__/\__ \--/ __
+        x     │     OR     │    \___|----|  |   __
+        x     │   FYTOKEN  │        \ }{ /\ )_ / _\
+        x x    └────────────┘        /\__/\ \__O (__
+                                    (--/\--)    \__/
+                            │      _)(  )(_
+                            │     `---''---`
+                            ▼
+    _______
+    /  12   \  First lets check how much time `t` is left on the auction
+    |    |    | because that helps us determine the price we will accept
+    |9   |   3| for the debt! Yay!
+    |     \   |                       p + (1 - p) * t
+    |         |
+    \___6___/          (p is the auction starting price!)
+
+                            │
+                            │
+                            ▼                  (\
+                                                \ \
+    Then the Cauldron updates our internal    __    \/ ___,.-------..__        __
+    accounting by slurping up the debt      //\\ _,-'\\               `'--._ //\\
+    and the collateral from the vault!      \\ ;'      \\                   `: //
+                                            `(          \\                   )'
+    The Join  then dishes out the collateral   :.          \\,----,         ,;
+    to you, dear user. And the debt is          `.`--.___   (    /  ___.--','
+    settled with the base join or debt fyToken.   `.     ``-----'-''     ,'
+                                                    -.               ,-
+                                                        `-._______.-'gpyy
+
+
+    */
+    /// @dev quoutes hoy much ink a liquidator is expected to get if it repays an `artIn` amount
+    /// @param vaultId The vault to get a quote for
+    /// @param artIn How much of the vault debt will be paid. 0 means all
+    /// @return inkOut How much collateral the liquidator is expected to get
+    function calcPayout(bytes12 vaultId, uint256 artIn)
+        external
+        view
+        returns (uint256 inkOut);
+}

--- a/packages/foundry/contracts/mocks/ConvexPoolMock.sol
+++ b/packages/foundry/contracts/mocks/ConvexPoolMock.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
-import "@yield-protocol/vault-interfaces/src/DataTypes.sol";
+import "../interfaces/DataTypes.sol";
 import "@yield-protocol/utils-v2/contracts/token/TransferHelper.sol";
 
 contract ConvexPoolMock {

--- a/packages/foundry/contracts/mocks/ConvexYieldWrapperMock.sol
+++ b/packages/foundry/contracts/mocks/ConvexYieldWrapperMock.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
-import "@yield-protocol/vault-interfaces/src/DataTypes.sol";
+import "../interfaces/DataTypes.sol";
 import "@yield-protocol/utils-v2/contracts/token/TransferHelper.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 

--- a/packages/foundry/contracts/mocks/DAIMock.sol
+++ b/packages/foundry/contracts/mocks/DAIMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
 
 

--- a/packages/foundry/contracts/mocks/ERC20Mock.sol
+++ b/packages/foundry/contracts/mocks/ERC20Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "@yield-protocol/utils-v2/contracts/token/ERC20Permit.sol";
 
 

--- a/packages/foundry/contracts/mocks/FlashBorrower.sol
+++ b/packages/foundry/contracts/mocks/FlashBorrower.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "erc3156/contracts/interfaces/IERC3156FlashBorrower.sol";

--- a/packages/foundry/contracts/mocks/PoolMock.sol
+++ b/packages/foundry/contracts/mocks/PoolMock.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "@yield-protocol/utils-v2/contracts/access/Ownable.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
-import "@yield-protocol/vault-interfaces/src/IFYToken.sol";
+import "../interfaces/IFYToken.sol";
 import "../deprecated/IPoolFactory.sol";
 import "./ERC20Mock.sol";
 

--- a/packages/foundry/contracts/mocks/RestrictedERC20Mock.sol
+++ b/packages/foundry/contracts/mocks/RestrictedERC20Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "@yield-protocol/utils-v2/contracts/token/ERC20Permit.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 

--- a/packages/foundry/contracts/mocks/TLMMock.sol
+++ b/packages/foundry/contracts/mocks/TLMMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "./ERC20Mock.sol";

--- a/packages/foundry/contracts/mocks/TokenProxy.sol
+++ b/packages/foundry/contracts/mocks/TokenProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
 
 /// @notice A simple contract which could be used as a proxy for ERC20 contracts

--- a/packages/foundry/contracts/mocks/USDCMock.sol
+++ b/packages/foundry/contracts/mocks/USDCMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "@yield-protocol/utils-v2/contracts/token/ERC20Permit.sol";
 
 

--- a/packages/foundry/contracts/mocks/WETH9Mock.sol
+++ b/packages/foundry/contracts/mocks/WETH9Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 
 contract WETH9Mock is ERC20 {

--- a/packages/foundry/contracts/mocks/WstETHMock.sol
+++ b/packages/foundry/contracts/mocks/WstETHMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import '@yield-protocol/utils-v2/contracts/token/ERC20Permit.sol';
 
 contract WstETHMock is ERC20Permit {

--- a/packages/foundry/contracts/mocks/YvTokenMock.sol
+++ b/packages/foundry/contracts/mocks/YvTokenMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "./oracles/ISourceMock.sol";
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";

--- a/packages/foundry/contracts/mocks/oracles/ISourceMock.sol
+++ b/packages/foundry/contracts/mocks/oracles/ISourceMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 interface ISourceMock {
     function set(uint) external;

--- a/packages/foundry/contracts/mocks/oracles/OracleMock.sol
+++ b/packages/foundry/contracts/mocks/oracles/OracleMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+pragma solidity >=0.8.13;
+import "../../interfaces/IOracle.sol";
 
 
 /// @dev An oracle that allows to set the spot price to anyone. It also allows to record spot values and return the accrual between a recorded and current spots.

--- a/packages/foundry/contracts/mocks/oracles/chainlink/ChainlinkAggregatorV3Mock.sol
+++ b/packages/foundry/contracts/mocks/oracles/chainlink/ChainlinkAggregatorV3Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "../ISourceMock.sol";
 
 

--- a/packages/foundry/contracts/mocks/oracles/chainlink/ChainlinkAggregatorV3MockEx.sol
+++ b/packages/foundry/contracts/mocks/oracles/chainlink/ChainlinkAggregatorV3MockEx.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "./ChainlinkAggregatorV3Mock.sol";
 
 /**

--- a/packages/foundry/contracts/mocks/oracles/chainlink/FlagsInterfaceMock.sol
+++ b/packages/foundry/contracts/mocks/oracles/chainlink/FlagsInterfaceMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import '../../../oracles/chainlink/FlagsInterface.sol';
 
 /**

--- a/packages/foundry/contracts/mocks/oracles/compound/CTokenChiMock.sol
+++ b/packages/foundry/contracts/mocks/oracles/compound/CTokenChiMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "../ISourceMock.sol";
 
 

--- a/packages/foundry/contracts/mocks/oracles/compound/CTokenMock.sol
+++ b/packages/foundry/contracts/mocks/oracles/compound/CTokenMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "../ISourceMock.sol";
 
 contract CTokenMock is ISourceMock {

--- a/packages/foundry/contracts/mocks/oracles/compound/CTokenRateMock.sol
+++ b/packages/foundry/contracts/mocks/oracles/compound/CTokenRateMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "../ISourceMock.sol";
 
 

--- a/packages/foundry/contracts/mocks/oracles/convex/CurvePoolMock.sol
+++ b/packages/foundry/contracts/mocks/oracles/convex/CurvePoolMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 interface ICurvePool {
     function get_virtual_price() external view returns (uint256 price);

--- a/packages/foundry/contracts/mocks/oracles/lido/WstETHMock.sol
+++ b/packages/foundry/contracts/mocks/oracles/lido/WstETHMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "../ISourceMock.sol";
 import "../../ERC20Mock.sol";
 

--- a/packages/foundry/contracts/mocks/oracles/uniswap/UniswapV2PairMock.sol
+++ b/packages/foundry/contracts/mocks/oracles/uniswap/UniswapV2PairMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 contract UniswapV2PairMock {
     uint112 public reserves0;

--- a/packages/foundry/contracts/mocks/oracles/uniswap/UniswapV3FactoryMock.sol
+++ b/packages/foundry/contracts/mocks/oracles/uniswap/UniswapV3FactoryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "./UniswapV3PoolMock.sol";
 

--- a/packages/foundry/contracts/mocks/oracles/uniswap/UniswapV3OracleLibraryMock.sol
+++ b/packages/foundry/contracts/mocks/oracles/uniswap/UniswapV3OracleLibraryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
 import "@yield-protocol/utils-v2/contracts/math/WDiv.sol";

--- a/packages/foundry/contracts/mocks/oracles/uniswap/UniswapV3PoolMock.sol
+++ b/packages/foundry/contracts/mocks/oracles/uniswap/UniswapV3PoolMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "../ISourceMock.sol";
 import "../../../oracles/uniswap/IUniswapV3PoolImmutables.sol";

--- a/packages/foundry/contracts/modules/HealerModule.sol
+++ b/packages/foundry/contracts/modules/HealerModule.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
-import "@yield-protocol/vault-interfaces/src/ICauldron.sol";
-import "@yield-protocol/vault-interfaces/src/ILadle.sol";
+import "../interfaces/ICauldron.sol";
+import "../interfaces/ILadle.sol";
 import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastU256I128.sol";
 import "../LadleStorage.sol";

--- a/packages/foundry/contracts/modules/TLMModule.sol
+++ b/packages/foundry/contracts/modules/TLMModule.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
-import "@yield-protocol/vault-interfaces/src/ICauldron.sol";
-import "@yield-protocol/vault-interfaces/src/IFYToken.sol";
-import "@yield-protocol/vault-interfaces/src/DataTypes.sol";
+pragma solidity >=0.8.13;
+import "../interfaces/ICauldron.sol";
+import "../interfaces/IFYToken.sol";
+import "../interfaces/DataTypes.sol";
 import "../LadleStorage.sol";
 
 

--- a/packages/foundry/contracts/oracles/accumulator/AccumulatorMultiOracle.sol
+++ b/packages/foundry/contracts/oracles/accumulator/AccumulatorMultiOracle.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
 import "@yield-protocol/utils-v2/contracts/math/WPow.sol";
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import "../../interfaces/IOracle.sol";
 
 import "../../constants/Constants.sol";
 

--- a/packages/foundry/contracts/oracles/chainlink/ChainlinkL2USDMultiOracle.sol
+++ b/packages/foundry/contracts/oracles/chainlink/ChainlinkL2USDMultiOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import './ChainlinkUSDMultiOracle.sol';
 

--- a/packages/foundry/contracts/oracles/chainlink/ChainlinkMultiOracle.sol
+++ b/packages/foundry/contracts/oracles/chainlink/ChainlinkMultiOracle.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC20Metadata.sol";
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import "../../interfaces/IOracle.sol";
 import "../../constants/Constants.sol";
 import "./AggregatorV3Interface.sol";
 

--- a/packages/foundry/contracts/oracles/chainlink/ChainlinkUSDMultiOracle.sol
+++ b/packages/foundry/contracts/oracles/chainlink/ChainlinkUSDMultiOracle.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import '@yield-protocol/utils-v2/contracts/access/AccessControl.sol';
 import '@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol';
 import '@yield-protocol/utils-v2/contracts/token/IERC20Metadata.sol';
-import '@yield-protocol/vault-interfaces/src/IOracle.sol';
+import '../../interfaces/IOracle.sol';
 import '../../constants/Constants.sol';
 import './AggregatorV3Interface.sol';
 import './FlagsInterface.sol';

--- a/packages/foundry/contracts/oracles/composite/CompositeMultiOracle.sol
+++ b/packages/foundry/contracts/oracles/composite/CompositeMultiOracle.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import "../../interfaces/IOracle.sol";
 
 /**
  * @title CompositeMultiOracle

--- a/packages/foundry/contracts/oracles/compound/CTokenMultiOracle.sol
+++ b/packages/foundry/contracts/oracles/compound/CTokenMultiOracle.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC20Metadata.sol";
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import "../../interfaces/IOracle.sol";
 import "../../constants/Constants.sol";
 import "./CTokenInterface.sol";
 

--- a/packages/foundry/contracts/oracles/compound/CompoundMultiOracle.sol
+++ b/packages/foundry/contracts/oracles/compound/CompoundMultiOracle.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import "../../interfaces/IOracle.sol";
 import "../../constants/Constants.sol";
 import "./CTokenInterface.sol";
 

--- a/packages/foundry/contracts/oracles/convex/Cvx3CrvOracle.sol
+++ b/packages/foundry/contracts/oracles/convex/Cvx3CrvOracle.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import "../../interfaces/IOracle.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
 
 import "./ICurvePool.sol";

--- a/packages/foundry/contracts/oracles/convex/ICurvePool.sol
+++ b/packages/foundry/contracts/oracles/convex/ICurvePool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 interface ICurvePool {
     function get_virtual_price() external view returns (uint256 price);

--- a/packages/foundry/contracts/oracles/euler/ETokenMultiOracle.sol
+++ b/packages/foundry/contracts/oracles/euler/ETokenMultiOracle.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
-import {IOracle} from "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import {IOracle} from "../../interfaces/IOracle.sol";
 import {CastBytes32Bytes6} from "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
 import {IEToken} from "./IEToken.sol";
 import {AccessControl} from "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";

--- a/packages/foundry/contracts/oracles/lido/LidoOracle.sol
+++ b/packages/foundry/contracts/oracles/lido/LidoOracle.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC20Metadata.sol";
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import "../../interfaces/IOracle.sol";
 import "./IWstETH.sol";
 
 /**

--- a/packages/foundry/contracts/oracles/uniswap/UniswapV3Oracle.sol
+++ b/packages/foundry/contracts/oracles/uniswap/UniswapV3Oracle.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import "../../interfaces/IOracle.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastU256U128.sol";
-import "uniswapv3-oracle/contracts/uniswapv0.8/OracleLibrary.sol";
-import "uniswapv3-oracle/contracts/uniswapv0.8/pool/IUniswapV3PoolImmutables.sol";
+import "./uniswapv0.8/OracleLibrary.sol";
+import "./uniswapv0.8/pool/IUniswapV3PoolImmutables.sol";
 
 /**
  * @title UniswapV3Oracle

--- a/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/FullMath.sol
+++ b/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/FullMath.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.0;
+
+/// @title Contains 512-bit math functions
+/// @notice Facilitates multiplication and division that can have overflow of an intermediate value without any loss of precision
+/// @dev Handles "phantom overflow" i.e., allows multiplication and division where an intermediate value overflows 256 bits
+library FullMath {
+    /// @notice Calculates floor(a×b÷denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
+    /// @param a The multiplicand
+    /// @param b The multiplier
+    /// @param denominator The divisor
+    /// @return result The 256-bit result
+    /// @dev Credit to Remco Bloemen under MIT license https://xn--2-umb.com/21/muldiv
+    function mulDiv(
+        uint256 a,
+        uint256 b,
+        uint256 denominator
+    ) internal pure returns (uint256 result) {
+        // 512-bit multiply [prod1 prod0] = a * b
+        // Compute the product mod 2**256 and mod 2**256 - 1
+        // then use the Chinese Remainder Theorem to reconstruct
+        // the 512 bit result. The result is stored in two 256
+        // variables such that product = prod1 * 2**256 + prod0
+        uint256 prod0; // Least significant 256 bits of the product
+        uint256 prod1; // Most significant 256 bits of the product
+        assembly {
+            let mm := mulmod(a, b, not(0))
+            prod0 := mul(a, b)
+            prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+        }
+
+        // Handle non-overflow cases, 256 by 256 division
+        if (prod1 == 0) {
+            require(denominator > 0);
+            assembly {
+                result := div(prod0, denominator)
+            }
+            return result;
+        }
+
+        // Make sure the result is less than 2**256.
+        // Also prevents denominator == 0
+        require(denominator > prod1);
+
+        ///////////////////////////////////////////////
+        // 512 by 256 division.
+        ///////////////////////////////////////////////
+
+        // Make division exact by subtracting the remainder from [prod1 prod0]
+        // Compute remainder using mulmod
+        uint256 remainder;
+        assembly {
+            remainder := mulmod(a, b, denominator)
+        }
+        // Subtract 256 bit number from 512 bit number
+        assembly {
+            prod1 := sub(prod1, gt(remainder, prod0))
+            prod0 := sub(prod0, remainder)
+        }
+
+        // Factor powers of two out of denominator
+        // Compute largest power of two divisor of denominator.
+        // Always >= 1.
+        uint256 twos = (~denominator + 1) & denominator;
+        // Divide denominator by power of two
+        assembly {
+            denominator := div(denominator, twos)
+        }
+
+        // Divide [prod1 prod0] by the factors of two
+        assembly {
+            prod0 := div(prod0, twos)
+        }
+        // Shift in bits from prod1 into prod0. For this we need
+        // to flip `twos` such that it is 2**256 / twos.
+        // If twos is zero, then it becomes one
+        assembly {
+            twos := add(div(sub(0, twos), twos), 1)
+        }
+        prod0 |= prod1 * twos;
+
+        // Invert denominator mod 2**256
+        // Now that denominator is an odd number, it has an inverse
+        // modulo 2**256 such that denominator * inv = 1 mod 2**256.
+        // Compute the inverse by starting with a seed that is correct
+        // correct for four bits. That is, denominator * inv = 1 mod 2**4
+        uint256 inv = (3 * denominator) ^ 2;
+        // Now use Newton-Raphson iteration to improve the precision.
+        // Thanks to Hensel's lifting lemma, this also works in modular
+        // arithmetic, doubling the correct bits in each step.
+        inv *= 2 - denominator * inv; // inverse mod 2**8
+        inv *= 2 - denominator * inv; // inverse mod 2**16
+        inv *= 2 - denominator * inv; // inverse mod 2**32
+        inv *= 2 - denominator * inv; // inverse mod 2**64
+        inv *= 2 - denominator * inv; // inverse mod 2**128
+        inv *= 2 - denominator * inv; // inverse mod 2**256
+
+        // Because the division is now exact we can divide by multiplying
+        // with the modular inverse of denominator. This will give us the
+        // correct result modulo 2**256. Since the precoditions guarantee
+        // that the outcome is less than 2**256, this is the final result.
+        // We don't need to compute the high bits of the result and prod1
+        // is no longer required.
+        result = prod0 * inv;
+        return result;
+    }
+
+    /// @notice Calculates ceil(a×b÷denominator) with full precision. Throws if result overflows a uint256 or denominator == 0
+    /// @param a The multiplicand
+    /// @param b The multiplier
+    /// @param denominator The divisor
+    /// @return result The 256-bit result
+    function mulDivRoundingUp(
+        uint256 a,
+        uint256 b,
+        uint256 denominator
+    ) internal pure returns (uint256 result) {
+        result = mulDiv(a, b, denominator);
+        if (mulmod(a, b, denominator) > 0) {
+            require(result < type(uint256).max);
+            result++;
+        }
+    }
+}

--- a/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/IUniswapV3Pool.sol
+++ b/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/IUniswapV3Pool.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+import './pool/IUniswapV3PoolImmutables.sol';
+import './pool/IUniswapV3PoolState.sol';
+import './pool/IUniswapV3PoolDerivedState.sol';
+import './pool/IUniswapV3PoolActions.sol';
+import './pool/IUniswapV3PoolOwnerActions.sol';
+import './pool/IUniswapV3PoolEvents.sol';
+
+/// @title The interface for a Uniswap V3 Pool
+/// @notice A Uniswap pool facilitates swapping and automated market making between any two assets that strictly conform
+/// to the ERC20 specification
+/// @dev The pool interface is broken up into many smaller pieces
+interface IUniswapV3Pool is
+    IUniswapV3PoolImmutables,
+    IUniswapV3PoolState,
+    IUniswapV3PoolDerivedState,
+    IUniswapV3PoolActions,
+    IUniswapV3PoolOwnerActions,
+    IUniswapV3PoolEvents
+{
+
+}

--- a/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/LowGasSafeMath.sol
+++ b/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/LowGasSafeMath.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.0;
+
+/// @title Optimized overflow and underflow safe math operations
+/// @notice Contains methods for doing math operations that revert on overflow or underflow for minimal gas cost
+library LowGasSafeMath {
+    /// @notice Returns x + y, reverts if sum overflows uint256
+    /// @param x The augend
+    /// @param y The addend
+    /// @return z The sum of x and y
+    function add(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x + y) >= x);
+    }
+
+    /// @notice Returns x - y, reverts if underflows
+    /// @param x The minuend
+    /// @param y The subtrahend
+    /// @return z The difference of x and y
+    function sub(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require((z = x - y) <= x);
+    }
+
+    /// @notice Returns x * y, reverts if overflows
+    /// @param x The multiplicand
+    /// @param y The multiplier
+    /// @return z The product of x and y
+    function mul(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        require(x == 0 || (z = x * y) / x == y);
+    }
+
+    /// @notice Returns x + y, reverts if overflows or underflows
+    /// @param x The augend
+    /// @param y The addend
+    /// @return z The sum of x and y
+    function add(int256 x, int256 y) internal pure returns (int256 z) {
+        require((z = x + y) >= x == (y >= 0));
+    }
+
+    /// @notice Returns x - y, reverts if overflows or underflows
+    /// @param x The minuend
+    /// @param y The subtrahend
+    /// @return z The difference of x and y
+    function sub(int256 x, int256 y) internal pure returns (int256 z) {
+        require((z = x - y) <= x == (y >= 0));
+    }
+}

--- a/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/OracleLibrary.sol
+++ b/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/OracleLibrary.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+import "./FullMath.sol";
+import "./TickMath.sol";
+import "./IUniswapV3Pool.sol";
+import "./LowGasSafeMath.sol";
+import "./PoolAddress.sol";
+
+/// @title Oracle library
+/// @notice Provides functions to integrate with V3 pool oracle
+library OracleLibrary {
+    /// @notice Fetches time-weighted average tick using Uniswap V3 oracle
+    /// @param pool Address of Uniswap V3 pool that we want to observe
+    /// @param period Number of seconds in the past to start calculating time-weighted average
+    /// @return timeWeightedAverageTick The time-weighted average tick from (block.timestamp - period) to block.timestamp
+    function consult(address pool, uint32 period)
+        internal
+        view
+        returns (int24 timeWeightedAverageTick)
+    {
+        require(period != 0, "BP");
+
+        uint32[] memory secondAgos = new uint32[](2);
+        secondAgos[0] = period;
+        secondAgos[1] = 0;
+
+        (int56[] memory tickCumulatives, ) = IUniswapV3Pool(pool).observe(
+            secondAgos
+        );
+        int56 tickCumulativesDelta = tickCumulatives[1] - tickCumulatives[0];
+
+        timeWeightedAverageTick = int24(
+            tickCumulativesDelta / int56(uint56(period))
+        );
+
+        // Always round to negative infinity
+        if (
+            tickCumulativesDelta < 0 &&
+            (tickCumulativesDelta % int56(uint56(period)) != 0)
+        ) timeWeightedAverageTick--;
+    }
+
+    /// @notice Given a tick and a token amount, calculates the amount of token received in exchange
+    /// @param tick Tick value used to calculate the quote
+    /// @param baseAmount Amount of token to be converted
+    /// @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
+    /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
+    /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
+    function getQuoteAtTick(
+        int24 tick,
+        uint128 baseAmount,
+        address baseToken,
+        address quoteToken
+    ) internal pure returns (uint256 quoteAmount) {
+        uint160 sqrtRatioX96 = TickMath.getSqrtRatioAtTick(tick);
+
+        // Calculate quoteAmount with better precision if it doesn't overflow when multiplied by itself
+        if (sqrtRatioX96 <= type(uint128).max) {
+            uint256 ratioX192 = uint256(sqrtRatioX96) * sqrtRatioX96;
+            quoteAmount = baseToken < quoteToken
+                ? FullMath.mulDiv(ratioX192, baseAmount, 1 << 192)
+                : FullMath.mulDiv(1 << 192, baseAmount, ratioX192);
+        } else {
+            uint256 ratioX128 = FullMath.mulDiv(
+                sqrtRatioX96,
+                sqrtRatioX96,
+                1 << 64
+            );
+            quoteAmount = baseToken < quoteToken
+                ? FullMath.mulDiv(ratioX128, baseAmount, 1 << 128)
+                : FullMath.mulDiv(1 << 128, baseAmount, ratioX128);
+        }
+    }
+}

--- a/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/PoolAddress.sol
+++ b/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/PoolAddress.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Provides functions for deriving a pool address from the factory, tokens, and the fee
+library PoolAddress {
+    bytes32 internal constant POOL_INIT_CODE_HASH = 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54;
+
+    /// @notice The identifying key of the pool
+    struct PoolKey {
+        address token0;
+        address token1;
+        uint24 fee;
+    }
+
+    /// @notice Returns PoolKey: the ordered tokens with the matched fee levels
+    /// @param tokenA The first token of a pool, unsorted
+    /// @param tokenB The second token of a pool, unsorted
+    /// @param fee The fee level of the pool
+    /// @return Poolkey The pool details with ordered token0 and token1 assignments
+    function getPoolKey(
+        address tokenA,
+        address tokenB,
+        uint24 fee
+    ) internal pure returns (PoolKey memory) {
+        if (tokenA > tokenB) (tokenA, tokenB) = (tokenB, tokenA);
+        return PoolKey({token0: tokenA, token1: tokenB, fee: fee});
+    }
+
+    /// @notice Deterministically computes the pool address given the factory and PoolKey
+    /// @param factory The Uniswap V3 factory contract address
+    /// @param key The PoolKey
+    /// @return pool The contract address of the V3 pool
+    function computeAddress(address factory, PoolKey memory key) internal pure returns (address pool) {
+        require(key.token0 < key.token1);
+        pool = address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            hex'ff',
+                            factory,
+                            keccak256(abi.encode(key.token0, key.token1, key.fee)),
+                            POOL_INIT_CODE_HASH
+                        )
+                    )
+                )
+            )
+        );
+    }
+}

--- a/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/TickMath.sol
+++ b/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/TickMath.sol
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Math library for computing sqrt prices from ticks and vice versa
+/// @notice Computes sqrt price for ticks of size 1.0001, i.e. sqrt(1.0001^tick) as fixed point Q64.96 numbers. Supports
+/// prices between 2**-128 and 2**128
+library TickMath {
+    /// @dev The minimum tick that may be passed to #getSqrtRatioAtTick computed from log base 1.0001 of 2**-128
+    int24 internal constant MIN_TICK = -887272;
+    /// @dev The maximum tick that may be passed to #getSqrtRatioAtTick computed from log base 1.0001 of 2**128
+    int24 internal constant MAX_TICK = -MIN_TICK;
+
+    /// @dev The minimum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MIN_TICK)
+    uint160 internal constant MIN_SQRT_RATIO = 4295128739;
+    /// @dev The maximum value that can be returned from #getSqrtRatioAtTick. Equivalent to getSqrtRatioAtTick(MAX_TICK)
+    uint160 internal constant MAX_SQRT_RATIO = 1461446703485210103287273052203988822378723970342;
+
+    /// @notice Calculates sqrt(1.0001^tick) * 2^96
+    /// @dev Throws if |tick| > max tick
+    /// @param tick The input tick for the above formula
+    /// @return sqrtPriceX96 A Fixed point Q64.96 number representing the sqrt of the ratio of the two assets (token1/token0)
+    /// at the given tick
+    function getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtPriceX96) {
+        uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
+        require(absTick <= uint256(uint24(MAX_TICK)), 'T');
+
+        uint256 ratio = absTick & 0x1 != 0 ? 0xfffcb933bd6fad37aa2d162d1a594001 : 0x100000000000000000000000000000000;
+        if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;
+        if (absTick & 0x4 != 0) ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdcc) >> 128;
+        if (absTick & 0x8 != 0) ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0) >> 128;
+        if (absTick & 0x10 != 0) ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644) >> 128;
+        if (absTick & 0x20 != 0) ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0) >> 128;
+        if (absTick & 0x40 != 0) ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861) >> 128;
+        if (absTick & 0x80 != 0) ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053) >> 128;
+        if (absTick & 0x100 != 0) ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4) >> 128;
+        if (absTick & 0x200 != 0) ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54) >> 128;
+        if (absTick & 0x400 != 0) ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3) >> 128;
+        if (absTick & 0x800 != 0) ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9) >> 128;
+        if (absTick & 0x1000 != 0) ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825) >> 128;
+        if (absTick & 0x2000 != 0) ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5) >> 128;
+        if (absTick & 0x4000 != 0) ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7) >> 128;
+        if (absTick & 0x8000 != 0) ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6) >> 128;
+        if (absTick & 0x10000 != 0) ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9) >> 128;
+        if (absTick & 0x20000 != 0) ratio = (ratio * 0x5d6af8dedb81196699c329225ee604) >> 128;
+        if (absTick & 0x40000 != 0) ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98) >> 128;
+        if (absTick & 0x80000 != 0) ratio = (ratio * 0x48a170391f7dc42444e8fa2) >> 128;
+
+        if (tick > 0) ratio = type(uint256).max / ratio;
+
+        // this divides by 1<<32 rounding up to go from a Q128.128 to a Q128.96.
+        // we then downcast because we know the result always fits within 160 bits due to our tick input constraint
+        // we round up in the division so getTickAtSqrtRatio of the output price is always consistent
+        sqrtPriceX96 = uint160((ratio >> 32) + (ratio % (1 << 32) == 0 ? 0 : 1));
+    }
+
+    /// @notice Calculates the greatest tick value such that getRatioAtTick(tick) <= ratio
+    /// @dev Throws in case sqrtPriceX96 < MIN_SQRT_RATIO, as MIN_SQRT_RATIO is the lowest value getRatioAtTick may
+    /// ever return.
+    /// @param sqrtPriceX96 The sqrt ratio for which to compute the tick as a Q64.96
+    /// @return tick The greatest tick for which the ratio is less than or equal to the input ratio
+    function getTickAtSqrtRatio(uint160 sqrtPriceX96) internal pure returns (int24 tick) {
+        // second inequality must be < because the price can never reach the price at the max tick
+        require(sqrtPriceX96 >= MIN_SQRT_RATIO && sqrtPriceX96 < MAX_SQRT_RATIO, 'R');
+        uint256 ratio = uint256(sqrtPriceX96) << 32;
+
+        uint256 r = ratio;
+        uint256 msb = 0;
+
+        assembly {
+            let f := shl(7, gt(r, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := shl(6, gt(r, 0xFFFFFFFFFFFFFFFF))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := shl(5, gt(r, 0xFFFFFFFF))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := shl(4, gt(r, 0xFFFF))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := shl(3, gt(r, 0xFF))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := shl(2, gt(r, 0xF))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := shl(1, gt(r, 0x3))
+            msb := or(msb, f)
+            r := shr(f, r)
+        }
+        assembly {
+            let f := gt(r, 0x1)
+            msb := or(msb, f)
+        }
+
+        if (msb >= 128) r = ratio >> (msb - 127);
+        else r = ratio << (127 - msb);
+
+        int256 log_2 = (int256(msb) - 128) << 64;
+
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(63, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(62, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(61, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(60, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(59, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(58, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(57, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(56, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(55, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(54, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(53, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(52, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(51, f))
+            r := shr(f, r)
+        }
+        assembly {
+            r := shr(127, mul(r, r))
+            let f := shr(128, r)
+            log_2 := or(log_2, shl(50, f))
+        }
+
+        int256 log_sqrt10001 = log_2 * 255738958999603826347141; // 128.128 number
+
+        int24 tickLow = int24((log_sqrt10001 - 3402992956809132418596140100660247210) >> 128);
+        int24 tickHi = int24((log_sqrt10001 + 291339464771989622907027621153398088495) >> 128);
+
+        tick = tickLow == tickHi ? tickLow : getSqrtRatioAtTick(tickHi) <= sqrtPriceX96 ? tickHi : tickLow;
+    }
+}

--- a/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/pool/IUniswapV3PoolActions.sol
+++ b/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/pool/IUniswapV3PoolActions.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Permissionless pool actions
+/// @notice Contains pool methods that can be called by anyone
+interface IUniswapV3PoolActions {
+    /// @notice Sets the initial price for the pool
+    /// @dev Price is represented as a sqrt(amountToken1/amountToken0) Q64.96 value
+    /// @param sqrtPriceX96 the initial sqrt price of the pool as a Q64.96
+    function initialize(uint160 sqrtPriceX96) external;
+
+    /// @notice Adds liquidity for the given recipient/tickLower/tickUpper position
+    /// @dev The caller of this method receives a callback in the form of IUniswapV3MintCallback#uniswapV3MintCallback
+    /// in which they must pay any token0 or token1 owed for the liquidity. The amount of token0/token1 due depends
+    /// on tickLower, tickUpper, the amount of liquidity, and the current price.
+    /// @param recipient The address for which the liquidity will be created
+    /// @param tickLower The lower tick of the position in which to add liquidity
+    /// @param tickUpper The upper tick of the position in which to add liquidity
+    /// @param amount The amount of liquidity to mint
+    /// @param data Any data that should be passed through to the callback
+    /// @return amount0 The amount of token0 that was paid to mint the given amount of liquidity. Matches the value in the callback
+    /// @return amount1 The amount of token1 that was paid to mint the given amount of liquidity. Matches the value in the callback
+    function mint(
+        address recipient,
+        int24 tickLower,
+        int24 tickUpper,
+        uint128 amount,
+        bytes calldata data
+    ) external returns (uint256 amount0, uint256 amount1);
+
+    /// @notice Collects tokens owed to a position
+    /// @dev Does not recompute fees earned, which must be done either via mint or burn of any amount of liquidity.
+    /// Collect must be called by the position owner. To withdraw only token0 or only token1, amount0Requested or
+    /// amount1Requested may be set to zero. To withdraw all tokens owed, caller may pass any value greater than the
+    /// actual tokens owed, e.g. type(uint128).max. Tokens owed may be from accumulated swap fees or burned liquidity.
+    /// @param recipient The address which should receive the fees collected
+    /// @param tickLower The lower tick of the position for which to collect fees
+    /// @param tickUpper The upper tick of the position for which to collect fees
+    /// @param amount0Requested How much token0 should be withdrawn from the fees owed
+    /// @param amount1Requested How much token1 should be withdrawn from the fees owed
+    /// @return amount0 The amount of fees collected in token0
+    /// @return amount1 The amount of fees collected in token1
+    function collect(
+        address recipient,
+        int24 tickLower,
+        int24 tickUpper,
+        uint128 amount0Requested,
+        uint128 amount1Requested
+    ) external returns (uint128 amount0, uint128 amount1);
+
+    /// @notice Burn liquidity from the sender and account tokens owed for the liquidity to the position
+    /// @dev Can be used to trigger a recalculation of fees owed to a position by calling with an amount of 0
+    /// @dev Fees must be collected separately via a call to #collect
+    /// @param tickLower The lower tick of the position for which to burn liquidity
+    /// @param tickUpper The upper tick of the position for which to burn liquidity
+    /// @param amount How much liquidity to burn
+    /// @return amount0 The amount of token0 sent to the recipient
+    /// @return amount1 The amount of token1 sent to the recipient
+    function burn(
+        int24 tickLower,
+        int24 tickUpper,
+        uint128 amount
+    ) external returns (uint256 amount0, uint256 amount1);
+
+    /// @notice Swap token0 for token1, or token1 for token0
+    /// @dev The caller of this method receives a callback in the form of IUniswapV3SwapCallback#uniswapV3SwapCallback
+    /// @param recipient The address to receive the output of the swap
+    /// @param zeroForOne The direction of the swap, true for token0 to token1, false for token1 to token0
+    /// @param amountSpecified The amount of the swap, which implicitly configures the swap as exact input (positive), or exact output (negative)
+    /// @param sqrtPriceLimitX96 The Q64.96 sqrt price limit. If zero for one, the price cannot be less than this
+    /// value after the swap. If one for zero, the price cannot be greater than this value after the swap
+    /// @param data Any data to be passed through to the callback
+    /// @return amount0 The delta of the balance of token0 of the pool, exact when negative, minimum when positive
+    /// @return amount1 The delta of the balance of token1 of the pool, exact when negative, minimum when positive
+    function swap(
+        address recipient,
+        bool zeroForOne,
+        int256 amountSpecified,
+        uint160 sqrtPriceLimitX96,
+        bytes calldata data
+    ) external returns (int256 amount0, int256 amount1);
+
+    /// @notice Receive token0 and/or token1 and pay it back, plus a fee, in the callback
+    /// @dev The caller of this method receives a callback in the form of IUniswapV3FlashCallback#uniswapV3FlashCallback
+    /// @dev Can be used to donate underlying tokens pro-rata to currently in-range liquidity providers by calling
+    /// with 0 amount{0,1} and sending the donation amount(s) from the callback
+    /// @param recipient The address which will receive the token0 and token1 amounts
+    /// @param amount0 The amount of token0 to send
+    /// @param amount1 The amount of token1 to send
+    /// @param data Any data to be passed through to the callback
+    function flash(
+        address recipient,
+        uint256 amount0,
+        uint256 amount1,
+        bytes calldata data
+    ) external;
+
+    /// @notice Increase the maximum number of price and liquidity observations that this pool will store
+    /// @dev This method is no-op if the pool already has an observationCardinalityNext greater than or equal to
+    /// the input observationCardinalityNext.
+    /// @param observationCardinalityNext The desired minimum number of observations for the pool to store
+    function increaseObservationCardinalityNext(uint16 observationCardinalityNext) external;
+}

--- a/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/pool/IUniswapV3PoolDerivedState.sol
+++ b/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/pool/IUniswapV3PoolDerivedState.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Pool state that is not stored
+/// @notice Contains view functions to provide information about the pool that is computed rather than stored on the
+/// blockchain. The functions here may have variable gas costs.
+interface IUniswapV3PoolDerivedState {
+    /// @notice Returns the cumulative tick and liquidity as of each timestamp `secondsAgo` from the current block timestamp
+    /// @dev To get a time weighted average tick or liquidity-in-range, you must call this with two values, one representing
+    /// the beginning of the period and another for the end of the period. E.g., to get the last hour time-weighted average tick,
+    /// you must call it with secondsAgos = [3600, 0].
+    /// @dev The time weighted average tick represents the geometric time weighted average price of the pool, in
+    /// log base sqrt(1.0001) of token1 / token0. The TickMath library can be used to go from a tick value to a ratio.
+    /// @param secondsAgos From how long ago each cumulative tick and liquidity value should be returned
+    /// @return tickCumulatives Cumulative tick values as of each `secondsAgos` from the current block timestamp
+    /// @return secondsPerLiquidityCumulativeX128s Cumulative seconds per liquidity-in-range value as of each `secondsAgos` from the current block
+    /// timestamp
+    function observe(uint32[] calldata secondsAgos)
+        external
+        view
+        returns (int56[] memory tickCumulatives, uint160[] memory secondsPerLiquidityCumulativeX128s);
+
+    /// @notice Returns a snapshot of the tick cumulative, seconds per liquidity and seconds inside a tick range
+    /// @dev Snapshots must only be compared to other snapshots, taken over a period for which a position existed.
+    /// I.e., snapshots cannot be compared if a position is not held for the entire period between when the first
+    /// snapshot is taken and the second snapshot is taken.
+    /// @param tickLower The lower tick of the range
+    /// @param tickUpper The upper tick of the range
+    /// @return tickCumulativeInside The snapshot of the tick accumulator for the range
+    /// @return secondsPerLiquidityInsideX128 The snapshot of seconds per liquidity for the range
+    /// @return secondsInside The snapshot of seconds per liquidity for the range
+    function snapshotCumulativesInside(int24 tickLower, int24 tickUpper)
+        external
+        view
+        returns (
+            int56 tickCumulativeInside,
+            uint160 secondsPerLiquidityInsideX128,
+            uint32 secondsInside
+        );
+}

--- a/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/pool/IUniswapV3PoolEvents.sol
+++ b/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/pool/IUniswapV3PoolEvents.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Events emitted by a pool
+/// @notice Contains all events emitted by the pool
+interface IUniswapV3PoolEvents {
+    /// @notice Emitted exactly once by a pool when #initialize is first called on the pool
+    /// @dev Mint/Burn/Swap cannot be emitted by the pool before Initialize
+    /// @param sqrtPriceX96 The initial sqrt price of the pool, as a Q64.96
+    /// @param tick The initial tick of the pool, i.e. log base 1.0001 of the starting price of the pool
+    event Initialize(uint160 sqrtPriceX96, int24 tick);
+
+    /// @notice Emitted when liquidity is minted for a given position
+    /// @param sender The address that minted the liquidity
+    /// @param owner The owner of the position and recipient of any minted liquidity
+    /// @param tickLower The lower tick of the position
+    /// @param tickUpper The upper tick of the position
+    /// @param amount The amount of liquidity minted to the position range
+    /// @param amount0 How much token0 was required for the minted liquidity
+    /// @param amount1 How much token1 was required for the minted liquidity
+    event Mint(
+        address sender,
+        address indexed owner,
+        int24 indexed tickLower,
+        int24 indexed tickUpper,
+        uint128 amount,
+        uint256 amount0,
+        uint256 amount1
+    );
+
+    /// @notice Emitted when fees are collected by the owner of a position
+    /// @dev Collect events may be emitted with zero amount0 and amount1 when the caller chooses not to collect fees
+    /// @param owner The owner of the position for which fees are collected
+    /// @param tickLower The lower tick of the position
+    /// @param tickUpper The upper tick of the position
+    /// @param amount0 The amount of token0 fees collected
+    /// @param amount1 The amount of token1 fees collected
+    event Collect(
+        address indexed owner,
+        address recipient,
+        int24 indexed tickLower,
+        int24 indexed tickUpper,
+        uint128 amount0,
+        uint128 amount1
+    );
+
+    /// @notice Emitted when a position's liquidity is removed
+    /// @dev Does not withdraw any fees earned by the liquidity position, which must be withdrawn via #collect
+    /// @param owner The owner of the position for which liquidity is removed
+    /// @param tickLower The lower tick of the position
+    /// @param tickUpper The upper tick of the position
+    /// @param amount The amount of liquidity to remove
+    /// @param amount0 The amount of token0 withdrawn
+    /// @param amount1 The amount of token1 withdrawn
+    event Burn(
+        address indexed owner,
+        int24 indexed tickLower,
+        int24 indexed tickUpper,
+        uint128 amount,
+        uint256 amount0,
+        uint256 amount1
+    );
+
+    /// @notice Emitted by the pool for any swaps between token0 and token1
+    /// @param sender The address that initiated the swap call, and that received the callback
+    /// @param recipient The address that received the output of the swap
+    /// @param amount0 The delta of the token0 balance of the pool
+    /// @param amount1 The delta of the token1 balance of the pool
+    /// @param sqrtPriceX96 The sqrt(price) of the pool after the swap, as a Q64.96
+    /// @param liquidity The liquidity of the pool after the swap
+    /// @param tick The log base 1.0001 of price of the pool after the swap
+    event Swap(
+        address indexed sender,
+        address indexed recipient,
+        int256 amount0,
+        int256 amount1,
+        uint160 sqrtPriceX96,
+        uint128 liquidity,
+        int24 tick
+    );
+
+    /// @notice Emitted by the pool for any flashes of token0/token1
+    /// @param sender The address that initiated the swap call, and that received the callback
+    /// @param recipient The address that received the tokens from flash
+    /// @param amount0 The amount of token0 that was flashed
+    /// @param amount1 The amount of token1 that was flashed
+    /// @param paid0 The amount of token0 paid for the flash, which can exceed the amount0 plus the fee
+    /// @param paid1 The amount of token1 paid for the flash, which can exceed the amount1 plus the fee
+    event Flash(
+        address indexed sender,
+        address indexed recipient,
+        uint256 amount0,
+        uint256 amount1,
+        uint256 paid0,
+        uint256 paid1
+    );
+
+    /// @notice Emitted by the pool for increases to the number of observations that can be stored
+    /// @dev observationCardinalityNext is not the observation cardinality until an observation is written at the index
+    /// just before a mint/swap/burn.
+    /// @param observationCardinalityNextOld The previous value of the next observation cardinality
+    /// @param observationCardinalityNextNew The updated value of the next observation cardinality
+    event IncreaseObservationCardinalityNext(
+        uint16 observationCardinalityNextOld,
+        uint16 observationCardinalityNextNew
+    );
+
+    /// @notice Emitted when the protocol fee is changed by the pool
+    /// @param feeProtocol0Old The previous value of the token0 protocol fee
+    /// @param feeProtocol1Old The previous value of the token1 protocol fee
+    /// @param feeProtocol0New The updated value of the token0 protocol fee
+    /// @param feeProtocol1New The updated value of the token1 protocol fee
+    event SetFeeProtocol(uint8 feeProtocol0Old, uint8 feeProtocol1Old, uint8 feeProtocol0New, uint8 feeProtocol1New);
+
+    /// @notice Emitted when the collected protocol fees are withdrawn by the factory owner
+    /// @param sender The address that collects the protocol fees
+    /// @param recipient The address that receives the collected protocol fees
+    /// @param amount0 The amount of token0 protocol fees that is withdrawn
+    /// @param amount0 The amount of token1 protocol fees that is withdrawn
+    event CollectProtocol(address indexed sender, address indexed recipient, uint128 amount0, uint128 amount1);
+}

--- a/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/pool/IUniswapV3PoolImmutables.sol
+++ b/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/pool/IUniswapV3PoolImmutables.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Pool state that never changes
+/// @notice These parameters are fixed for a pool forever, i.e., the methods will always return the same values
+interface IUniswapV3PoolImmutables {
+    /// @notice The contract that deployed the pool, which must adhere to the IUniswapV3Factory interface
+    /// @return The contract address
+    function factory() external view returns (address);
+
+    /// @notice The first of the two tokens of the pool, sorted by address
+    /// @return The token contract address
+    function token0() external view returns (address);
+
+    /// @notice The second of the two tokens of the pool, sorted by address
+    /// @return The token contract address
+    function token1() external view returns (address);
+
+    /// @notice The pool's fee in hundredths of a bip, i.e. 1e-6
+    /// @return The fee
+    function fee() external view returns (uint24);
+
+    /// @notice The pool tick spacing
+    /// @dev Ticks can only be used at multiples of this value, minimum of 1 and always positive
+    /// e.g.: a tickSpacing of 3 means ticks can be initialized every 3rd tick, i.e., ..., -6, -3, 0, 3, 6, ...
+    /// This value is an int24 to avoid casting even though it is always positive.
+    /// @return The tick spacing
+    function tickSpacing() external view returns (int24);
+
+    /// @notice The maximum amount of position liquidity that can use any tick in the range
+    /// @dev This parameter is enforced per tick to prevent liquidity from overflowing a uint128 at any point, and
+    /// also prevents out-of-range liquidity from being used to prevent adding in-range liquidity to a pool
+    /// @return The max amount of liquidity per tick
+    function maxLiquidityPerTick() external view returns (uint128);
+}

--- a/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/pool/IUniswapV3PoolOwnerActions.sol
+++ b/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/pool/IUniswapV3PoolOwnerActions.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Permissioned pool actions
+/// @notice Contains pool methods that may only be called by the factory owner
+interface IUniswapV3PoolOwnerActions {
+    /// @notice Set the denominator of the protocol's % share of the fees
+    /// @param feeProtocol0 new protocol fee for token0 of the pool
+    /// @param feeProtocol1 new protocol fee for token1 of the pool
+    function setFeeProtocol(uint8 feeProtocol0, uint8 feeProtocol1) external;
+
+    /// @notice Collect the protocol fee accrued to the pool
+    /// @param recipient The address to which collected protocol fees should be sent
+    /// @param amount0Requested The maximum amount of token0 to send, can be 0 to collect fees in only token1
+    /// @param amount1Requested The maximum amount of token1 to send, can be 0 to collect fees in only token0
+    /// @return amount0 The protocol fee collected in token0
+    /// @return amount1 The protocol fee collected in token1
+    function collectProtocol(
+        address recipient,
+        uint128 amount0Requested,
+        uint128 amount1Requested
+    ) external returns (uint128 amount0, uint128 amount1);
+}

--- a/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/pool/IUniswapV3PoolState.sol
+++ b/packages/foundry/contracts/oracles/uniswap/uniswapv0.8/pool/IUniswapV3PoolState.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/// @title Pool state that can change
+/// @notice These methods compose the pool's state, and can change with any frequency including multiple times
+/// per transaction
+interface IUniswapV3PoolState {
+    /// @notice The 0th storage slot in the pool stores many values, and is exposed as a single method to save gas
+    /// when accessed externally.
+    /// @return sqrtPriceX96 The current price of the pool as a sqrt(token1/token0) Q64.96 value
+    /// tick The current tick of the pool, i.e. according to the last tick transition that was run.
+    /// This value may not always be equal to SqrtTickMath.getTickAtSqrtRatio(sqrtPriceX96) if the price is on a tick
+    /// boundary.
+    /// observationIndex The index of the last oracle observation that was written,
+    /// observationCardinality The current maximum number of observations stored in the pool,
+    /// observationCardinalityNext The next maximum number of observations, to be updated when the observation.
+    /// feeProtocol The protocol fee for both tokens of the pool.
+    /// Encoded as two 4 bit values, where the protocol fee of token1 is shifted 4 bits and the protocol fee of token0
+    /// is the lower 4 bits. Used as the denominator of a fraction of the swap fee, e.g. 4 means 1/4th of the swap fee.
+    /// unlocked Whether the pool is currently locked to reentrancy
+    function slot0()
+        external
+        view
+        returns (
+            uint160 sqrtPriceX96,
+            int24 tick,
+            uint16 observationIndex,
+            uint16 observationCardinality,
+            uint16 observationCardinalityNext,
+            uint8 feeProtocol,
+            bool unlocked
+        );
+
+    /// @notice The fee growth as a Q128.128 fees of token0 collected per unit of liquidity for the entire life of the pool
+    /// @dev This value can overflow the uint256
+    function feeGrowthGlobal0X128() external view returns (uint256);
+
+    /// @notice The fee growth as a Q128.128 fees of token1 collected per unit of liquidity for the entire life of the pool
+    /// @dev This value can overflow the uint256
+    function feeGrowthGlobal1X128() external view returns (uint256);
+
+    /// @notice The amounts of token0 and token1 that are owed to the protocol
+    /// @dev Protocol fees will never exceed uint128 max in either token
+    function protocolFees() external view returns (uint128 token0, uint128 token1);
+
+    /// @notice The currently in range liquidity available to the pool
+    /// @dev This value has no relationship to the total liquidity across all ticks
+    function liquidity() external view returns (uint128);
+
+    /// @notice Look up information about a specific tick in the pool
+    /// @param tick The tick to look up
+    /// @return liquidityGross the total amount of position liquidity that uses the pool either as tick lower or
+    /// tick upper,
+    /// liquidityNet how much liquidity changes when the pool price crosses the tick,
+    /// feeGrowthOutside0X128 the fee growth on the other side of the tick from the current tick in token0,
+    /// feeGrowthOutside1X128 the fee growth on the other side of the tick from the current tick in token1,
+    /// tickCumulativeOutside the cumulative tick value on the other side of the tick from the current tick
+    /// secondsPerLiquidityOutsideX128 the seconds spent per liquidity on the other side of the tick from the current tick,
+    /// secondsOutside the seconds spent on the other side of the tick from the current tick,
+    /// initialized Set to true if the tick is initialized, i.e. liquidityGross is greater than 0, otherwise equal to false.
+    /// Outside values can only be used if the tick is initialized, i.e. if liquidityGross is greater than 0.
+    /// In addition, these values are only relative and must be used only in comparison to previous snapshots for
+    /// a specific position.
+    function ticks(int24 tick)
+        external
+        view
+        returns (
+            uint128 liquidityGross,
+            int128 liquidityNet,
+            uint256 feeGrowthOutside0X128,
+            uint256 feeGrowthOutside1X128,
+            int56 tickCumulativeOutside,
+            uint160 secondsPerLiquidityOutsideX128,
+            uint32 secondsOutside,
+            bool initialized
+        );
+
+    /// @notice Returns 256 packed tick initialized boolean values. See TickBitmap for more information
+    function tickBitmap(int16 wordPosition) external view returns (uint256);
+
+    /// @notice Returns the information about a position by the position's key
+    /// @param key The position's key is a hash of a preimage composed by the owner, tickLower and tickUpper
+    /// @return _liquidity The amount of liquidity in the position,
+    /// Returns feeGrowthInside0LastX128 fee growth of token0 inside the tick range as of the last mint/burn/poke,
+    /// Returns feeGrowthInside1LastX128 fee growth of token1 inside the tick range as of the last mint/burn/poke,
+    /// Returns tokensOwed0 the computed amount of token0 owed to the position as of the last mint/burn/poke,
+    /// Returns tokensOwed1 the computed amount of token1 owed to the position as of the last mint/burn/poke
+    function positions(bytes32 key)
+        external
+        view
+        returns (
+            uint128 _liquidity,
+            uint256 feeGrowthInside0LastX128,
+            uint256 feeGrowthInside1LastX128,
+            uint128 tokensOwed0,
+            uint128 tokensOwed1
+        );
+
+    /// @notice Returns data about a specific observation index
+    /// @param index The element of the observations array to fetch
+    /// @dev You most likely want to use #observe() instead of this method to get an observation as of some amount of time
+    /// ago, rather than at a specific index in the array.
+    /// @return blockTimestamp The timestamp of the observation,
+    /// Returns tickCumulative the tick multiplied by seconds elapsed for the life of the pool as of the observation timestamp,
+    /// Returns secondsPerLiquidityCumulativeX128 the seconds per in range liquidity for the life of the pool as of the observation timestamp,
+    /// Returns initialized whether the observation has been initialized and the values are safe to use
+    function observations(uint256 index)
+        external
+        view
+        returns (
+            uint32 blockTimestamp,
+            int56 tickCumulative,
+            uint160 secondsPerLiquidityCumulativeX128,
+            bool initialized
+        );
+}

--- a/packages/foundry/contracts/oracles/yearn/YearnVaultMultiOracle.sol
+++ b/packages/foundry/contracts/oracles/yearn/YearnVaultMultiOracle.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
 
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import "../../interfaces/IOracle.sol";
 
 import "./IYvToken.sol";
 

--- a/packages/foundry/contracts/oracles/yieldspace/IPoolOracle.sol
+++ b/packages/foundry/contracts/oracles/yieldspace/IPoolOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 interface IPoolOracle {
 

--- a/packages/foundry/contracts/oracles/yieldspace/PoolOracle.sol
+++ b/packages/foundry/contracts/oracles/yieldspace/PoolOracle.sol
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
-import {IPool} from "@yield-protocol/yieldspace-interfaces/IPool.sol";
+import {IPool} from "@yield-protocol/yieldspace-tv/src/interfaces/IPool.sol";
 import {IPoolOracle} from "./IPoolOracle.sol";
+
+// TODO: Migrate to YieldSpace-tv, unless this needs to be used with v2 pools (last one maturing EO September 2022)
+contract PoolOracle { }
 
 /**
  * @title PoolOracle
@@ -11,6 +14,7 @@ import {IPoolOracle} from "./IPoolOracle.sol";
  * Adapted from https://github.com/Uniswap/v2-periphery/blob/master/contracts/examples/ExampleSlidingWindowOracle.sol
  */
 //solhint-disable not-rely-on-time
+/*
 contract PoolOracle is IPoolOracle {
     event ObservationRecorded(address indexed pool, uint256 index, Observation observation);
 
@@ -154,3 +158,4 @@ contract PoolOracle is IPoolOracle {
         }
     }
 }
+*/

--- a/packages/foundry/contracts/oracles/yieldspace/YieldSpaceMultiOracle.sol
+++ b/packages/foundry/contracts/oracles/yieldspace/YieldSpaceMultiOracle.sol
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "./IPoolOracle.sol";
-import "@yield-protocol/yieldspace-interfaces/IPool.sol";
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import "@yield-protocol/yieldspace-tv/src/interfaces/IPool.sol";
+import "../../interfaces/IOracle.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
-import "@yield-protocol/yieldspace-v2/contracts/YieldMath.sol";
+import "@yield-protocol/yieldspace-tv/src/YieldMath.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
 import "@yield-protocol/utils-v2/contracts/math/WDiv.sol";
 
+// TODO: Migrate to YieldSpace-tv, unless this needs to be used with v2 pools (last one maturing EO September 2022)
+contract YieldSpaceMultiOracle { }
+
+/*
 contract YieldSpaceMultiOracle is IOracle, AccessControl {
     using CastBytes32Bytes6 for bytes32;
     using Math64x64 for int128;
@@ -143,3 +147,4 @@ contract YieldSpaceMultiOracle is IOracle, AccessControl {
         return source.lending ? amount.wmul(marginalPrice) : amount.wdiv(marginalPrice);
     }
 }
+*/

--- a/packages/foundry/contracts/other/contango/ContangoLadle.sol
+++ b/packages/foundry/contracts/other/contango/ContangoLadle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "../../Ladle.sol";
 

--- a/packages/foundry/contracts/other/contango/ContangoWitch.sol
+++ b/packages/foundry/contracts/other/contango/ContangoWitch.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "../../Witch.sol";
 import "./interfaces/IContangoWitchListener.sol";

--- a/packages/foundry/contracts/other/contango/interfaces/IContangoLadle.sol
+++ b/packages/foundry/contracts/other/contango/interfaces/IContangoLadle.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "@yield-protocol/vault-interfaces/src/ILadle.sol";
+import "../../../interfaces/ILadle.sol";
 
 interface IContangoLadle is ILadle {
     function deterministicBuild(

--- a/packages/foundry/contracts/other/convex/ConvexJoin.sol
+++ b/packages/foundry/contracts/other/convex/ConvexJoin.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Original contract: https://github.com/convex-eth/platform/blob/main/contracts/contracts/wrappers/ConvexStakingWrapper.sol
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
-import "@yield-protocol/vault-interfaces/src/ICauldron.sol";
+import "../../interfaces/ICauldron.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "@yield-protocol/utils-v2/contracts/token/TransferHelper.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastU256U128.sol";

--- a/packages/foundry/contracts/other/convex/ConvexModule.sol
+++ b/packages/foundry/contracts/other/convex/ConvexModule.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
-import "@yield-protocol/vault-interfaces/src/ICauldron.sol";
+import "../../interfaces/ICauldron.sol";
 import "./interfaces/IConvexJoin.sol";
 import "../../LadleStorage.sol";
 

--- a/packages/foundry/contracts/other/convex/CvxMining.sol
+++ b/packages/foundry/contracts/other/convex/CvxMining.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "./interfaces/ICvx.sol";
 

--- a/packages/foundry/contracts/other/convex/interfaces/IConvexDeposits.sol
+++ b/packages/foundry/contracts/other/convex/interfaces/IConvexDeposits.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 interface IConvexDeposits {
     function deposit(uint256 _pid, uint256 _amount, bool _stake) external returns(bool);

--- a/packages/foundry/contracts/other/convex/interfaces/IConvexJoin.sol
+++ b/packages/foundry/contracts/other/convex/interfaces/IConvexJoin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 interface IConvexJoin {
     function addVault(bytes12 vault_) external;

--- a/packages/foundry/contracts/other/convex/interfaces/ICvx.sol
+++ b/packages/foundry/contracts/other/convex/interfaces/ICvx.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 interface ICvx {
     function reductionPerCliff() external view returns(uint256);

--- a/packages/foundry/contracts/other/convex/interfaces/IRewardStaking.sol
+++ b/packages/foundry/contracts/other/convex/interfaces/IRewardStaking.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 interface IRewardStaking {
     function stakeFor(address, uint256) external;

--- a/packages/foundry/contracts/other/ether/WrapEtherModule.sol
+++ b/packages/foundry/contracts/other/ether/WrapEtherModule.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "@yield-protocol/utils-v2/contracts/token/TransferHelper.sol";
 import "../../LadleStorage.sol";
 

--- a/packages/foundry/contracts/other/lido/StEthConverter.sol
+++ b/packages/foundry/contracts/other/lido/StEthConverter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "@yield-protocol/utils-v2/contracts/token/TransferHelper.sol";

--- a/packages/foundry/contracts/other/notional/IBatchAction.sol
+++ b/packages/foundry/contracts/other/notional/IBatchAction.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 interface IBatchAction {
     /// @notice Specifies different deposit actions that can occur during BalanceAction or BalanceActionWithTrades

--- a/packages/foundry/contracts/other/notional/NotionalJoin.sol
+++ b/packages/foundry/contracts/other/notional/NotionalJoin.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
-import "@yield-protocol/vault-interfaces/src/IJoin.sol";
+import "../../interfaces/IJoin.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import "@yield-protocol/utils-v2/contracts/token/MinimalTransferHelper.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";

--- a/packages/foundry/contracts/other/notional/NotionalMultiOracle.sol
+++ b/packages/foundry/contracts/other/notional/NotionalMultiOracle.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/cast/CastBytes32Bytes6.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC20Metadata.sol";
-import "@yield-protocol/vault-interfaces/src/IOracle.sol";
+import "../../interfaces/IOracle.sol";
 
 
 /**

--- a/packages/foundry/contracts/other/notional/Transfer1155Module.sol
+++ b/packages/foundry/contracts/other/notional/Transfer1155Module.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 import "./ERC1155.sol"; // TODO: Move to yield-utils-v2
 import "../../LadleStorage.sol";
 

--- a/packages/foundry/contracts/test/Witch.t.sol
+++ b/packages/foundry/contracts/test/Witch.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "./utils/TestConstants.sol";
 import "./utils/Mocks.sol";
 
-import "@yield-protocol/vault-interfaces/src/IWitch.sol";
+import "../interfaces/IWitch.sol";
 import "../Witch.sol";
 
 abstract contract WitchStateZero is Test, TestConstants {

--- a/packages/foundry/contracts/test/modules/HealerModule.t.sol
+++ b/packages/foundry/contracts/test/modules/HealerModule.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "forge-std/src/console.sol";
-import "@yield-protocol/vault-interfaces/src/ICauldron.sol";
-import "@yield-protocol/vault-interfaces/src/ILadle.sol";
+import "../../interfaces/ICauldron.sol";
+import "../../interfaces/ILadle.sol";
 import "@yield-protocol/utils-v2/contracts/interfaces/IWETH9.sol";
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";
 import "../../mocks/WETH9Mock.sol";

--- a/packages/foundry/contracts/test/oracles/AccumulatorOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/AccumulatorOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "../../oracles/accumulator/AccumulatorMultiOracle.sol";

--- a/packages/foundry/contracts/test/oracles/CTokenMultiOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/CTokenMultiOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";

--- a/packages/foundry/contracts/test/oracles/ChainlinkETHMultiOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/ChainlinkETHMultiOracle.t.sol
@@ -2,42 +2,33 @@
 pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
-import "../../oracles/chainlink/ChainlinkMultiOracle.sol";
-import "../../mocks/DAIMock.sol";
-import "../../mocks/USDCMock.sol";
-import "../../mocks/WETH9Mock.sol";
+import "../../oracles/chainlink/ChainlinkETHMultiOracle.sol";
 import "../../mocks/oracles/OracleMock.sol";
-import "../../mocks/oracles/chainlink/ChainlinkAggregatorV3Mock.sol";
+import "../../oracles/chainlink/AggregatorV3Interface.sol";
 import "../utils/TestConstants.sol";
 
 contract ChainlinkMultiOracleTest is Test, TestConstants {
     OracleMock public oracleMock;
-    DAIMock public dai;
-    USDCMock public usdc;
-    WETH9Mock public weth;
-    ChainlinkMultiOracle public chainlinkMultiOracle;
-    ChainlinkAggregatorV3Mock public daiEthAggregator;
-    ChainlinkAggregatorV3Mock public usdcEthAggregator;
+    ChainlinkETHMultiOracle public chainlinkOracle;
+    AggregatorV3Interface daiEthAggregator = AggregatorV3Interface(0x773616E4d11A78F511299002da57A0a94577F1f4);
+    AggregatorV3Interface usdcEthAggregator = AggregatorV3Interface(0x986b5E1e1755e3C2440e960477f25201B0a8bbD4);
+
+    address public dai = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address public usdc = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
 
     bytes32 public mockBytes32 = 0x0000000000000000000000000000000000000000000000000000000000000001;
-    bytes6 public mockBytes6 = 0x000000000001;
     uint256 public oneUSDC = 1e6;
 
     function setUp() public {
         oracleMock = new OracleMock();
-        dai = new DAIMock();
-        usdc = new USDCMock();
-        weth = new WETH9Mock();
         daiEthAggregator = new ChainlinkAggregatorV3Mock();
         usdcEthAggregator = new ChainlinkAggregatorV3Mock();
-        chainlinkMultiOracle = new ChainlinkMultiOracle();
-        chainlinkMultiOracle.grantRole(0xef532f2e, address(this));
-        chainlinkMultiOracle.setSource(DAI, dai, ETH, weth, address(daiEthAggregator));
-        chainlinkMultiOracle.setSource(USDC, usdc, ETH, weth, address(usdcEthAggregator));
-        vm.warp(uint256(mockBytes32));
-        // WAD / 2500 here represents the amount of ETH received for either 1 DAI or 1 USDC
-        daiEthAggregator.set(WAD / 2500);
-        usdcEthAggregator.set(WAD / 2500);
+        chainlinkOracle = new ChainlinkETHMultiOracle();
+
+        vm.createSelectFork('mainnet', 15044600);
+        chainlinkOracle.grantRole(chainlinkMultiOracle.setSource.selector, address(this));
+        chainlinkOracle.setSource(DAI, dai, daiEthAggregator);
+        chainlinkOracle.setSource(USDC, usdc, usdcEthAggregator);
     }
 
     function testGetConversion() public {
@@ -48,7 +39,7 @@ contract ChainlinkMultiOracleTest is Test, TestConstants {
 
     function testRevertOnUnknownSource() public {
         vm.expectRevert("Source not found");
-        chainlinkMultiOracle.get(bytes32(DAI), bytes32(mockBytes6), WAD);
+        chainlinkMultiOracle.get(bytes32(DAI), mockBytes32, WAD);
     }
 
     function testChainlinkMultiOracleConversion() public {

--- a/packages/foundry/contracts/test/oracles/ChainlinkMultiOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/ChainlinkMultiOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "../../oracles/chainlink/ChainlinkMultiOracle.sol";

--- a/packages/foundry/contracts/test/oracles/ChainlinkUSDMultiOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/ChainlinkUSDMultiOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";

--- a/packages/foundry/contracts/test/oracles/CompositeMulltiOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/CompositeMulltiOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";

--- a/packages/foundry/contracts/test/oracles/ConvexOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/ConvexOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "@yield-protocol/utils-v2/contracts/token/ERC20.sol";

--- a/packages/foundry/contracts/test/oracles/ETokenMultiOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/ETokenMultiOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import {IEToken} from "../../oracles/euler/IEToken.sol";

--- a/packages/foundry/contracts/test/oracles/LidoOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/LidoOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";

--- a/packages/foundry/contracts/test/oracles/NotionalMultiOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/NotionalMultiOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "../../other/notional/NotionalMultiOracle.sol";

--- a/packages/foundry/contracts/test/oracles/PoolOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/PoolOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "../utils/Mocks.sol";
@@ -7,6 +7,7 @@ import "../utils/Mocks.sol";
 import "../../oracles/yieldspace/PoolOracle.sol";
 
 contract PoolOracleTest is Test {
+    /*
     using Mocks for *;
 
     PoolOracle private oracle;
@@ -517,4 +518,5 @@ contract PoolOracleTest is Test {
     }
 
     event ObservationRecorded(address indexed pool, uint256 index, PoolOracle.Observation observation);
+    */
 }

--- a/packages/foundry/contracts/test/oracles/RateChiMultiOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/RateChiMultiOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";

--- a/packages/foundry/contracts/test/oracles/UniswapOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/UniswapOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "../../oracles/uniswap/UniswapV3Oracle.sol";

--- a/packages/foundry/contracts/test/oracles/YearnVaultMultiOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/YearnVaultMultiOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";

--- a/packages/foundry/contracts/test/oracles/YieldSpaceMultiOracle.t.sol
+++ b/packages/foundry/contracts/test/oracles/YieldSpaceMultiOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "../utils/Mocks.sol";
@@ -8,6 +8,7 @@ import "../../oracles/yieldspace/YieldSpaceMultiOracle.sol";
 import "../utils/TestConstants.sol";
 
 contract YieldSpaceMultiOracleTest is Test, TestConstants {
+    /*
     using Mocks for *;
 
     event SourceSet(
@@ -142,4 +143,5 @@ contract YieldSpaceMultiOracleTest is Test, TestConstants {
         assertEq(updateTime, NOW);
         assertEq(value, 1000.690277e6);
     }
+    */
 }

--- a/packages/foundry/contracts/test/other/contango/ContangoLadle.t.sol
+++ b/packages/foundry/contracts/test/other/contango/ContangoLadle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 import "forge-std/src/Test.sol";
 import "../../utils/TestConstants.sol";

--- a/packages/foundry/contracts/test/utils/Mocks.sol
+++ b/packages/foundry/contracts/test/utils/Mocks.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 import "forge-std/src/Test.sol";
-import "@yield-protocol/vault-interfaces/src/DataTypes.sol";
+import "../../interfaces/DataTypes.sol";
 
 //common utilities for forge tests
 library Mocks  {

--- a/packages/foundry/contracts/test/utils/TestConstants.sol
+++ b/packages/foundry/contracts/test/utils/TestConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
 contract TestConstants {
     uint256 public constant WAD = 1e18;

--- a/packages/foundry/contracts/utils/Giver.sol
+++ b/packages/foundry/contracts/utils/Giver.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.14;
+pragma solidity >=0.8.13;
 
-import "@yield-protocol/vault-interfaces/src/ICauldron.sol";
-import "@yield-protocol/vault-interfaces/src/DataTypes.sol";
+import "../interfaces/ICauldron.sol";
+import "../interfaces/DataTypes.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 
 /// @title A contract that allows owner of a vault to give the vault

--- a/packages/foundry/foundry.toml
+++ b/packages/foundry/foundry.toml
@@ -1,11 +1,12 @@
 [profile.default]
-src = 'contracts'
+src = './contracts'
+root = '.'
 test = 'test'
 out = 'out'
 libs = ['lib']
 block_timestamp = 1651743369 # Arbitrary Thursday, 5 May 2022 09:36:09
 verbosity = 3
-solc_version = '0.8.14'
+solc_version = '0.8.15'
 rpc_endpoints = { mainnet = "${MAINNET_RPC}" }
 
 # See more config options https://github.com/gakonst/foundry/tree/master/config

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@yield-protocol/vault-v2",
-  "version": "0.16.6",
+  "version": "0.17.1-rc1",
   "description": "Yield Collateralized Debt Engine v2",
   "author": "Yield Inc.",
+  "files": [
+    "contracts/*.sol",
+    "contracts/**/*.sol",
+    "!contracts/mocks/**/*.sol",
+    "!contracts/deprecated/**/*.sol",
+    "!lib"
+  ],
   "scripts": {
     "forge:build": "forge build",
     "forge:test": "forge test",

--- a/packages/foundry/remappings.txt
+++ b/packages/foundry/remappings.txt
@@ -1,8 +1,6 @@
 @yield-protocol/utils-v2/=lib/yield-utils-v2/
-@yield-protocol/vault-interfaces/=lib/vault-interfaces/
-@yield-protocol/yieldspace-interfaces/=lib/yieldspace-interfaces/
-@yield-protocol/yieldspace-v2/=lib/yieldspace-v2/
+@yield-protocol/yieldspace-tv/=lib/yieldspace-tv/
+@yield-protocol/vault-v2/contracts=contracts/
 forge-std/=lib/forge-std/
-uniswapv3-oracle/=lib/Yield-UniswapOracleV3/
 erc3156/=lib/ERC3156/
 dss-interfaces/=lib/dss-interfaces/

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -29,10 +29,8 @@
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@truffle/hdwallet-provider": "^1.0.40",
     "@types/mocha": "^8.0.0",
-    "@yield-protocol/utils-v2": "^2.5.0",
-    "@yield-protocol/vault-interfaces": "^2.4.1",
-    "@yield-protocol/yieldspace-interfaces": "^2.3.2",
-    "@yield-protocol/yieldspace-v2": "^0.12.3",
+    "@yield-protocol/utils-v2": "^2.6.0",
+    "@yield-protocol/yieldspace-tv": "^0.1.2-rc0",
     "chai": "4.2.0",
     "dss-interfaces": "0.1.1",
     "erc3156": "^0.4.8",
@@ -53,8 +51,7 @@
     "tsdx": "^0.14.1",
     "typechain": "^4.0.3",
     "typechain-target-ethers-v5": "^5.0.1",
-    "typescript": "^3.9.7",
-    "uniswapv3-oracle": "^1.0.1"
+    "typescript": "^3.9.7"
   },
   "repository": {
     "url": "git+https://github.com/yieldprotocol/vault-v2.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,33 +2443,18 @@
   resolved "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
-"@yield-protocol/utils-v2@^2.4.2", "@yield-protocol/utils-v2@^2.5.0":
-  version "2.5.2"
-  resolved "https://registry.npmjs.org/@yield-protocol/utils-v2/-/utils-v2-2.5.2.tgz"
-  integrity sha512-0oQ+F8xa1q+eD4YIF/3XBRRVIUx1pgwb9yF870U+t2dXhGr1uP5bBesA01OrIZ2CUlocEMFSxuYujA7CLse5nQ==
+"@yield-protocol/utils-v2@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/utils-v2/-/utils-v2-2.6.0.tgz#9badd6db67ae4603c4f765e9cea494d0373add6d"
+  integrity sha512-Z8ksHeG02tHPnKJGuKKrjzLG7Yz7kWj3Lsf50jsuTDwd8pBYq27OemOmscI2dNp4R0+qaf/+vJjvriEvtd9utQ==
   dependencies:
     ethereumjs-util "^7.0.8"
     ethers "^5.0.7"
 
-"@yield-protocol/vault-interfaces@^2.3.0-rc4":
-  version "2.4.1"
-  resolved "https://registry.npmjs.org/@yield-protocol/vault-interfaces/-/vault-interfaces-2.4.1.tgz"
-  integrity sha512-qqyBx6DERbkMhRTEVxvxr0OVVyxVyEq1rw/bfFjR/rW1xRAVufF+IQiyR5EFo807i/cW0MVjxt1KPVZGSyrLHA==
-
-"@yield-protocol/vault-interfaces@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@yield-protocol/vault-interfaces/-/vault-interfaces-2.5.0.tgz#9487b8a2d35d4171f6772f88a00d683482bcbf61"
-  integrity sha512-aoIn1tTADJaIiNPHoy7EswvFZZXZFUhJfYPEJdakLvfGruhfoPXm/Wl2aq/A1qmuniov5RDuvpWENZsBNaEgRw==
-
-"@yield-protocol/yieldspace-interfaces@^2.3.2":
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/@yield-protocol/yieldspace-interfaces/-/yieldspace-interfaces-2.3.2.tgz"
-  integrity sha512-8U43J4lfWnkagCTKi/JGdG4DAP69kwfCC85NAUUxb51gPGuZLSmfzm1UjroCPC5jQN4Nw0tCvIMKjIEYK0jaZw==
-
-"@yield-protocol/yieldspace-v2@^0.12.3":
-  version "0.12.3"
-  resolved "https://registry.npmjs.org/@yield-protocol/yieldspace-v2/-/yieldspace-v2-0.12.3.tgz"
-  integrity sha512-Lq5eggILP3QGk7pSmmC8tntI0KS3hXbqdoKIcjUEF6KhfZkxJtHQrZR9qnrrhOyDombAwT0iVvZps8EVFI8AqA==
+"@yield-protocol/yieldspace-tv@^0.1.2-rc0":
+  version "0.1.2-rc0"
+  resolved "https://registry.yarnpkg.com/@yield-protocol/yieldspace-tv/-/yieldspace-tv-0.1.2-rc0.tgz#7af7575beabbbf08d93ce4a0724bf00bc5c02dc0"
+  integrity sha512-3Mk8kFzyE0aDSXL0xKOUeLpeB/qfj1Ug6UXkMgzUpiaC0oPAJEgiLAcNOwfbsNWtcAel9puAraAevbc7xfCFYw==
 
 abab@^2.0.0:
   version "2.0.6"
@@ -12683,14 +12668,6 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^2.0.1"
-
-uniswapv3-oracle@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/uniswapv3-oracle/-/uniswapv3-oracle-1.0.1.tgz"
-  integrity sha512-B2GpmD7HnI+XW/sCNu6nYZ206cdB8g6e7uYjdrJ41XiVxGEX2Cxdzt/wAiSYDG5euDFFBJSdw7p5wzIcTHij3w==
-  dependencies:
-    "@yield-protocol/utils-v2" "^2.4.2"
-    "@yield-protocol/vault-interfaces" "^2.3.0-rc4"
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
This PR updates the `ChainlinkMultiOracle` to only accept ETH data feeds. Closes #460 