### PR TITLE
fix: receive and wrap ETH from Notional

### DIFF
--- a/packages/foundry/contracts/other/notional/NotionalJoin.sol
+++ b/packages/foundry/contracts/other/notional/NotionalJoin.sol
@@ -200,6 +200,10 @@ contract NotionalJoin is IJoin, ERC1155TokenReceiver, AccessControl {
 
         IBatchAction(asset).batchBalanceAction(address(this), withdrawActions);
 
+        // If this is an ETH Notional Join, we wrap all Ether we own on redemption. It should
+        // only have arrived from Notional. Donations accepted :)
+        if (fCashId >> 48 == 1) IWETH9(underlying).deposit{ value: address(this).balance }();
+
         uint256 underlyingBalance = IERC20(underlying).balanceOf(address(this));
         uint256 storedBalance_ = storedBalance;
         // The accrual covers the possible return from holding fCash after maturity, and also the change in decimals
@@ -262,6 +266,5 @@ contract NotionalJoin is IJoin, ERC1155TokenReceiver, AccessControl {
     /// @dev Notional will send unwrapped ETH on redemption, which we have to wrap into WETH.
     receive() external payable {
         require(fCashId >> 48 == 1 && msg.sender == asset, "Only ETH NotionalJoins");
-        IWETH9(underlying).deposit{ value: msg.value }();
     }
 }

--- a/packages/foundry/contracts/other/notional/NotionalJoin.sol
+++ b/packages/foundry/contracts/other/notional/NotionalJoin.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.13;
 
 import "../../interfaces/IJoin.sol";
 import "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+import "@yield-protocol/utils-v2/contracts/interfaces/IWETH9.sol";
 import "@yield-protocol/utils-v2/contracts/token/MinimalTransferHelper.sol";
 import "@yield-protocol/utils-v2/contracts/access/AccessControl.sol";
 import "@yield-protocol/utils-v2/contracts/math/WMul.sol";
@@ -256,5 +257,11 @@ contract NotionalJoin is IJoin, ERC1155TokenReceiver, AccessControl {
             token.balanceOf(address(this), id),
             ""
         );
+    }
+
+    /// @dev Notional will send unwrapped ETH on redemption, which we have to wrap into WETH.
+    receive() external payable {
+        require(fCashId >> 48 == 1 && msg.sender == asset, "Only ETH NotionalJoins");
+        IWETH9(underlying).deposit{ value: msg.value }();
     }
 }

--- a/packages/foundry/contracts/test/other/notional/NotionalJoin.t.sol
+++ b/packages/foundry/contracts/test/other/notional/NotionalJoin.t.sol
@@ -295,6 +295,7 @@ contract StateMaturedTest is StateMatured {
         emit Redeemed(0, 10e8, 1e8);
         uint beforeUserBalance = IERC20(currency).balanceOf(user);
         uint beforeJoinBalance = IERC20(currency).balanceOf(address(underlyingJoin));
+        vm.prank(me);
         njoin.exit(user, 1e8);
         
         assertGt(njoin.accrual(), 0);

--- a/packages/foundry/contracts/test/other/notional/NotionalJoin.t.sol
+++ b/packages/foundry/contracts/test/other/notional/NotionalJoin.t.sol
@@ -287,7 +287,7 @@ contract StateMaturedTest is StateMatured {
 
     function testRedeem() public {
         console2.log("First exit call should call redeem()");
-        (address currency, uint16 currencyId_) = whichCurrency(fCashId);
+        (address currency, ) = whichCurrency(fCashId);
         vm.expectEmit(true, true, true, false);
         emit Redeemed(0, 10e8, 1e8);
 
@@ -327,15 +327,15 @@ contract StateRedeemedTest is StateRedeemed {
 
     function testSubsequentExit() public {
         console2.log("_exitUnderlying executed");
-
+        (address currency, ) = whichCurrency(fCashId);
         vm.prank(me);
         njoin.exit(user, 1e8);
 
         assertTrue(njoin.storedBalance() == 0); 
-        assertTrue(dai.balanceOf(address(njoin)) == 0); 
-        assertTrue(dai.balanceOf(address(underlyingJoin)) == 0);
+        assertTrue(IERC20(currency).balanceOf(address(njoin)) == 0); 
+        assertTrue(IERC20(currency).balanceOf(address(underlyingJoin)) == 0);
 
-        assertTrue(dai.balanceOf(address(user)) == 2e8);
+        assertTrue(IERC20(currency).balanceOf(address(user)) == 2e8);
         
     }
 }

--- a/packages/foundry/contracts/test/other/notional/NotionalJoin.t.sol
+++ b/packages/foundry/contracts/test/other/notional/NotionalJoin.t.sol
@@ -8,77 +8,142 @@ import "../../../test/utils/TestConstants.sol";
 import "../../../test/utils/Mocks.sol";
 import "../../../mocks/ERC20Mock.sol";
 
-//import {IJoin} from "@yield-protocol/vault-interfaces/src/IJoin.sol";
-import {Join} from "../../../Join.sol";
-import {NotionalJoin} from "../../../other/notional/NotionalJoin.sol";
-import {FCashMock} from "../../../other/notional/FCashMock.sol";
-import {DAIMock} from "../../../mocks/DAIMock.sol";
+import { ILadle } from "../../../interfaces/ILadle.sol";
+import { Join } from "../../../Join.sol";
+import { NotionalJoin } from "../../../other/notional/NotionalJoin.sol";
+import { ERC1155 } from "../../../other/notional/ERC1155.sol";
+import { IWETH9 } from "@yield-protocol/utils-v2/contracts/interfaces/IWETH9.sol";
+import "./NotionalTypes.sol";
 
 using stdStorage for StdStorage;
 
 abstract contract StateZero is Test, TestConstants {
-    using Mocks for *;
+    using stdStorage for StdStorage;
 
     Join public underlyingJoin; 
     NotionalJoin public njoin; 
-    FCashMock public fcash;
-    DAIMock public dai;
-        
+    address timelock = 0x3b870db67a45611CF4723d44487EAF398fAc51E3;
+    Notional public notional = Notional(0x1344A36A1B56144C3Bc62E7757377D288fDE0369);
+    ERC1155 public fCash = ERC1155(0x1344A36A1B56144C3Bc62E7757377D288fDE0369);
+    ILadle public ladle = ILadle(0x6cB18fF2A33e981D1e38A663Ca056c0a5265066A);
+    bytes6 public wethId = 0x303000000000;
+    bytes6 public daiId = 0x303100000000;
+    bytes6 public usdcId = 0x303200000000;
+    bytes6 public underlyingId;
+    IWETH9 public weth;
+    IERC20 public dai;
+    IERC20 public usdc;
+    IERC20 public underlying;
+
+    address me;
     address user; 
-    address deployer;
     uint256 fCashTokens;
 
     uint40 maturity;  
     uint16 currencyId;         
     uint256 fCashId;
 
-    event Redeemed(uint256 fCash, uint256 underlying, uint256 accrual);
+    event Redeemed(uint256 fCashAmount, uint256 underlying, uint256 accrual);
     event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 amount);
 
+    function cash(IERC20 token, address user, uint256 amount) public {
+        uint256 start = token.balanceOf(user);
+        deal(address(token), user, start + amount);
+    }
+
+    function getFCash(address to, uint256 id, uint256 amount) public returns (uint256 fCashAmount) {
+        uint16 currencyId_ = uint16(id >> 48);
+        address currency;
+        if (currencyId_ == 1) currency = address(weth);
+        else if (currencyId_ == 2) currency = address(dai);
+        else if (currencyId_ == 3) currency = address(usdc);
+        cash(IERC20(currency), address(this), amount);
+
+        fCash.setApprovalForAll(address(this), true);
+
+        // Deposit into notional to get the fCash
+        BalanceActionWithTrades[]
+            memory actions = new BalanceActionWithTrades[](1);
+        actions[0] = BalanceActionWithTrades({
+            actionType: DepositActionType.DepositUnderlying, // Deposit underlying, not cToken
+            currencyId: currencyId_,
+            depositActionAmount: amount, // total to invest
+            withdrawAmountInternalPrecision: 0,
+            withdrawEntireCashBalance: false, // Return all residual cash to lender
+            redeemToUnderlying: false, // Convert cToken to token
+            trades: new bytes32[](1)
+        });
+        // gas: 127997
+        bytes32 encodedTrade;
+        (fCashAmount, , encodedTrade) = notional.getfCashLendFromDeposit(
+            currencyId_,
+            amount, // total to invest
+            maturity,
+            0,
+            block.timestamp,
+            true
+        );
+
+        actions[0].trades[0] = encodedTrade;
+        if (currencyId_ == 1) {
+            // Converting WETH to ETH since notional accepts ETH
+            weth.withdraw(amount);
+            // gas: 302658
+            notional.batchBalanceAndTradeAction{value: amount}(
+                address(this),
+                actions
+            );
+        } else {
+            notional.batchBalanceAndTradeAction(address(this), actions);
+        }
+    }
+
     function setUp() public virtual {
+        vm.createSelectFork('mainnet', 15741300);
         
         // arbitrary values for testing
-        fCashTokens = 10e18;
-        maturity = 1671840000;  // 4/07/2022 23:09:57 GMT
-        currencyId = 2;         
-        fCashId = 563377944461313;
+        fCashTokens = 10e8;
+        maturity = 1672412400;  // EODEC
+        currencyId = 2;
+        underlyingId = daiId;
+
 
         //... Users ...
+        me = 0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84;
         user = address(1);
+        vm.label(user, "me");
         vm.label(user, "user");
         
-        deployer = 0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84;
-        vm.label(deployer, "deployer");
-
         //... Contracts ...
-        dai = new DAIMock();
+        vm.label(address(weth), "Weth token contract");
         vm.label(address(dai), "Dai token contract");
-        
-        fcash = new FCashMock(ERC20Mock(address(dai)), fCashId);
-        fcash.setAccrual(1e18);  // set fCash == underlying for simplicity
-        vm.label(address(fcash), "fCashMock contract");
+        vm.label(address(usdc), "USDC token contract");
+        vm.label(address(notional), "Notional contract");
+
+        vm.startPrank(timelock);
 
         //... Deploy Joins and grant access ...
-        underlyingJoin = new Join(address(dai));
-        vm.label(address(dai), "Dai Join");
+        underlyingJoin = Join(address(ladle.joins(underlyingId)));
+        underlying = IERC20(underlyingJoin.asset());
+        vm.label(address(underlyingJoin), "Underlying Join");
 
-        njoin = new NotionalJoin(address(fcash), address(dai), address(underlyingJoin), maturity, currencyId);
+        njoin = new NotionalJoin(address(fCash), address(underlyingJoin.asset()), address(underlyingJoin), maturity, currencyId);
         vm.label(address(njoin), "Notional Join");
 
         //... Permissions ...
-        njoin.grantRole(NotionalJoin.join.selector, deployer);
-        njoin.grantRole(NotionalJoin.exit.selector, deployer);
-        njoin.grantRole(NotionalJoin.retrieve.selector, deployer);
-        njoin.grantRole(NotionalJoin.retrieveERC1155.selector, deployer);
+        njoin.grantRole(NotionalJoin.join.selector, me);
+        njoin.grantRole(NotionalJoin.exit.selector, me);
+        njoin.grantRole(NotionalJoin.retrieve.selector, me);
+        njoin.grantRole(NotionalJoin.retrieveERC1155.selector, me);
 
         underlyingJoin.grantRole(Join.join.selector, address(njoin));       
         underlyingJoin.grantRole(Join.exit.selector, address(njoin));
-        
 
-        fcash.mint(user, fCashId, 10e18, "");
+        vm.stopPrank();
+
+        uint256 fCashAmount = getFCash(user, fCashId, 10e8);
         vm.prank(user);
-        fcash.setApprovalForAll(address(njoin), true);
-        
+        fCash.setApprovalForAll(address(njoin), true);
     }  
 }
 
@@ -88,26 +153,26 @@ contract StateZeroTest is StateZero {
         console2.log("join pulls fCash from user");
 
         vm.expectEmit(true, true, true, true);
-        emit TransferSingle(address(njoin), user, address(njoin), fCashId, 1e18);
+        emit TransferSingle(address(njoin), user, address(njoin), fCashId, 1e8);
 
-        njoin.join(user, 1e18);
+        njoin.join(user, 1e8);
 
-        assertTrue(njoin.storedBalance() ==  1e18);
-        assertTrue(fcash.balanceOf(user, fCashId) ==  fCashTokens - 1e18);
+        assertTrue(njoin.storedBalance() ==  1e8);
+        assertTrue(fCash.balanceOf(user, fCashId) ==  fCashTokens - 1e8);
     }
 }
 
-// Njoin receives fcash tokens from user
+// Njoin receives fCash tokens from user
 abstract contract StateJoined is StateZero {
     function setUp() public override virtual {
         super.setUp();
 
-        njoin.join(user, 2e18);
+        njoin.join(user, 2e8);
 
     }
 }
 
-// Njoin has 2e18 fCash | storedBalance = 2e18
+// Njoin has 2e8 fCash | storedBalance = 2e8
 contract StateJoinedTest is StateJoined {
 
     function testAcceptSurplus() public {
@@ -115,31 +180,31 @@ contract StateJoinedTest is StateJoined {
         
         //surplus 
         vm.prank(user);
-        fcash.safeTransferFrom(user, address(njoin), fCashId, 1e18, "");
+        fCash.safeTransferFrom(user, address(njoin), fCashId, 1e8, "");
 
         // no TransferSingle event emitted
-        njoin.join(user, 1e18);
+        njoin.join(user, 1e8);
         
-        assertTrue(njoin.storedBalance() ==  3e18);
-        assertTrue(fcash.balanceOf(user, fCashId) ==  fCashTokens - 3e18);
+        assertTrue(njoin.storedBalance() ==  3e8);
+        assertTrue(fCash.balanceOf(user, fCashId) ==  fCashTokens - 3e8);
 
     }
 
     function testSurplusRegistered() public {
         console2.log("combines surplus and fCashs pulled from the user");
 
-        // surplus of 1e18
+        // surplus of 1e8
         vm.prank(user);
-        fcash.safeTransferFrom(user, address(njoin), fCashId, 1e18, "");
+        fCash.safeTransferFrom(user, address(njoin), fCashId, 1e8, "");
 
         vm.expectEmit(true, true, true, true);
-        emit TransferSingle(address(njoin), user, address(njoin), fCashId, 1e18);
+        emit TransferSingle(address(njoin), user, address(njoin), fCashId, 1e8);
         
-        // 1e18 transferred from user | 1e18 taken from surplus
-        njoin.join(user, 2e18);
+        // 1e8 transferred from user | 1e8 taken from surplus
+        njoin.join(user, 2e8);
 
-        assertTrue(njoin.storedBalance() ==  4e18);
-        assertTrue(fcash.balanceOf(user, fCashId) ==  fCashTokens - 4e18);
+        assertTrue(njoin.storedBalance() ==  4e8);
+        assertTrue(fCash.balanceOf(user, fCashId) ==  fCashTokens - 4e8);
     }
 }
 
@@ -149,23 +214,23 @@ abstract contract StatePositiveStoredBalance is StateJoined {
     }
 }
 
-// Njoin holds 2e18 of fCash
+// Njoin holds 2e8 of fCash
 contract StatePositiveStoredBalanceTest is StatePositiveStoredBalance {
     function testExit() public {
         console2.log("pushes fCash to user");
 
         vm.expectEmit(true, true, true, true);
-        emit TransferSingle(address(njoin), address(njoin), user, fCashId, 1e18);
+        emit TransferSingle(address(njoin), address(njoin), user, fCashId, 1e8);
 
-        njoin.exit(user, 1e18);
+        njoin.exit(user, 1e8);
 
-        assertTrue(njoin.storedBalance() ==  1e18);
-        assertTrue(fcash.balanceOf(user, fCashId) ==  fCashTokens - 1e18);
+        assertTrue(njoin.storedBalance() ==  1e8);
+        assertTrue(fCash.balanceOf(user, fCashId) ==  fCashTokens - 1e8);
 
     }
 }
 
-// Njoin holds 2e18 of fCash
+// Njoin holds 2e8 of fCash
 abstract contract StateMatured is StatePositiveStoredBalance {
     function setUp() public override virtual {
         super.setUp();
@@ -194,24 +259,24 @@ contract StateMaturedTest is StateMatured {
         console2.log("Cannot call join() after maturity");
 
         vm.expectRevert("Only before maturity");
-        njoin.join(user, 1e18);
+        njoin.join(user, 1e8);
     }
 
     function testRedeem() public {
         console2.log("First exit call should call redeem()");
 
         vm.expectEmit(true, true, true, false);
-        emit Redeemed(0, 10e18, 1e18);
+        emit Redeemed(0, 10e8, 1e8);
 
-        njoin.exit(user, 1e18);
+        njoin.exit(user, 1e8);
         
-        assertTrue(njoin.accrual() == 1e18);
+        assertTrue(njoin.accrual() == 1e8);
         assertTrue(njoin.storedBalance() == 0); 
         assertTrue(dai.balanceOf(address(njoin)) == 0); 
         
         // 1 dai to user on redemption, 1 dai remains in underlyingJoin
-        assertTrue(dai.balanceOf(user) == 1e18);
-        assertTrue(dai.balanceOf(address(underlyingJoin)) == 1e18);
+        assertTrue(dai.balanceOf(user) == 1e8);
+        assertTrue(dai.balanceOf(address(underlyingJoin)) == 1e8);
     }
 }
 
@@ -221,9 +286,9 @@ abstract contract StateRedeemed is StateMatured {
         super.setUp();
 
         // state transition: accrual > 0         
-        vm.prank(deployer);
-        njoin.exit(user, 1e18);
-        assertTrue(njoin.accrual() == 1e18);
+        vm.prank(me);
+        njoin.exit(user, 1e8);
+        assertTrue(njoin.accrual() == 1e8);
     }
 
 }
@@ -240,14 +305,14 @@ contract StateRedeemedTest is StateRedeemed {
     function testSubsequentExit() public {
         console2.log("_exitUnderlying executed");
 
-        vm.prank(deployer);
-        njoin.exit(user, 1e18);
+        vm.prank(me);
+        njoin.exit(user, 1e8);
 
         assertTrue(njoin.storedBalance() == 0); 
         assertTrue(dai.balanceOf(address(njoin)) == 0); 
         assertTrue(dai.balanceOf(address(underlyingJoin)) == 0);
 
-        assertTrue(dai.balanceOf(address(user)) == 2e18);
+        assertTrue(dai.balanceOf(address(user)) == 2e8);
         
     }
 }

--- a/packages/foundry/contracts/test/other/notional/NotionalJoin.t.sol
+++ b/packages/foundry/contracts/test/other/notional/NotionalJoin.t.sol
@@ -104,7 +104,7 @@ abstract contract StateZero is Test, TestConstants {
     }
 
     function setUp() public virtual {
-        vm.createSelectFork('mainnet', 16017869);
+        vm.createSelectFork(MAINNET, 16017869);
         
         // arbitrary values for testing
         fCashTokens = 10e18;

--- a/packages/foundry/contracts/test/other/notional/NotionalJoin.t.sol
+++ b/packages/foundry/contracts/test/other/notional/NotionalJoin.t.sol
@@ -177,6 +177,7 @@ contract StateZeroTest is StateZero {
         vm.expectEmit(true, true, true, true);
         emit TransferSingle(address(njoin), user, address(njoin), fCashId, 1e8);
         fCashTokens = fCash.balanceOf(user, fCashId);
+        vm.prank(me);
         njoin.join(user, 1e8);
 
         assertTrue(njoin.storedBalance() ==  1e8);
@@ -188,7 +189,7 @@ contract StateZeroTest is StateZero {
 abstract contract StateJoined is StateZero {
     function setUp() public override virtual {
         super.setUp();
-
+        vm.prank(me);
         njoin.join(user, 2e8);
 
     }
@@ -205,6 +206,7 @@ contract StateJoinedTest is StateJoined {
         vm.prank(user);
         fCash.safeTransferFrom(user, address(njoin), fCashId, 1e8, "");
         // no TransferSingle event emitted
+        vm.prank(me);
         njoin.join(user, 1e8);
         
         assertTrue(njoin.storedBalance() ==  3e8);
@@ -223,6 +225,7 @@ contract StateJoinedTest is StateJoined {
         emit TransferSingle(address(njoin), user, address(njoin), fCashId, 1e8);
         
         // 1e8 transferred from user | 1e8 taken from surplus
+        vm.prank(me);
         njoin.join(user, 2e8);
 
         assertTrue(njoin.storedBalance() ==  4e8);
@@ -243,7 +246,7 @@ contract StatePositiveStoredBalanceTest is StatePositiveStoredBalance {
         fCashTokens = fCash.balanceOf(user, fCashId);
         vm.expectEmit(true, true, true, true);
         emit TransferSingle(address(njoin), address(njoin), user, fCashId, 1e8);
-
+        vm.prank(me);
         njoin.exit(user, 1e8);
 
         assertTrue(njoin.storedBalance() ==  1e8);
@@ -278,8 +281,8 @@ contract StateMaturedTest is StateMatured {
 
     function testCannotJoin() public {
         console2.log("Cannot call join() after maturity");
-
         vm.expectRevert("Only before maturity");
+        vm.prank(me);
         njoin.join(user, 1e8);
     }
 

--- a/packages/foundry/contracts/test/other/notional/NotionalJoinHarness.t.sol
+++ b/packages/foundry/contracts/test/other/notional/NotionalJoinHarness.t.sol
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.8.13;
+
+import "forge-std/src/Test.sol";
+import "forge-std/src/console2.sol";
+
+import "../../../test/utils/TestConstants.sol";
+
+import { ERC1155 } from "../../../other/notional/ERC1155.sol";
+import { IWETH9 } from "@yield-protocol/utils-v2/contracts/interfaces/IWETH9.sol";
+import { IERC20 } from "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
+import { IERC20Metadata } from "@yield-protocol/utils-v2/contracts/token/IERC20Metadata.sol";
+import { IJoin } from "../../../interfaces/IJoin.sol";
+import { NotionalJoin } from "../../../other/notional/NotionalJoin.sol";
+import "./NotionalTypes.sol";
+
+using stdStorage for StdStorage;
+
+abstract contract StateZero is Test, TestConstants {
+    using stdStorage for StdStorage;
+
+    event Redeemed(uint256 fCashAmount, uint256 underlying, uint256 accrual);
+    event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 amount);
+
+    address timelock = 0x3b870db67a45611CF4723d44487EAF398fAc51E3;
+    Notional public notional = Notional(0x1344A36A1B56144C3Bc62E7757377D288fDE0369);
+    ERC1155 public fCash = ERC1155(0x1344A36A1B56144C3Bc62E7757377D288fDE0369);
+    address public ladle = 0x6cB18fF2A33e981D1e38A663Ca056c0a5265066A;
+
+    // FETH2212: `0xa6624D8CF4A1Ba950d380D1e38A2D5261b711145`
+    // FETH2303: `0xa9d104c4e020087944332632a8c5b451885fba4a`
+
+    NotionalJoin public nJoin = NotionalJoin(payable(0xa6624D8CF4A1Ba950d380D1e38A2D5261b711145));
+    IJoin public underlyingJoin; 
+    IERC20 public underlying;
+
+    uint40 public maturity;  
+    uint256 public fCashId;
+    uint128 public underlyingUnit;
+    uint128 public fCashUnit = 1e8;
+
+    address public me;
+    address public user;
+
+    mapping(string => uint256) tracked;
+
+
+    function track(string memory id, uint256 amount) public {
+        tracked[id] = amount;
+    }
+
+    function assertTrackPlusEq(string memory id, uint256 plus, uint256 amount) public {
+        assertEq(tracked[id] + plus, amount);
+    }
+
+    function assertTrackMinusEq(string memory id, uint256 minus, uint256 amount) public {
+        assertEq(tracked[id] - minus, amount);
+    }
+
+    function assertTrackPlusApproxEqAbs(string memory id, uint256 plus, uint256 amount, uint256 delta) public {
+        assertApproxEqAbs(tracked[id] + plus, amount, delta);
+    }
+
+    function assertTrackMinusApproxEqAbs(string memory id, uint256 minus, uint256 amount, uint256 delta) public {
+        assertApproxEqAbs(tracked[id] - minus, amount, delta);
+    }
+
+    function assertApproxGeAbs(uint256 a, uint256 b, uint256 delta) public {
+        assertGe(a, b);
+        assertApproxEqAbs(a, b, delta);
+    }
+
+    function assertTrackPlusApproxGeAbs(string memory id, uint256 plus, uint256 amount, uint256 delta) public {
+        assertGe(tracked[id] + plus, amount);
+        assertApproxEqAbs(tracked[id] + plus, amount, delta);
+    }
+
+    function assertTrackMinusApproxGeAbs(string memory id, uint256 minus, uint256 amount, uint256 delta) public {
+        assertGe(tracked[id] - minus, amount);
+        assertApproxEqAbs(tracked[id] - minus, amount, delta);
+    }
+
+    function cash(IERC20 token, address to, uint256 amount) public {
+        uint256 start = token.balanceOf(to);
+        deal(address(token), to, start + amount);
+    }
+
+    /// @dev Gets fCash of the same denomination as the NotionalJoin
+    function getFCash(address to, uint256 amount) public returns (uint256 fCashAmount) {
+        uint16 currencyId_ = uint16(fCashId >> 48);
+        cash(IERC20(underlying), address(this), amount);
+        IERC20(underlying).approve(address(notional),type(uint).max);
+
+        fCash.setApprovalForAll(address(this), true);
+
+        // Deposit into notional to get the fCash
+        BalanceActionWithTrades[]
+            memory actions = new BalanceActionWithTrades[](1);
+        actions[0] = BalanceActionWithTrades({
+            actionType: DepositActionType.DepositUnderlying, // Deposit underlying, not cToken
+            currencyId: currencyId_,
+            depositActionAmount: amount, // total to invest
+            withdrawAmountInternalPrecision: 0,
+            withdrawEntireCashBalance: false, // Return all residual cash to lender
+            redeemToUnderlying: false, // Convert cToken to token
+            trades: new bytes32[](1)
+        });
+        // gas: 127997
+        bytes32 encodedTrade;
+        (fCashAmount, , encodedTrade) = notional.getfCashLendFromDeposit(
+            currencyId_,
+            amount, // total to invest
+            maturity,
+            0,
+            block.timestamp,
+            true
+        );
+
+        actions[0].trades[0] = encodedTrade;
+        if (currencyId_ == 1) {
+            // Converting WETH to ETH since notional accepts ETH
+            IWETH9(address(underlying)).withdraw(amount);
+            // gas: 302658
+            notional.batchBalanceAndTradeAction{value: amount}(
+                address(this),
+                actions
+            );
+        } else {
+            notional.batchBalanceAndTradeAction(address(this), actions);
+        }
+
+        fCash.safeTransferFrom(address(this), user, fCashId, fCashAmount, "");
+    }
+
+    receive() external payable {}
+
+    function setUp() public virtual {
+        vm.createSelectFork('tenderly');
+        
+        fCashId = nJoin.fCashId();
+        maturity = nJoin.maturity();
+        underlyingJoin = IJoin(nJoin.underlyingJoin());
+        underlying = IERC20(underlyingJoin.asset());
+        underlyingUnit = uint128(10 ** IERC20Metadata(address(underlying)).decimals());
+
+        //... Users ...
+        user = address(1);
+        vm.label(user, "user");
+        
+        //... Contracts ...
+        vm.label(address(nJoin), "Notional Join");
+        vm.label(address(underlying), "Underlying");
+        vm.label(address(underlyingJoin), "Underlying Join");
+        vm.label(address(notional), "Notional contract");
+        
+        uint256 fCashAmount = getFCash(user, 1000 * underlyingUnit);
+        vm.prank(user);
+        fCash.setApprovalForAll(address(nJoin), true);
+    }
+}
+
+contract StateZeroTest is StateZero {
+    
+    function testJoin() public {
+        console2.log("join()");
+
+        uint128 joinedAmount = fCashUnit;
+
+        track("storedBalance", nJoin.storedBalance());
+
+        vm.prank(user);
+        fCash.safeTransferFrom(user, address(nJoin), fCashId, joinedAmount, "");
+        
+        vm.prank(ladle);
+        nJoin.join(user, joinedAmount);
+
+        assertTrackPlusEq("storedBalance", joinedAmount, nJoin.storedBalance());
+    }
+}
+
+// Njoin receives fCash tokens from user
+abstract contract StateJoined is StateZero {
+    function setUp() public override virtual {
+        super.setUp();
+        
+        uint128 joinedAmount = fCashUnit;
+
+        vm.prank(user);
+        fCash.safeTransferFrom(user, address(nJoin), fCashId, joinedAmount, "");
+
+        vm.prank(ladle);
+        nJoin.join(user, joinedAmount);
+
+    }
+}
+
+
+contract StateJoinedTest is StateJoined {
+    function testExit() public {
+        console2.log("pushes fCash to user");
+
+        uint128 amountExited = fCashUnit;
+        
+        track("userFCash", fCash.balanceOf(user, fCashId));
+        track("storedBalance", nJoin.storedBalance());
+
+        vm.prank(ladle);
+        nJoin.exit(user, amountExited);
+
+        assertTrackMinusEq("storedBalance", amountExited, nJoin.storedBalance());
+        assertTrackPlusEq("userFCash", amountExited, fCash.balanceOf(user, fCashId));
+    }
+}
+// 
+// // Njoin holds 2e8 of fCash
+// abstract contract StateMatured is StatePositiveStoredBalance {
+//     function setUp() public override virtual {
+//         super.setUp();
+//         
+//         // set blocktime to pass maturity
+//         vm.warp(maturity + 100); 
+//     }
+// }
+// 
+// contract StateMaturedTest is StateMatured {
+//     // sanity check - maturity
+//     function testMaturity() public {
+//         console2.log("fCash tokens are mature");
+//         assertGe(block.timestamp, maturity);         
+//     }  
+//        
+//     // sanity check - accrual
+//     function testAccrual() public {
+//         console2.log("Accrual in Njoin should be 0");
+//         assertTrue(nJoin.accrual() == 0); 
+//     }
+// 
+//     function testCannotJoin() public {
+//         console2.log("Cannot call join() after maturity");
+//         vm.expectRevert("Only before maturity");
+//         vm.prank(me);
+//         nJoin.join(user, 1e8);
+//     }
+// 
+//     function testRedeem() public {
+//         console2.log("First exit call should call redeem()");
+//         (address currency,uint16 currencyId ) = whichCurrency(fCashId);
+//         
+//         assertTrue(nJoin.accrual() == 0);
+//         vm.expectEmit(true, true, true, false);
+//         emit Redeemed(0, 10e8, 1e8);
+//         uint beforeUserBalance = IERC20(currency).balanceOf(user);
+//         uint beforeJoinBalance = IERC20(currency).balanceOf(address(underlyingJoin));
+//         vm.prank(me);
+//         nJoin.exit(user, 1e8);
+//         
+//         assertGt(nJoin.accrual(), 0);
+//         assertTrue(nJoin.storedBalance() == 0);
+//         assertTrue(IERC20(currency).balanceOf(address(nJoin)) == 0); 
+//         uint afterUserBalance = IERC20(currency).balanceOf(user);
+//         uint afterJoinBalance = IERC20(currency).balanceOf(address(underlyingJoin));
+//         
+//         if(currencyId == 3){
+//             assertApproxEqAbs(afterUserBalance - beforeUserBalance, 1e6, 1e5);
+//             assertApproxEqAbs(afterJoinBalance - beforeJoinBalance, 1e6, 1e5);
+//         }else{
+//             assertApproxEqAbs(afterUserBalance - beforeUserBalance, 1e18, 1e17);
+//             assertApproxEqAbs(afterJoinBalance - beforeJoinBalance, 1e18, 1e17);
+//         }
+//     }
+// }
+// 
+// abstract contract StateRedeemed is StateMatured {
+// 
+//      function setUp() public override virtual {
+//         super.setUp();
+// 
+//         // state transition: accrual > 0         
+//         vm.prank(me);
+//         nJoin.exit(user, 1e8);
+//         assertGt(nJoin.accrual(),0);
+//     }
+// 
+// }
+// 
+// contract StateRedeemedTest is StateRedeemed {
+// 
+//     function testCannotRedeem() public {
+//         console2.log("Redeem will revert since accrual > 0");
+//         
+//         vm.expectRevert("Already redeemed");
+//         nJoin.redeem();
+//     }
+// 
+//     function testSubsequentExit() public {
+//         console2.log("_exitUnderlying executed");
+//         (address currency, uint16 currencyId) = whichCurrency(fCashId);
+//         uint beforeUserBalance = IERC20(currency).balanceOf(user);
+//         uint beforeJoinBalance = IERC20(currency).balanceOf(address(underlyingJoin));
+//         vm.prank(me);
+//         nJoin.exit(user, 1e8);
+// 
+//         assertTrue(nJoin.storedBalance() == 0); 
+//         assertTrue(IERC20(currency).balanceOf(address(nJoin)) == 0); 
+//         uint afterUserBalance = IERC20(currency).balanceOf(user);
+//         uint afterJoinBalance = IERC20(currency).balanceOf(address(underlyingJoin));
+//         if(currencyId == 3){
+//             assertApproxEqAbs(afterUserBalance - beforeUserBalance, 1e6, 1e5);
+//             assertApproxEqAbs(beforeJoinBalance - afterJoinBalance, 1e6, 1e5);
+//         }else{
+//             assertApproxEqAbs(afterUserBalance - beforeUserBalance, 1e18, 1e17);
+//             assertApproxEqAbs(beforeJoinBalance - afterJoinBalance, 1e18, 1e17);
+//         }
+//         
+//     }
+// }
+// 

--- a/packages/foundry/contracts/test/other/notional/NotionalJoinHarness.t.sol
+++ b/packages/foundry/contracts/test/other/notional/NotionalJoinHarness.t.sol
@@ -141,7 +141,7 @@ abstract contract StateZero is Test, TestConstants {
     function setUp() public virtual {
         vm.createSelectFork('tenderly');
         
-        nJoin = NotionalJoin(payable(vm.envAddress("STRATEGY")));
+        nJoin = NotionalJoin(payable(vm.envAddress("JOIN")));
         fCashId = nJoin.fCashId();
         maturity = nJoin.maturity();
         underlyingJoin = IJoin(nJoin.underlyingJoin());

--- a/packages/foundry/contracts/test/other/notional/NotionalJoinHarness.t.sol
+++ b/packages/foundry/contracts/test/other/notional/NotionalJoinHarness.t.sol
@@ -30,7 +30,12 @@ abstract contract StateZero is Test, TestConstants {
     // FETH2212: `0xa6624D8CF4A1Ba950d380D1e38A2D5261b711145`
     // FETH2303: `0xa9d104c4e020087944332632a8c5b451885fba4a`
 
-    NotionalJoin public nJoin = NotionalJoin(payable(0xA9d104c4E020087944332632A8c5B451885FbA4a));
+    // FUSDC2303: `0x3FdDa15EccEE67248048a560ab61Dd2CdBDeA5E6`
+    // FDAI2303: `0xE6A63e2166fcEeB447BFB1c0f4f398083214b7aB`
+    // FUSDC2212: `0xA9078E573EC536c4066A5E89F715553Ed67B13E0`
+    // FDAI2212: `0x83e99A843607CfFFC97A3acA15422aC672a463eF`
+
+    NotionalJoin public nJoin = NotionalJoin(payable(0x83e99A843607CfFFC97A3acA15422aC672a463eF));
     IJoin public underlyingJoin; 
     IERC20 public underlying;
 

--- a/packages/foundry/contracts/test/other/notional/NotionalJoinHarness.t.sol
+++ b/packages/foundry/contracts/test/other/notional/NotionalJoinHarness.t.sol
@@ -139,7 +139,7 @@ abstract contract StateZero is Test, TestConstants {
     receive() external payable {}
 
     function setUp() public virtual {
-        vm.createSelectFork('tenderly');
+        vm.createSelectFork(TENDERLY);
         
         nJoin = NotionalJoin(payable(vm.envAddress("JOIN")));
         fCashId = nJoin.fCashId();

--- a/packages/foundry/contracts/test/other/notional/NotionalJoinHarness.t.sol
+++ b/packages/foundry/contracts/test/other/notional/NotionalJoinHarness.t.sol
@@ -29,13 +29,12 @@ abstract contract StateZero is Test, TestConstants {
 
     // FETH2212: `0xa6624D8CF4A1Ba950d380D1e38A2D5261b711145`
     // FETH2303: `0xa9d104c4e020087944332632a8c5b451885fba4a`
-
     // FUSDC2303: `0x3FdDa15EccEE67248048a560ab61Dd2CdBDeA5E6`
     // FDAI2303: `0xE6A63e2166fcEeB447BFB1c0f4f398083214b7aB`
     // FUSDC2212: `0xA9078E573EC536c4066A5E89F715553Ed67B13E0`
     // FDAI2212: `0x83e99A843607CfFFC97A3acA15422aC672a463eF`
 
-    NotionalJoin public nJoin = NotionalJoin(payable(0x83e99A843607CfFFC97A3acA15422aC672a463eF));
+    NotionalJoin public nJoin;
     IJoin public underlyingJoin; 
     IERC20 public underlying;
 
@@ -142,6 +141,7 @@ abstract contract StateZero is Test, TestConstants {
     function setUp() public virtual {
         vm.createSelectFork('tenderly');
         
+        nJoin = NotionalJoin(payable(vm.envAddress("STRATEGY")));
         fCashId = nJoin.fCashId();
         maturity = nJoin.maturity();
         underlyingJoin = IJoin(nJoin.underlyingJoin());

--- a/packages/foundry/contracts/test/other/notional/NotionalTypes.sol
+++ b/packages/foundry/contracts/test/other/notional/NotionalTypes.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.14;
+/// @notice Specifies different deposit actions that can occur during BalanceAction or BalanceActionWithTrades
+enum DepositActionType {
+    // No deposit action
+    None,
+    // Deposit asset cash, depositActionAmount is specified in asset cash external precision
+    DepositAsset,
+    // Deposit underlying tokens that are mintable to asset cash, depositActionAmount is specified in underlying token
+    // external precision
+    DepositUnderlying,
+    // Deposits specified asset cash external precision amount into an nToken and mints the corresponding amount of
+    // nTokens into the account
+    DepositAssetAndMintNToken,
+    // Deposits specified underlying in external precision, mints asset cash, and uses that asset cash to mint nTokens
+    DepositUnderlyingAndMintNToken,
+    // Redeems an nToken balance to asset cash. depositActionAmount is specified in nToken precision. Considered a deposit action
+    // because it deposits asset cash into an account. If there are fCash residuals that cannot be sold off, will revert.
+    RedeemNToken,
+    // Converts specified amount of asset cash balance already in Notional to nTokens. depositActionAmount is specified in
+    // Notional internal 8 decimal precision.
+    ConvertCashToNToken
+}
+
+/// @notice Defines a balance action for batchAction
+struct BalanceAction {
+    // Deposit action to take (if any)
+    DepositActionType actionType;
+    uint16 currencyId;
+    // Deposit action amount must correspond to the depositActionType, see documentation above.
+    uint256 depositActionAmount;
+    // Withdraw an amount of asset cash specified in Notional internal 8 decimal precision
+    uint256 withdrawAmountInternalPrecision;
+    // If set to true, will withdraw entire cash balance. Useful if there may be an unknown amount of asset cash
+    // residual left from trading.
+    bool withdrawEntireCashBalance;
+    // If set to true, will redeem asset cash to the underlying token on withdraw.
+    bool redeemToUnderlying;
+}
+
+/// @notice Defines a balance action with a set of trades to do as well
+struct BalanceActionWithTrades {
+    DepositActionType actionType;
+    uint16 currencyId;
+    uint256 depositActionAmount;
+    uint256 withdrawAmountInternalPrecision;
+    bool withdrawEntireCashBalance;
+    bool redeemToUnderlying;
+    // Array of tightly packed 32 byte objects that represent trades. See TradeActionType documentation
+    bytes32[] trades;
+}
+
+enum TradeActionType {
+    // (uint8 TradeActionType, uint8 MarketIndex, uint88 fCashAmount, uint32 minImpliedRate, uint120 unused)
+    Lend,
+    // (uint8 TradeActionType, uint8 MarketIndex, uint88 fCashAmount, uint32 maxImpliedRate, uint128 unused)
+    Borrow,
+    // (uint8 TradeActionType, uint8 MarketIndex, uint88 assetCashAmount, uint32 minImpliedRate, uint32 maxImpliedRate, uint88 unused)
+    AddLiquidity,
+    // (uint8 TradeActionType, uint8 MarketIndex, uint88 tokenAmount, uint32 minImpliedRate, uint32 maxImpliedRate, uint88 unused)
+    RemoveLiquidity,
+    // (uint8 TradeActionType, uint32 Maturity, int88 fCashResidualAmount, uint128 unused)
+    PurchaseNTokenResidual,
+    // (uint8 TradeActionType, address CounterpartyAddress, int88 fCashAmountToSettle)
+    SettleCashDebt
+}
+
+function encodeLendTrade(
+    uint8 marketIndex,
+    uint88 fCashAmount,
+    uint32 minLendRate // Set this to zero to allow any lend rate
+) pure returns (bytes32) {
+    return
+        bytes32(
+            uint256(
+                (uint8(TradeActionType.Lend) << 248) |
+                    (marketIndex << 240) |
+                    (fCashAmount << 152) |
+                    (minLendRate << 120)
+            )
+        );
+}
+
+interface Notional {
+    function getfCashLendFromDeposit(
+        uint16 currencyId,
+        uint256 depositAmountExternal,
+        uint256 maturity,
+        uint32 minLendRate,
+        uint256 blockTime,
+        bool useUnderlying
+    )
+        external
+        view
+        returns (
+            uint88 fCashAmount,
+            uint8 marketIndex,
+            bytes32 encodedTrade
+        );
+
+    function batchBalanceAndTradeAction(
+        address account,
+        BalanceActionWithTrades[] calldata actions
+    ) external payable;
+
+    function balanceOf(address account, uint256 id)
+        external
+        view
+        returns (uint256);
+
+    function setApprovalForAll(address operator, bool approved) external;
+
+    function getPrincipalFromfCashBorrow(
+        uint16 currencyId,
+        uint256 fCashBorrow,
+        uint256 maturity,
+        uint32 maxBorrowRate,
+        uint256 blockTime
+    )
+        external
+        view
+        returns (
+            uint256 borrowAmountUnderlying,
+            uint256 borrowAmountAsset,
+            uint8 marketIndex,
+            bytes32 encodedTrade
+        );
+}

--- a/packages/foundry/contracts/test/other/notional/testHarness.sh
+++ b/packages/foundry/contracts/test/other/notional/testHarness.sh
@@ -8,6 +8,9 @@ JOINS=(\
   "0xA9078E573EC536c4066A5E89F715553Ed67B13E0"\
   "0x83e99A843607CfFFC97A3acA15422aC672a463eF")
 
+export NETWORK=TENDERLY
+export MOCK=false
+
 for join in ${JOINS[@]}; do
   JOIN=$join forge test --match-path contracts/test/other/notional/NotionalJoinHarness.t.sol
 done

--- a/packages/foundry/contracts/test/other/notional/testHarness.sh
+++ b/packages/foundry/contracts/test/other/notional/testHarness.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Loop through the following addresses, and run the NotionalJoinHarness.t.sol tests for each one.
+strategies=(\
+  "0xa6624D8CF4A1Ba950d380D1e38A2D5261b711145"\
+  "0xa9d104c4e020087944332632a8c5b451885fba4a"\
+  "0x3FdDa15EccEE67248048a560ab61Dd2CdBDeA5E6"\
+  "0xE6A63e2166fcEeB447BFB1c0f4f398083214b7aB"\
+  "0xA9078E573EC536c4066A5E89F715553Ed67B13E0"\
+  "0x83e99A843607CfFFC97A3acA15422aC672a463eF")
+
+for strategy in ${strategies[@]}; do
+  STRATEGY=$strategy forge test --match-path contracts/test/other/notional/NotionalJoinHarness.t.sol
+done

--- a/packages/foundry/contracts/test/other/notional/testHarness.sh
+++ b/packages/foundry/contracts/test/other/notional/testHarness.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Loop through the following addresses, and run the NotionalJoinHarness.t.sol tests for each one.
-strategies=(\
+JOINS=(\
   "0xa6624D8CF4A1Ba950d380D1e38A2D5261b711145"\
   "0xa9d104c4e020087944332632a8c5b451885fba4a"\
   "0x3FdDa15EccEE67248048a560ab61Dd2CdBDeA5E6"\
@@ -8,6 +8,6 @@ strategies=(\
   "0xA9078E573EC536c4066A5E89F715553Ed67B13E0"\
   "0x83e99A843607CfFFC97A3acA15422aC672a463eF")
 
-for strategy in ${strategies[@]}; do
-  STRATEGY=$strategy forge test --match-path contracts/test/other/notional/NotionalJoinHarness.t.sol
+for join in ${JOINS[@]}; do
+  JOIN=$join forge test --match-path contracts/test/other/notional/NotionalJoinHarness.t.sol
 done

--- a/packages/foundry/foundry.toml
+++ b/packages/foundry/foundry.toml
@@ -7,7 +7,7 @@ libs = ['lib']
 block_timestamp = 1651743369 # Arbitrary Thursday, 5 May 2022 09:36:09
 verbosity = 3
 solc_version = '0.8.15'
-rpc_endpoints = { MAINNET = "${MAINNET_RPC}", ARBITRUM = "${ARBITRUM_RPC}", TENDERLY = "" }
+rpc_endpoints = { MAINNET = "${MAINNET_RPC}", ARBITRUM = "${ARBITRUM_RPC}", TENDERLY = "https://rpc.tenderly.co/fork/797d23ed-3bc3-41e2-9ac6-b94987e6575c" }
 
 [profile.dev]
 ignored_error_codes = [

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "forge:build": "forge build",
-    "forge:test": "forge test -vvvv",
+    "forge:test": "forge test -vvv",
     "forge:snapshot": "forge snapshot"
   },
   "repository": {

--- a/packages/foundry/package.json
+++ b/packages/foundry/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "forge:build": "forge build",
-    "forge:test": "forge test",
+    "forge:test": "forge test -vvvv",
     "forge:snapshot": "forge snapshot"
   },
   "repository": {


### PR DESCRIPTION
Draft fix for Notional sending unwrapped ETH on redemption to the NotionalJoin.

Tests still not working because Notional is hard.

Published as 0.16.7-rc.0