### PR TITLE
witchAuditFixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ deployments/
 .mythxKey
 .secret
 build/
+.env
 
 # Solidity-coverage
 coverage/

--- a/packages/foundry/contracts/Witch.sol
+++ b/packages/foundry/contracts/Witch.sol
@@ -603,7 +603,8 @@ contract Witch is AccessControl {
         } else {
             proportionNow =
                 uint256(initialProportion) +
-                uint256(1e18 - initialProportion).wmul(elapsed.wdiv(duration));
+                (uint256(1e18 - initialProportion) * elapsed) /
+                duration;
         }
 
         uint256 inkAtEnd = uint256(artIn).wdiv(auction_.art).wmul(auction_.ink);

--- a/packages/foundry/contracts/Witch.sol
+++ b/packages/foundry/contracts/Witch.sol
@@ -97,11 +97,9 @@ contract Witch is AccessControl {
     ) external auth {
         require(initialOffer <= 1e18, "InitialOffer above 100%");
         require(proportion <= 1e18, "Proportion above 100%");
-        require(
-            initialOffer == 0 || initialOffer >= 0.01e18,
-            "InitialOffer below 1%"
-        );
+        require(initialOffer >= 0.01e18, "InitialOffer below 1%");
         require(proportion >= 0.01e18, "Proportion below 1%");
+
         lines[ilkId][baseId] = DataTypes.Line({
             duration: duration,
             proportion: proportion,

--- a/packages/foundry/contracts/Witch.sol
+++ b/packages/foundry/contracts/Witch.sol
@@ -178,7 +178,7 @@ contract Witch is AccessControl {
         returns (DataTypes.Auction memory auction_)
     {
         DataTypes.Vault memory vault = cauldron.vaults(vaultId);
-        if (vault.owner == address(this) || otherWitches[vault.owner]) {
+        if (auctions[vaultId].start != 0 || otherWitches[vault.owner]) {
             revert VaultAlreadyUnderAuction(vaultId, vault.owner);
         }
         DataTypes.Series memory series = cauldron.series(vault.seriesId);

--- a/packages/foundry/contracts/Witch.sol
+++ b/packages/foundry/contracts/Witch.sol
@@ -395,24 +395,24 @@ contract Witch is AccessControl {
         uint256 liquidatorCut,
         uint256 auctioneerCut
     ) internal returns (uint256, uint256) {
-        // If liquidatorCut is 0, then auctioneerCut is 0 too, so no need to double check
-        if (liquidatorCut > 0) {
-            IJoin ilkJoin = ladle.joins(auction_.ilkId);
-            require(ilkJoin != IJoin(address(0)), "Join not found");
+        IJoin ilkJoin = ladle.joins(auction_.ilkId);
+        require(ilkJoin != IJoin(address(0)), "Join not found");
 
-            // Pay auctioneer's cut if necessary
-            if (auctioneerCut > 0) {
-                try
-                    ilkJoin.exit(auction_.auctioneer, auctioneerCut.u128())
-                returns (uint128) {} catch {
-                    liquidatorCut += auctioneerCut;
-                    auctioneerCut = 0;
-                }
+        // Pay auctioneer's cut if necessary
+        if (auctioneerCut > 0) {
+            try
+                ilkJoin.exit(auction_.auctioneer, auctioneerCut.u128())
+            returns (uint128) {} catch {
+                liquidatorCut += auctioneerCut;
+                auctioneerCut = 0;
             }
+        }
 
-            // Give collateral to the liquidator
+        // Give collateral to the liquidator
+        if (liquidatorCut > 0) {
             ilkJoin.exit(to, liquidatorCut.u128());
         }
+        
         return (liquidatorCut, auctioneerCut);
     }
 

--- a/packages/foundry/contracts/test/Witch.t.sol
+++ b/packages/foundry/contracts/test/Witch.t.sol
@@ -357,6 +357,14 @@ contract WitchWithMetadataTest is WitchWithMetadata {
         assertLe(liquidatorCut, 50 ether);
     }
 
+    function testWitchIsTooOld() public {
+        vm.warp(uint256(type(uint32).max) + 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(Witch.WitchPermanentlyDisabled.selector)
+        );
+        witch.auction(VAULT_ID, bot);
+    }
+
     function testVaultNotUndercollateralised() public {
         cauldron.level.mock(VAULT_ID, 0);
         vm.expectRevert("Not undercollateralized");
@@ -471,6 +479,9 @@ contract WitchWithAuction is WitchWithMetadata {
 
     function setUp() public virtual override {
         super.setUp();
+
+        // Test everyithing on the last moment the witch would be usable
+        vm.warp(type(uint32).max);
 
         cauldron.level.mock(VAULT_ID, -1);
         cauldron.give.mock(VAULT_ID, address(witch), vault);

--- a/packages/foundry/contracts/test/Witch.t.sol
+++ b/packages/foundry/contracts/test/Witch.t.sol
@@ -30,7 +30,7 @@ abstract contract WitchStateZero is Test, TestConstants {
     event LimitSet(bytes6 indexed ilkId, bytes6 indexed baseId, uint128 max);
     event Point(bytes32 indexed param, address indexed value);
     event AnotherWitchSet(address indexed a, bool isWitch);
-    event AuctioneerRewardSet(uint128 auctioneerReward);
+    event AuctioneerRewardSet(uint256 auctioneerReward);
 
     bytes12 internal constant VAULT_ID = "vault";
     bytes6 internal constant ILK_ID = ETH;
@@ -353,9 +353,7 @@ contract WitchWithMetadataTest is WitchWithMetadata {
 
     function testWitchIsTooOld() public {
         vm.warp(uint256(type(uint32).max) + 1);
-        vm.expectRevert(
-            abi.encodeWithSelector(Witch.WitchPermanentlyDisabled.selector)
-        );
+        vm.expectRevert(abi.encodeWithSelector(Witch.WitchIsDead.selector));
         witch.auction(VAULT_ID, bot);
     }
 

--- a/packages/foundry/contracts/test/Witch.t.sol
+++ b/packages/foundry/contracts/test/Witch.t.sol
@@ -122,7 +122,7 @@ contract WitchStateZeroTest is WitchStateZero {
     function testSetLineRequiresProportionTooLow() public {
         vm.prank(ada);
         vm.expectRevert("Proportion below 1%");
-        witch.setLine("", "", 0, 0.01e18 - 1, 0);
+        witch.setLine("", "", 0, 0.01e18 - 1, 1e18);
     }
 
     function testSetLine() public {


### PR DESCRIPTION
- Fix issue with invalid auctioneer reward address
- Code simplification
- Use auction state to determine if a vault is already under auction or not
- Cater for all the dust scenarios
- Check that config is valid for base/ilk pair before starting an auction
- Remove initialOffer = 0 as valid value
- Auto disable the witch after it can't handle the timestamp
- Merge setLine & setLimit
- refactor _payInk
- add .env to .gitignore
