### PR TITLE
Witch bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *~
 *.swp
 *.swo
+.idea
 
 # Packaging
 *.tar.gz

--- a/packages/foundry/contracts/test/Witch.t.sol
+++ b/packages/foundry/contracts/test/Witch.t.sol
@@ -818,6 +818,33 @@ contract WitchWithAuction is WitchWithMetadata {
         assertEq(auction2.ink, 9 ether, "ink");
     }
 
+    function testVaultDebtBelowDustLimit()
+        public
+    {
+        // 50% of this vault would be less than the min of 5k
+        // Increasing the liquidated amount to the 5k min would leave a remainder under the limit (9000 - 5000 = 4000)
+        _stubVault(
+            StubVault({
+                vaultId: VAULT_ID_2,
+                ink: 9 ether,
+                art: 4999e6,
+                level: -1
+            })
+        );
+
+        (DataTypes.Auction memory auction2, , ) = witch.auction(
+            VAULT_ID_2,
+            bot
+        );
+
+        assertEq(auction2.owner, address(0xb0b));
+        assertEq(auction2.start, uint32(block.timestamp));
+        assertEq(auction2.baseId, series.baseId);
+        // 100% of the vault was put for liquidation
+        assertEq(auction2.art, 4999e6, "art");
+        assertEq(auction2.ink, 9 ether, "ink");
+    }
+
     function testUpdateLineAndLimitKeepsSum() public {
         (, uint128 sum) = witch.limits(ILK_ID, BASE_ID);
         assertEq(sum, 50 ether);

--- a/packages/foundry/contracts/test/Witch.t.sol
+++ b/packages/foundry/contracts/test/Witch.t.sol
@@ -821,8 +821,7 @@ contract WitchWithAuction is WitchWithMetadata {
     function testVaultDebtBelowDustLimit()
         public
     {
-        // 50% of this vault would be less than the min of 5k
-        // Increasing the liquidated amount to the 5k min would leave a remainder under the limit (9000 - 5000 = 4000)
+        // 4999 is below the min debt of 5k
         _stubVault(
             StubVault({
                 vaultId: VAULT_ID_2,


### PR DESCRIPTION
Testing the bot with all the main net history we discovered that some vaults made the auction calculation fail.
Those vaults are broken in many other ways, but made me realised that any vault for which the debt is below the min debt would make the auction calculation fail.
I think it needs to be addressed cause otherwise you can never raise the min debt unless you ensure there are 0 vaults below the new min, which I think is probably not an option.